### PR TITLE
Use StringComparison.Ordinal to speedup string comparison

### DIFF
--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/DriverFactory.cs
@@ -9,12 +9,10 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.SqlClient;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Xtensive.Core;
 using Xtensive.Orm;
 using Xtensive.Sql.Info;
 using SqlServerConnection = System.Data.SqlClient.SqlConnection;
-using JetBrains.Annotations;
 
 namespace Xtensive.Sql.Drivers.SqlServer
 {
@@ -56,7 +54,7 @@ namespace Xtensive.Sql.Drivers.SqlServer
     {
       using (var command = connection.CreateCommand()) {
         command.CommandText = "SELECT @@VERSION";
-        return ((string) command.ExecuteScalar()).Contains("Azure");
+        return ((string) command.ExecuteScalar()).IndexOf("Azure", StringComparison.Ordinal) >= 0;
       }
     }
 
@@ -66,7 +64,7 @@ namespace Xtensive.Sql.Drivers.SqlServer
       SqlHelper.ValidateConnectionUrl(url);
 
       var builder = new SqlConnectionStringBuilder();
-      
+
       // host, port, database
       if (url.Port==0)
         builder.DataSource = url.Host;

--- a/Orm/Xtensive.Orm/Core/Extensions/StringExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/StringExtensions.cs
@@ -22,11 +22,11 @@ namespace Xtensive.Core
     /// </summary>
     /// <param name="value">The original string value.</param>
     /// <param name="suffix">The suffix to cut.</param>
-    /// <returns>String without <paramref name="suffix"/> if it was found; 
+    /// <returns>String without <paramref name="suffix"/> if it was found;
     /// otherwise, original <paramref name="value"/>.</returns>
     public static string TryCutSuffix(this string value, string suffix)
     {
-      if (!value.EndsWith(suffix))
+      if (!value.EndsWith(suffix, StringComparison.Ordinal))
         return value;
       return value.Substring(0, value.Length - suffix.Length);
     }
@@ -36,11 +36,11 @@ namespace Xtensive.Core
     /// </summary>
     /// <param name="value">The original string value.</param>
     /// <param name="prefix">The prefix to cut.</param>
-    /// <returns>String without <paramref name="prefix"/> if it was found; 
+    /// <returns>String without <paramref name="prefix"/> if it was found;
     /// otherwise, original <paramref name="value"/>.</returns>
     public static string TryCutPrefix(this string value, string prefix)
     {
-      if (!value.StartsWith(prefix))
+      if (!value.StartsWith(prefix, StringComparison.Ordinal))
         return value;
       return value.Substring(prefix.Length);
     }
@@ -412,7 +412,7 @@ namespace Xtensive.Core
           if (match.Value=="_") {
             return ".";
           }
-          if(match.Value.StartsWith(escapeCharacter.ToString())) {
+          if(match.Value.StartsWith(escapeCharacter.ToString(), StringComparison.Ordinal)) {
             return match.Value[1].ToString();
           }
           return Regex.Escape(match.Value);
@@ -429,12 +429,20 @@ namespace Xtensive.Core
     {
       var start = 0;
       var end = value.Length - 1;
-      var actualLenght = value.Length;
-      for (start = 0; value[start++]=='(' && value[end--]==')'; actualLenght -= 2) { }
+      var actualLength = value.Length;
+      for (start = 0; value[start++]=='(' && value[end--]==')'; actualLength -= 2) { }
 
       return start == 1
         ? value
-        : value.Substring(start - 1, actualLenght);
+        : value.Substring(start - 1, actualLength);
+    }
+
+    internal static bool Contains(this string str, string value, StringComparison comparison)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(str, nameof(str));
+      ArgumentValidator.EnsureArgumentNotNull(value, nameof(value));
+
+      return str.IndexOf(value, comparison) >= 0;
     }
 
   }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -156,7 +156,7 @@ namespace Xtensive.Orm.Building.Builders
         var action = actionContainer.BuildPrefetchAction();
         domain.PrefetchActionMap.Add(type, action);
       }
-    } 
+    }
 
     private void BuildTypes(IEnumerable<TypeDef> typeDefs)
     {
@@ -177,7 +177,7 @@ namespace Xtensive.Orm.Building.Builders
     private void PreprocessAssociations()
     {
       foreach (var typeInfo in context.Model.Types.Where(t => t.IsEntity && !t.IsAuxiliary)) {
-        
+
         // pair integrity escalation and consistency check
         typesWithProcessedInheritedAssociations.Add(typeInfo);
         var refFields = typeInfo.Fields.Where(f => f.IsEntity || f.IsEntitySet).ToList();
@@ -368,12 +368,12 @@ namespace Xtensive.Orm.Building.Builders
         // Updating fields names only if types differ.
         if (masterType != slaveType) {
           try {
-            if (!masterType.Name.Contains("."))
+            if (!masterType.Name.Contains(".", StringComparison.Ordinal))
               masterFieldDef.MappingName = context.NameBuilder.ApplyNamingRules(masterType.Name);
           }
           catch(DomainBuilderException){}
           try {
-            if (!slaveType.Name.Contains("."))
+            if (!slaveType.Name.Contains(".", StringComparison.Ordinal))
               slaveFieldDef.MappingName = context.NameBuilder.ApplyNamingRules(slaveType.Name);
           }
           catch (DomainBuilderException){}

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
+// Copyright (C) 2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Building.Builders
 
       public bool Equals(MappingRequest other)
       {
-        return Equals(Assembly, other.Assembly) && string.Equals(Namespace, other.Namespace);
+        return Equals(Assembly, other.Assembly) && string.Equals(Namespace, other.Namespace, StringComparison.Ordinal);
       }
 
       public override bool Equals(object obj)
@@ -131,7 +131,7 @@ namespace Xtensive.Orm.Building.Builders
       var assemblyMatch =
         rule.Assembly==null || rule.Assembly==type.Assembly;
       var namespaceMatch =
-        string.IsNullOrEmpty(rule.Namespace) || type.FullName.StartsWith(rule.Namespace + ".");
+        string.IsNullOrEmpty(rule.Namespace) || type.FullName.StartsWith(rule.Namespace + ".", StringComparison.Ordinal);
       return assemblyMatch && namespaceMatch;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/ConnectionInfoParser.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/ConnectionInfoParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Configuration
     {
       const string prefix = "#";
 
-      if (!connectionString.StartsWith(prefix))
+      if (!connectionString.StartsWith(prefix, StringComparison.Ordinal))
         return connectionString;
 
       string connectionStringName = connectionString.Substring(prefix.Length);

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/DomainTypeRegistrationHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/DomainTypeRegistrationHandler.cs
@@ -11,11 +11,11 @@ using Xtensive.Core;
 namespace Xtensive.Orm.Configuration
 {
   /// <summary>
-  /// <see cref="ITypeRegistrationProcessor"/> for processing <see cref="SessionBound"/> 
-  /// and <see cref="IEntity"/> descendants registration in 
+  /// <see cref="ITypeRegistrationProcessor"/> for processing <see cref="SessionBound"/>
+  /// and <see cref="IEntity"/> descendants registration in
   /// <see cref="DomainConfiguration.Types"/> registry.
   /// </summary>
-  /// <remarks>This implementation provides topologically sorted list 
+  /// <remarks>This implementation provides topologically sorted list
   /// of <see cref="Type"/>s.</remarks>
   internal sealed class DomainTypeRegistrationHandler : TypeRegistrationProcessorBase
   {
@@ -32,7 +32,7 @@ namespace Xtensive.Orm.Configuration
     {
       // Disallow implicit (via assembly scan) registration of types in Orm.Providers namespace
       return base.IsAcceptable(registration, type)
-        && (registration.Type!=null || !type.FullName.StartsWith(providersNamespace));
+        && (registration.Type!=null || !type.FullName.StartsWith(providersNamespace, StringComparison.Ordinal));
     }
 
     /// <inheritdoc/>
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Configuration
         return;
       if (!DomainTypeRegistry.IsInterestingType(type))
         return;
-      // The type is interesting; 
+      // The type is interesting;
       // If it is a persistent type, let's register all its bases
       if (DomainTypeRegistry.IsPersistentType(type))
         Process(registry, registration, type.BaseType);

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -159,7 +159,7 @@ namespace Xtensive.Orm
       if (Owner.IsRemoved)
         throw new InvalidOperationException(Strings.ExEntityIsRemoved);
     }
-    
+
     #region System-level event-like members
 
     private void SystemInitialize()
@@ -369,7 +369,7 @@ namespace Xtensive.Orm
       var subscriptionInfo = GetSubscription(EntityEventBroker.CollectionChangedEventKey);
       if (subscriptionInfo.Second != null) {
         var handler = (NotifyCollectionChangedEventHandler) subscriptionInfo.Second;
-        if (action==NotifyCollectionChangedAction.Reset) 
+        if (action==NotifyCollectionChangedAction.Reset)
           handler.Invoke(this, new NotifyCollectionChangedEventArgs(action));
         else if (!index.HasValue) {
           if (action==NotifyCollectionChangedAction.Remove) {
@@ -378,11 +378,11 @@ namespace Xtensive.Orm
             foreach (var @delegate in invocationList) {
               var typedDelegate = (NotifyCollectionChangedEventHandler) @delegate;
               var subscriberAssemblyName = @delegate.Method.DeclaringType.Assembly.FullName;
-              if (subscriberAssemblyName.StartsWith(presentationFrameworkAssemblyPrefix))
+              if (subscriberAssemblyName.StartsWith(presentationFrameworkAssemblyPrefix, StringComparison.Ordinal))
                 // WPF can't handle "Remove" event w/o item index
                 typedDelegate.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 #if DEBUG
-              else if (subscriberAssemblyName.StartsWith(storageTestsAssemblyPrefix))
+              else if (subscriberAssemblyName.StartsWith(storageTestsAssemblyPrefix, StringComparison.Ordinal))
                 typedDelegate.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 #endif
               else
@@ -543,15 +543,15 @@ namespace Xtensive.Orm
             Session.EntitySetChangeRegistry.Register(state);
             index = GetItemIndex(state, itemKey);
           };
-          
+
           operations.NotifyOperationStarting();
           if (association.IsPaired)
-            Session.PairSyncManager.ProcessRecursively(syncContext, removalContext, 
+            Session.PairSyncManager.ProcessRecursively(syncContext, removalContext,
               OperationType.Add, association, Owner, item, finalizer);
           else
             finalizer.Invoke();
 
-          // removalContext is unused here, since Add is never 
+          // removalContext is unused here, since Add is never
           // invoked in reference cleanup process directly
 
           if (!skipOwnerVersionChange)
@@ -626,7 +626,7 @@ namespace Xtensive.Orm
             removalContext.EnqueueFinalizer(() => {
               try {
                 try {
-                  index = GetItemIndex(State, itemKey); // Necessary, since index can be already changed 
+                  index = GetItemIndex(State, itemKey); // Necessary, since index can be already changed
                   if (!skipOwnerVersionChange)
                     Owner.UpdateVersionInfo(Owner, Field);
                   SystemRemove(item, index);
@@ -662,7 +662,7 @@ namespace Xtensive.Orm
         throw;
       }
     }
-    
+
     /// <summary>
     /// Clears this collection.
     /// </summary>
@@ -814,8 +814,8 @@ namespace Xtensive.Orm
       if (foundInCache)
         return true;
       var ownerState = Owner.PersistenceState;
-      var itemState = item == null 
-        ? PersistenceState.Synchronized 
+      var itemState = item == null
+        ? PersistenceState.Synchronized
         : item.PersistenceState;
       if (PersistenceState.New.In(ownerState, itemState) || State.IsFullyLoaded)
         return false;
@@ -897,7 +897,7 @@ namespace Xtensive.Orm
           ArrayUtils<Type>.EmptyArray);
       return new EntitySetTypeState(seek, seekTransform, itemCtor, entitySet.GetItemCountQueryDelegate(field));
     }
-    
+
     private int? GetItemIndex(EntitySetState state, Key key)
     {
       if (!state.IsFullyLoaded)
@@ -908,7 +908,7 @@ namespace Xtensive.Orm
       if (subscriptionInfo.Second==null)
         return null;
 
-      // Ok, it seems there is a reason 
+      // Ok, it seems there is a reason
       // to waste linear time on calculating this...
       int i = 0;
       foreach (var cachedKey in state) {
@@ -930,7 +930,7 @@ namespace Xtensive.Orm
     // Initialization
 
     /// <summary>
-    /// Performs initialization (see <see cref="Initialize()"/>) of the <see cref="EntitySetBase"/> 
+    /// Performs initialization (see <see cref="Initialize()"/>) of the <see cref="EntitySetBase"/>
     /// if type of <see langword="this" /> is the same as <paramref name="ctorType"/>.
     /// Automatically invoked in the epilogue of any constructor of this type and its ancestors.
     /// </summary>

--- a/Orm/Xtensive.Orm/Orm/Providers/NameBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/NameBuilder.cs
@@ -26,7 +26,7 @@ using TypeInfo = Xtensive.Orm.Model.TypeInfo;
 namespace Xtensive.Orm.Providers
 {
   /// <summary>
-  /// Name builder for <see cref="Orm.Model.DomainModel"/> nodes 
+  /// Name builder for <see cref="Orm.Model.DomainModel"/> nodes
   /// Provides names according to a set of naming rules contained in
   /// <see cref="NamingConvention"/>.
   /// </summary>
@@ -258,7 +258,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <summary>
-    /// Gets the name for <see cref="ColumnInfo"/> object concatenating 
+    /// Gets the name for <see cref="ColumnInfo"/> object concatenating
     /// <see cref="Node.Name"/> of its declaring type with the original column name.
     /// </summary>
     /// <param name="column">The <see cref="ColumnInfo"/> object.</param>
@@ -266,7 +266,7 @@ namespace Xtensive.Orm.Providers
     public string BuildColumnName(ColumnInfo column)
     {
       ArgumentValidator.EnsureArgumentNotNull(column, "column");
-      if (column.Name.StartsWith(column.Field.DeclaringType.Name + "."))
+      if (column.Name.StartsWith(column.Field.DeclaringType.Name + ".", StringComparison.Ordinal))
         throw new InvalidOperationException();
       string result = string.Concat(column.Field.DeclaringType.Name, ".", column.Name);
       return ApplyNamingRules(result);
@@ -426,9 +426,9 @@ namespace Xtensive.Orm.Providers
     /// <returns>Association name.</returns>
     public string BuildAssociationName(AssociationInfo target)
     {
-      return ApplyNamingRules(string.Format(AssociationPattern, 
-        target.OwnerType.Name, 
-        target.OwnerField.Name, 
+      return ApplyNamingRules(string.Format(AssociationPattern,
+        target.OwnerType.Name,
+        target.OwnerField.Name,
         target.TargetType.Name));
     }
 
@@ -441,9 +441,9 @@ namespace Xtensive.Orm.Providers
     /// <returns>Association name.</returns>
     public string BuildAssociationName(TypeInfo ownerType, FieldInfo ownerField, TypeInfo targetType)
     {
-      return ApplyNamingRules(string.Format(AssociationPattern, 
-        ownerType.Name, 
-        ownerField.Name, 
+      return ApplyNamingRules(string.Format(AssociationPattern,
+        ownerType.Name,
+        ownerField.Name,
         targetType.Name));
     }
 
@@ -455,9 +455,9 @@ namespace Xtensive.Orm.Providers
     /// <returns>Auxiliary type mapping name.</returns>
     public string BuildAuxiliaryTypeMappingName(AssociationInfo target)
     {
-      return ApplyNamingRules(string.Format(AssociationPattern, 
-        target.OwnerType.MappingName ?? target.OwnerType.Name, 
-        target.OwnerField.MappingName ?? target.OwnerField.Name, 
+      return ApplyNamingRules(string.Format(AssociationPattern,
+        target.OwnerType.MappingName ?? target.OwnerType.Name,
+        target.OwnerField.MappingName ?? target.OwnerField.Name,
         target.TargetType.MappingName ?? target.TargetType.Name));
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -118,7 +118,7 @@ namespace Xtensive.Orm.Providers
         result.Catalogs
           .SelectMany(c => c.Schemas)
           .SelectMany(s => s.Tables)
-          .Where(t => t.Name.EndsWith("-Generator")
+          .Where(t => t.Name.EndsWith("-Generator", StringComparison.Ordinal)
             && t.TableColumns.Count==1
             && t.TableColumns[0].SequenceDescriptor==null);
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameTypeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameTypeHint.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm.Upgrade
         return false;
       if (ReferenceEquals(this, other))
         return true;
-      return base.Equals(other) 
+      return base.Equals(other)
         && other.NewType==NewType
         && other.OldType==OldType;
     }
@@ -78,7 +78,7 @@ namespace Xtensive.Orm.Upgrade
       ArgumentValidator.EnsureArgumentNotNull(newType, "newType");
       ArgumentValidator.EnsureArgumentNotNullOrEmpty(oldType, "oldType");
 
-      if (!oldType.Contains("."))
+      if (!oldType.Contains(".", StringComparison.Ordinal))
         oldType = newType.Namespace + "." + oldType;
       OldType = oldType;
       NewType = newType;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Upgrade
     private readonly Dictionary<StoredFieldInfo, StoredFieldInfo> fieldMapping;
     private readonly Dictionary<StoredTypeInfo, StoredFieldInfo[]> extractedModelFields;
 
-    private readonly NativeTypeClassifier<UpgradeHint> hints; 
+    private readonly NativeTypeClassifier<UpgradeHint> hints;
 
     private readonly List<Hint> schemaHints = new List<Hint>();
 
@@ -49,10 +49,10 @@ namespace Xtensive.Orm.Upgrade
 
       var removedTypes = GetRemovedTypes(extractedModel);
       GenerateRecordCleanupHints(removedTypes, false);
-      
+
       var movedTypes = GetMovedTypes(extractedModel);
       GenerateRecordCleanupHints(movedTypes, true);
-      
+
       // Adding useful info
 
       CalculateAffectedTablesAndColumns(hints);
@@ -123,7 +123,7 @@ namespace Xtensive.Orm.Upgrade
         RegisterRenameFieldHint(oldTargetType, newTargetType, oldField.MappingName, newField.MappingName);
       }
     }
-    
+
     private void GenerateCopyColumnHints(IEnumerable<CopyFieldHint> hints)
     {
       foreach (var hint in hints)
@@ -150,13 +150,13 @@ namespace Xtensive.Orm.Upgrade
       if (sourceField==null)
         throw new InvalidOperationException(String.Format(Strings.ExUpgradeHintSourceFieldNotFound, hint.SourceField));
       var sourceHierarchy = sourceType.Hierarchy;
-      
+
       // checking that types have hierarchies
       if (sourceHierarchy==null)
         throw TypeIsNotInHierarchy(hint.SourceType);
       if (targetHierarchy == null)
         throw TypeIsNotInHierarchy(targetTypeName);
-      
+
       // building set of key columns
       var pairedKeyColumns = AssociateMappedKeyFields(sourceHierarchy, targetHierarchy);
       if (pairedKeyColumns==null)
@@ -228,13 +228,13 @@ namespace Xtensive.Orm.Upgrade
           new DeleteDataHint(sourceTablePath, identities, isMovedToAnotherHierarchy));
       }
     }
-    
+
     private void GenerateCleanupByForegnKeyHints(StoredTypeInfo removedType)
     {
       var removedTypeAndAncestors = removedType.AllAncestors.AddOne(removedType).ToHashSet();
       var affectedAssociations = (
         from association in extractedModel.Associations
-        let requiresInverseCleanup = 
+        let requiresInverseCleanup =
           association.IsMaster &&
           association.ConnectorType!=null &&
           removedTypeAndAncestors.Contains(association.ReferencingField.DeclaringType)
@@ -261,7 +261,7 @@ namespace Xtensive.Orm.Upgrade
               foreach (var candidate in candidates) {
                   var inheritanceSchema = candidate.Hierarchy.InheritanceSchema;
                   GenerateClearReferenceHints(
-                    removedType, 
+                    removedType,
                     GetAffectedMappedTypes(candidate, inheritanceSchema==InheritanceSchema.ConcreteTable).ToArray(),
                     association,
                     requiresInverseCleanup);
@@ -270,7 +270,7 @@ namespace Xtensive.Orm.Upgrade
           else {
             var inheritanceSchema = declaringType.Hierarchy.InheritanceSchema;
             GenerateClearReferenceHints(
-              removedType, 
+              removedType,
               GetAffectedMappedTypes(declaringType, inheritanceSchema==InheritanceSchema.ConcreteTable).ToArray(),
               association,
               requiresInverseCleanup);
@@ -279,7 +279,7 @@ namespace Xtensive.Orm.Upgrade
         else
           // This is EntitySet
           GenerateClearReferenceHints(
-            removedType, 
+            removedType,
             new [] {association.ConnectorType},
             association,
             requiresInverseCleanup);
@@ -287,7 +287,7 @@ namespace Xtensive.Orm.Upgrade
     }
 
     private void GenerateClearReferenceHints(
-      StoredTypeInfo removedType, 
+      StoredTypeInfo removedType,
       StoredTypeInfo[] updatedTypes,
       StoredAssociationInfo association,
       bool inverse)
@@ -301,7 +301,7 @@ namespace Xtensive.Orm.Upgrade
     }
 
     private void GenerateClearReferenceHint(
-      StoredTypeInfo removedType, 
+      StoredTypeInfo removedType,
       StoredTypeInfo updatedType,
       StoredAssociationInfo association,
       bool inverse)
@@ -416,7 +416,7 @@ namespace Xtensive.Orm.Upgrade
 
       StoredFieldInfo storedField = null;
       // Nested field, looks like a field of a structure
-      if (hint.Field.Contains(".")) {
+      if (hint.Field.Contains(".", StringComparison.Ordinal)) {
         string[] path = hint.Field.Split('.');
         var fields = storedType.AllFields;
         string fieldName = string.Empty;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlActionTranslator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlActionTranslator.cs
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Upgrade
     private readonly List<Table> createdTables = new List<Table>();
     private readonly List<Sequence> createdSequences = new List<Sequence>();
     private readonly List<DataAction> clearDataActions = new List<DataAction>();
-    private readonly HashSet<TableColumn> recreatedColumns = new HashSet<TableColumn>(); 
+    private readonly HashSet<TableColumn> recreatedColumns = new HashSet<TableColumn>();
 
 
     private UpgradeActionSequenceBuilder currentOutput;
@@ -84,7 +84,7 @@ namespace Xtensive.Orm.Upgrade
       ProcessActions(Modelling.Comparison.UpgradeStage.CleanupData, SqlUpgradeStage.CleanupData);
       ProcessClearDataActions(false);
 
-      // Prepairing (aka запаривание :-)
+      // Prepairing (aka Р·Р°РїР°СЂРёРІР°РЅРёРµ :-)
       ProcessActions(Modelling.Comparison.UpgradeStage.Prepare, SqlUpgradeStage.PreUpgrade);
 
       // Mutual renaming
@@ -189,7 +189,7 @@ namespace Xtensive.Orm.Upgrade
       else if (node.GetType()==typeof (ForeignKeyInfo))
         VisitAlterForeignKeyAction(moveNodeAction);
     }
-    
+
     private void VisitDataAction(DataAction dataAction)
     {
       var hint = dataAction.DataHint;
@@ -210,7 +210,7 @@ namespace Xtensive.Orm.Upgrade
       }
     }
 
-    /// <exception cref="InvalidOperationException">Can not create copy command 
+    /// <exception cref="InvalidOperationException">Can not create copy command
     /// with specific hint parameters.</exception>
     private void VisitCopyDataAction(DataAction action)
     {
@@ -375,11 +375,11 @@ namespace Xtensive.Orm.Upgrade
     {
       var columnInfo = (StorageColumnInfo) createColumnAction.Difference.Target;
       var table = FindTable(columnInfo.Parent);
-      
+
       // Ensure table is not newly created
       if (createdTables.Contains(table))
         return;
-      
+
       var column = CreateColumn(columnInfo, table);
       if (columnInfo.DefaultValue != null)
         column.DefaultValue = SqlDml.Literal(columnInfo.DefaultValue);
@@ -455,7 +455,7 @@ namespace Xtensive.Orm.Upgrade
       if (!action.Properties.ContainsKey(ColumnTypePropertyName))
         if (!action.Properties.ContainsKey(ColumnDefaultPropertyName))
           return;
- 
+
       ChangeColumnType(action);
     }
 
@@ -524,7 +524,7 @@ namespace Xtensive.Orm.Upgrade
       // Ensure table is not removed
       if (table==null)
         return;
-      
+
       var primaryKey = table.TableConstraints[primaryIndexInfo.Name];
 
       currentOutput.RegisterCommand(SqlDdl.Alter(table, SqlDdl.DropConstraint(primaryKey)));
@@ -535,7 +535,7 @@ namespace Xtensive.Orm.Upgrade
     {
       throw new NotSupportedException();
     }
-    
+
     private void VisitCreateSecondaryIndexAction(CreateNodeAction action)
     {
       var secondaryIndexInfo = (SecondaryIndexInfo) action.Difference.Target;
@@ -552,11 +552,11 @@ namespace Xtensive.Orm.Upgrade
 
       var secondaryIndexInfo = (SecondaryIndexInfo) action.Difference.Source;
       var table = FindTable(secondaryIndexInfo.Parent);
-      
+
       // Ensure table is not removed
       if (table==null)
         return;
-      
+
       var index = table.Indexes[secondaryIndexInfo.Name];
       preCleanupDataOutput.RegisterCommand(SqlDdl.Drop(index));
       table.Indexes.Remove(index);
@@ -566,7 +566,7 @@ namespace Xtensive.Orm.Upgrade
     {
       throw new NotSupportedException();
     }
-    
+
     private void VisitCreateForeignKeyAction(CreateNodeAction action)
     {
       if (!allowCreateConstraints)
@@ -738,7 +738,7 @@ namespace Xtensive.Orm.Upgrade
       deleteFromConnectorTableActions.ForEach(
         a => ProcessDeleteDataAction(a, postCopy));
       ProcessClearAncestorsActions(deleteFromAncestorTableActions, postCopy);
-      
+
       // Necessary, since this method is called twice on upgrade
       clearDataActions.Clear();
     }
@@ -757,7 +757,7 @@ namespace Xtensive.Orm.Upgrade
       deleteOutput.RegisterCommand(delete);
     }
 
-    /// <exception cref="InvalidOperationException">Can not create update command 
+    /// <exception cref="InvalidOperationException">Can not create update command
     /// with specific hint parameters.</exception>
     private void ProcessUpdateDataAction(DataAction action, bool postCopy)
     {
@@ -770,10 +770,10 @@ namespace Xtensive.Orm.Upgrade
         .Select(pair => new Pair<StorageColumnInfo, object>(
           sourceModel.Resolve(pair.First, true) as StorageColumnInfo,
           pair.Second)).ToArray();
-      
+
       if (updatedColumns.Length==0)
         throw new InvalidOperationException(Strings.ExIncorrectCommandParameters);
-      
+
       foreach (var pair in updatedColumns) {
         var column = pair.First;
         var value = pair.Second;
@@ -834,7 +834,7 @@ namespace Xtensive.Orm.Upgrade
       var sortedTables = TopologicalSorter.Sort(nodes, out edges);
       sortedTables.Reverse();
       // TODO: Process removed edges
-      
+
       // Build DML commands
       foreach (var table in sortedTables) {
         var tableRef = SqlDml.TableRef(FindTable(table));
@@ -874,7 +874,7 @@ namespace Xtensive.Orm.Upgrade
       var newTypeInfo = targetColumn.Type;
       var newSqlType = (SqlValueType) newTypeInfo.NativeType;
       var newColumn = table.CreateColumn(originalName, newSqlType);
-      
+
       newColumn.IsNullable = newTypeInfo.IsNullable;
       if (!newColumn.IsNullable)
         newColumn.DefaultValue = GetDefaultValueExpression(targetColumn);
@@ -1123,7 +1123,7 @@ namespace Xtensive.Orm.Upgrade
       }
     }
 
-    /// <exception cref="InvalidOperationException">Can not create expression 
+    /// <exception cref="InvalidOperationException">Can not create expression
     /// with specific hint parameters.</exception>
     private SqlExpression CreateConditionalExpression(DataHint hint, SqlTableRef table)
     {
@@ -1144,7 +1144,7 @@ namespace Xtensive.Orm.Upgrade
           throw new InvalidOperationException(Strings.ExIncorrectCommandParameters);
 
         var identifiedTable = FindTable(selectColumns[0].Parent);
-        var identifiedTableRef = SqlDml.TableRef(identifiedTable, 
+        var identifiedTableRef = SqlDml.TableRef(identifiedTable,
           string.Format(SubqueryTableAliasNameFormat, identifiedTable.Name));
         var select = SqlDml.Select(identifiedTableRef);
         selectColumns.ForEach(column => select.Columns.Add(identifiedTableRef[column.Name]));
@@ -1163,7 +1163,7 @@ namespace Xtensive.Orm.Upgrade
         if (!identityConstantPairs.Any())
           throw new InvalidOperationException(Strings.ExIncorrectCommandParameters);
         SqlExpression expression = null;
-        identityConstantPairs.ForEach(pair => 
+        identityConstantPairs.ForEach(pair =>
           expression &= table[pair.First.Name]==SqlDml.Literal(pair.Second));
         return expression;
       }
@@ -1181,7 +1181,7 @@ namespace Xtensive.Orm.Upgrade
 
     private string TryUnquoteLiteral(string stringToUnquote)
     {
-      if (stringToUnquote.StartsWith("N")) {
+      if (stringToUnquote.StartsWith("N", StringComparison.Ordinal)) {
         var unquotedSting = stringToUnquote.Remove(0, 1).Trim(new[] {'\''}).Replace("''", "'");
         return unquotedSting;
       }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintValidator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2015 Xtensive LLC.
+// Copyright (C) 2015 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Kulakov
@@ -115,7 +115,7 @@ namespace Xtensive.Orm.Upgrade.Internals
           throw TypeNotFound(sourceTypeName);
 
         // Handling structure field
-        if (hint.Field.Contains(".")) {
+        if (hint.Field.Contains(".", StringComparison.Ordinal)) {
           StoredFieldInfo storedField;
           string[] path = hint.Field.Split('.');
           var fields = sourceType.AllFields;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradeHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradeHandler.cs
@@ -260,7 +260,7 @@ namespace Xtensive.Orm.Upgrade
         var oldName = r.Attribute.OriginalName;
         if (oldName.IsNullOrEmpty())
           oldName = GetOriginalName(r.Type);
-        else if (!oldName.Contains(".")) {
+        else if (!oldName.Contains(".", StringComparison.Ordinal)) {
           string ns = TryStripRecycledSuffix(r.Type.Namespace);
           oldName = ns + "." + oldName;
         }

--- a/Orm/Xtensive.Orm/Sql/SqlType.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlType.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Sql
     #region Real
 
     /// <summary>
-    /// Floating point number data from –3.40E + 38 through 3.40E + 38. 
+    /// Floating point number data from â€“3.40E + 38 through 3.40E + 38.
     /// Storage size is 4 bytes.
     /// </summary>
     public static readonly SqlType Float = new SqlType("Float");
@@ -82,18 +82,18 @@ namespace Xtensive.Sql
     #region DateTime
 
     /// <summary>
-    /// Date and time data from January 1, 1753 through December 31, 9999, 
-    /// to an accuracy of one three-hundredth of a second (equivalent to 3.33 
-    /// milliseconds or 0.00333 seconds). Values are rounded to increments 
+    /// Date and time data from January 1, 1753 through December 31, 9999,
+    /// to an accuracy of one three-hundredth of a second (equivalent to 3.33
+    /// milliseconds or 0.00333 seconds). Values are rounded to increments
     /// of .000, .003, or .007 seconds.
-    /// Storage size is 8 bytes. 
+    /// Storage size is 8 bytes.
     /// </summary>
     public static readonly SqlType DateTime = new SqlType("DateTime");
 
     /// <summary>
-    /// Date and time data from January 1,1 A.D. through December 31, 9999 A.D., 
+    /// Date and time data from January 1,1 A.D. through December 31, 9999 A.D.,
     /// to an accuracy of 100 nanoseconds.
-    /// Storage size is 8 to 10 bytes. 
+    /// Storage size is 8 to 10 bytes.
     /// </summary>
     public static readonly SqlType DateTimeOffset = new SqlType("DateTimeOffset");
 
@@ -107,22 +107,22 @@ namespace Xtensive.Sql
     #region String
 
     /// <summary>
-    /// Fixed-length Unicode character data of n characters. 
-    /// n must be a value from 1 through 4,000. Storage size is two times n bytes. 
+    /// Fixed-length Unicode character data of n characters.
+    /// n must be a value from 1 through 4,000. Storage size is two times n bytes.
     /// The SQL-92 synonyms for nchar are national char and national character.
     /// </summary>
     public static readonly SqlType Char = new SqlType("Char");
     /// <summary>
-    /// Variable-length Unicode character data of n characters. 
-    /// n must be a value from 1 through 4,000. Storage size, in bytes, is two times 
-    /// the number of characters entered. The data entered can be 0 characters in length. 
+    /// Variable-length Unicode character data of n characters.
+    /// n must be a value from 1 through 4,000. Storage size, in bytes, is two times
+    /// the number of characters entered. The data entered can be 0 characters in length.
     /// The SQL-92 synonyms for nvarchar are national char varying and national character varying.
     /// </summary>
     public static readonly SqlType VarChar = new SqlType("VarChar");
-   
+
     /// <summary>
-    /// Variable-length Unicode data with a maximum length of 2^30 - 1 (1,073,741,823) 
-    /// characters. Storage size, in bytes, is two times the number of characters entered. 
+    /// Variable-length Unicode data with a maximum length of 2^30 - 1 (1,073,741,823)
+    /// characters. Storage size, in bytes, is two times the number of characters entered.
     /// </summary>
     public static readonly SqlType VarCharMax = new SqlType("VarCharMax");
 
@@ -131,19 +131,19 @@ namespace Xtensive.Sql
     #region Binary
 
     /// <summary>
-    /// Fixed-length binary data of n bytes. n must be a value from 1 through 8,000. 
-    /// Storage size is n+4 bytes. 
+    /// Fixed-length binary data of n bytes. n must be a value from 1 through 8,000.
+    /// Storage size is n+4 bytes.
     /// </summary>
     public static readonly SqlType Binary = new SqlType("Binary");
 
     /// <summary>
-    /// Variable-length binary data of n bytes. n must be a value from 1 through 8,000. 
-    /// Storage size is the actual length of the data entered + 4 bytes, not n bytes. 
-    /// The data entered can be 0 bytes in length. 
+    /// Variable-length binary data of n bytes. n must be a value from 1 through 8,000.
+    /// Storage size is the actual length of the data entered + 4 bytes, not n bytes.
+    /// The data entered can be 0 bytes in length.
     /// The SQL-92 synonym for varbinary is binary varying.
     /// </summary>
     public static readonly SqlType VarBinary = new SqlType("VarBinary");
-    
+
     /// <summary>
     /// <para>Variable-length binary data from 0 through 2^31-1 (2,147,483,647) bytes.</para>
     /// </summary>
@@ -154,7 +154,7 @@ namespace Xtensive.Sql
     #region Other
 
     /// <summary>
-    /// A globally unique identifier (GUID). 
+    /// A globally unique identifier (GUID).
     /// </summary>
     public static readonly SqlType Guid = new SqlType("Guid");
 
@@ -186,7 +186,7 @@ namespace Xtensive.Sql
 
     public bool Equals(SqlType other)
     {
-      return string.Equals(Name, other.Name);
+      return string.Equals(Name, other.Name, StringComparison.Ordinal);
     }
 
     public override bool Equals(object obj)

--- a/Weaver/Xtensive.Orm.Weaver/Application/Program.cs
+++ b/Weaver/Xtensive.Orm.Weaver/Application/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Weaver.Application
 
     private void ProcessArgument(string argument)
     {
-      if (argument.StartsWith("@")) {
+      if (argument.StartsWith("@", StringComparison.Ordinal)) {
         foreach (var line in File.ReadLines(argument.Substring(1)))
           ProcessArgument(line);
         return;
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Weaver.Application
     private string StripOptionPrefix(string argument)
     {
       foreach (var prefix in OptionPrefixes)
-        if (argument.StartsWith(prefix))
+        if (argument.StartsWith(prefix, StringComparison.Ordinal))
           return argument.Substring(prefix.Length);
       return argument;
     }

--- a/Weaver/Xtensive.Orm.Weaver/WeavingHelper.cs
+++ b/Weaver/Xtensive.Orm.Weaver/WeavingHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -40,9 +40,9 @@ namespace Xtensive.Orm.Weaver
       const string getterPrefix = "get_";
       const string setterPrefix = "set_";
 
-      if (accessorName.StartsWith(getterPrefix))
+      if (accessorName.StartsWith(getterPrefix, StringComparison.Ordinal))
         return accessorName.Substring(getterPrefix.Length);
-      if (accessorName.StartsWith(setterPrefix))
+      if (accessorName.StartsWith(setterPrefix, StringComparison.Ordinal))
         return accessorName.Substring(setterPrefix.Length);
       throw new InvalidOperationException(String.Format("Invalid or unsupported accessor name '{0}'", accessorName));
     }


### PR DESCRIPTION
* Add StringComparison to couple helper functions

* Add StringComparison.Ordinal to string functions
# Conflicts:
#	.gitignore
#	Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/DriverFactory.cs
#	Orm/Xtensive.Orm/Core/Extensions/StringExtensions.cs
#	Orm/Xtensive.Orm/Orm/EntitySetBase.cs