### PR TITLE
KeyExpression performance improvements

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -18,32 +18,36 @@ namespace Xtensive.Orm.Linq.Expressions
   {
     private IPersistentExpression owner;
 
-    public new FieldInfo Field { get; private set; }
+    public new FieldInfo Field { get; }
 
     public virtual IPersistentExpression Owner
     {
-      get { return owner; }
+      get => owner;
       internal set
       {
-        if (owner!=null)
+        if (owner!=null) {
           throw Exceptions.AlreadyInitialized("Owner");
+        }
+
         owner = value;
       }
     }
 
     public override Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap)
+      if (!CanRemap) {
         return this;
+      }
 
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
+      if (processedExpressions.TryGetValue(this, out var result)) {
         return result;
+      }
 
       var mapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
       result = new FieldExpression(ExtendedExpressionType.Field, Field, mapping, OuterParameter, DefaultIfEmpty);
-      if (owner == null)
+      if (owner == null) {
         return result;
+      }
 
       processedExpressions.Add(this, result);
       Owner.Remap(offset, processedExpressions);


### PR DESCRIPTION
This pull request includes two major improvements
- When model is locked there is no need to sort key columns while creating `KeyExpression`. Presorted column collection could be taken from model;
- Compiler always creates a closure at very beginning of a method. However in `KeyExpression` class many methods perform a check in the beginning and return pre-calculated value if it exists already. With the aim to avoid unnecessary closure creation calculation part has been moved to a separate methods in such a cases.