### PR TITLE
TypeHelper class code formatting and performance improvements

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Core/Reflection/TypeHelperGetGenericInterfaceTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Reflection/TypeHelperGetGenericInterfaceTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xtensive.Reflection;
+
+namespace Xtensive.Orm.Tests.Core.Reflection
+{
+  [TestFixture]
+  public class TypeHelperGetGenericInterfaceTests
+  {
+    private class ListInt : List<int>
+    { }
+
+    private class ListIntLvl1 : ListInt
+    { }
+
+    private class GenericList<T> : List<T>
+    { }
+
+    private class GenericListLvl1<T> : GenericList<T>
+    { }
+
+    private class GenericListLvl1Int : GenericListLvl1<int>
+    { }
+
+    private class GenericListInt : GenericList<int>
+    { }
+
+    private class GenericListIntLvl1 : GenericListInt
+    { }
+
+    [Test]
+    public void InterfaceIsDiscoverable_OnOpenGenericType() =>
+      Assert.IsNotNull(typeof(List<>).GetGenericInterface(typeof(IList<>)));
+
+    [Test]
+    public void InterfaceIsDiscoverable_OnOpenGenericInterface() =>
+      Assert.IsNotNull(typeof(IList<>).GetGenericInterface(typeof(ICollection<>)));
+
+    [Test]
+    public void InterfaceIsDiscoverable_OnClosedGenericType() =>
+      Assert.AreSame(typeof(List<int>).GetGenericInterface(typeof(IList<>)), typeof(IList<int>));
+
+    [Test]
+    public void InterfaceIsDiscoverable_OnClosedGenericInterface() =>
+      Assert.AreSame(typeof(IList<int>).GetGenericInterface(typeof(ICollection<>)), typeof(ICollection<int>));
+
+    [Test]
+    public void InterfaceIsDiscoverable_OnItself() =>
+      Assert.AreSame(typeof(IList<int>).GetGenericInterface(typeof(IList<>)), typeof(IList<int>));
+
+    [TestCase(typeof(ListInt))]
+    [TestCase(typeof(ListIntLvl1))]
+    [TestCase(typeof(GenericList<int>))]
+    [TestCase(typeof(GenericListLvl1<int>))]
+    [TestCase(typeof(GenericListLvl1Int))]
+    [TestCase(typeof(GenericListInt))]
+    [TestCase(typeof(GenericListIntLvl1))]
+    public void InterfaceIsDiscoverable_OnAnyAncestorOfAnImplementor(Type type) =>
+      Assert.AreSame(type.GetGenericInterface(typeof(IList<>)), typeof(IList<int>));
+
+    [Test]
+    public void NullIsReturnedIfNoMatchFound() =>
+      Assert.IsNull(typeof(ICollection<int>).GetGenericInterface(typeof(IList<>)));
+
+    [Test]
+    public void NullIsAcceptedAsFirstParameter() =>
+      Assert.IsNull(TypeHelper.GetGenericInterface(null, typeof(List<>)));
+  }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Reflection/TypeHelperGetGenericTypeTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Reflection/TypeHelperGetGenericTypeTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xtensive.Reflection;
+
+namespace Xtensive.Orm.Tests.Core.Reflection
+{
+  [TestFixture]
+  public class TypeHelperGetGenericTypeTests
+  {
+    private class ListInt : List<int>
+    { }
+
+    private class ListIntLvl1 : ListInt
+    { }
+
+    private class GenericList<T> : List<T>
+    { }
+
+    private class GenericListLvl1<T> : GenericList<T>
+    { }
+
+    private class GenericListLvl1Int : GenericListLvl1<int>
+    { }
+
+    private class GenericListInt : GenericList<int>
+    { }
+
+    private class GenericListIntLvl1 : GenericListInt
+    { }
+
+    [Test]
+    public void ParameterizedGenericTypeIsDiscoverable_ByItself() =>
+      Assert.AreSame(typeof(List<int>).GetGenericType(typeof(List<>)), typeof(List<int>));
+
+    [Test]
+    public void ParameterizedGenericTypeIsDiscoverable_ByItsDirectNonGenericAncestor() =>
+      Assert.AreSame(typeof(ListInt).GetGenericType(typeof(List<>)), typeof(List<int>));
+
+    [Test]
+    public void ParameterizedGenericTypeIsDiscoverable_ByItsIndirectNonGenericAncestor() =>
+      Assert.AreSame(typeof(ListIntLvl1).GetGenericType(typeof(List<>)), typeof(List<int>));
+
+    [Test]
+    public void ParameterizedGenericTypeIsDiscoverable_ByItsDirectGenericAncestor() =>
+      Assert.AreSame(typeof(GenericList<int>).GetGenericType(typeof(List<>)), typeof(List<int>));
+
+    [Test]
+    public void ParameterizedGenericTypeIsDiscoverable_ByItsIndirectGenericAncestor() =>
+      Assert.AreSame(typeof(GenericListLvl1<int>).GetGenericType(typeof(List<>)), typeof(List<int>));
+
+    [Test]
+    public void ParameterizedGenericTypeIsDiscoverable_ByAnAncestorOfItsDirectGenericAncestor() =>
+      Assert.AreSame(typeof(GenericListIntLvl1).GetGenericType(typeof(List<>)), typeof(List<int>));
+
+    [Test]
+    public void ParameterizedGenericTypeIsDiscoverable_ByAnAncestorOfItsIndirectGenericAncestor() =>
+      Assert.AreSame(typeof(GenericListLvl1Int).GetGenericType(typeof(List<>)), typeof(List<int>));
+
+    [Test]
+    public void ParameterizedGenericInterfaceIsDiscoverable_ByItself() =>
+      Assert.AreSame(typeof(IList<int>).GetGenericType(typeof(IList<>)), typeof(IList<int>));
+
+    [Test]
+    public void ParameterizedGenericInterfaceIsNotDiscoverable_ByItsImplementation() =>
+      Assert.IsNull(typeof(List<int>).GetGenericType(typeof(IList<>)));
+
+    [Test]
+    public void NullIsReturnedIfNoMatchFound() =>
+      Assert.IsNull(typeof(Stack<int>).GetGenericType(typeof(List<>)));
+
+    [Test]
+    public void NullIsAcceptedAsFirstParameter() =>
+      Assert.IsNull(TypeHelper.GetGenericType(null, typeof(List<>)));
+  }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Reflection/TypeHelperTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Reflection/TypeHelperTest.cs
@@ -421,11 +421,64 @@ namespace Xtensive.Orm.Tests.Core.Reflection
         this.GetType(),
       };
 
-      foreach (var numericType in numericTypes)
+      foreach (var numericType in numericTypes) {
         Assert.IsTrue(numericType.IsNumericType());
+      }
 
-      foreach (var nonNumericType in nonNumericTypes)
+      foreach (var nonNumericType in nonNumericTypes) {
         Assert.IsFalse(nonNumericType.IsNumericType());
+      }
+    }
+
+    [Test]
+    public void IsNullableTest()
+    {
+      var nullableTypes = new[] {
+        typeof (Nullable<>),
+        typeof (byte?),
+        typeof (sbyte?),
+        typeof (short?),
+        typeof (ushort?),
+        typeof (int?),
+        typeof (uint?),
+        typeof (long?),
+        typeof (ulong?),
+        typeof (float?),
+        typeof (double?),
+        typeof (decimal?),
+        typeof (Guid?)
+      };
+
+      var nonNullableTypes = new[] {
+        typeof (string),
+        typeof (char),
+        typeof (bool),
+        typeof (DateTime),
+        typeof (TimeSpan),
+        typeof (Guid),
+        typeof (TypeCode),
+        typeof (byte[]),
+        typeof (Key),
+        this.GetType()
+      };
+
+      foreach (var type in nullableTypes) {
+        Assert.IsTrue(type.IsNullable());
+      }
+
+      foreach (var type in nonNullableTypes) {
+        Assert.IsFalse(type.IsNullable());
+      }
+    }
+
+    [Test]
+    public void GenericIsNullableTest()
+    {
+      Assert.IsTrue(TypeHelper.IsNullable<Guid?>());
+      Assert.IsTrue(TypeHelper.IsNullable<int?>());
+
+      Assert.IsFalse(TypeHelper.IsNullable<int>());
+      Assert.IsFalse(TypeHelper.IsNullable<string>());
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
@@ -184,8 +184,7 @@ namespace Xtensive.Orm.Linq
 
     public static Type GetSequenceElementType(Type type)
     {
-      var sequenceType = type.GetGenericType(typeof (IEnumerable<>))
-        ?? type.GetInterfaces().Select(i => i.GetGenericType(typeof (IEnumerable<>))).FirstOrDefault(i => i!=null);
+      var sequenceType = type.GetGenericInterface(typeof (IEnumerable<>));
       return sequenceType!=null ? sequenceType.GetGenericArguments()[0] : null;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/DomainModelConverter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/DomainModelConverter.cs
@@ -463,9 +463,7 @@ namespace Xtensive.Orm.Upgrade
 
     private static Type ToNullable(Type type, bool isNullable)
     {
-      return isNullable && type.IsValueType && !type.IsNullable()
-        ? type.ToNullable()
-        : type;
+      return isNullable ? type.ToNullable() : type;
     }
 
     private void ProcessDirectAssociation(TypeInfo ownerType, FieldInfo ownerField, TypeInfo targetType)

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlModelConverter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlModelConverter.cs
@@ -263,11 +263,10 @@ namespace Xtensive.Orm.Upgrade
         return StorageTypeInfo.Undefined;
       }
 
-      if (column.IsNullable 
-        && type.IsValueType 
-        && !type.IsNullable())
+      if (column.IsNullable) {
         type = type.ToNullable();
-        
+      }
+
       return new StorageTypeInfo(type, sqlValueType, column.IsNullable, sqlValueType.Length, sqlValueType.Precision, sqlValueType.Scale);
     }
 


### PR DESCRIPTION
- Lot of code formatting changes;
- `TypeHelper.Activate` method now uses constructor it found rather than always falling back to `Activator.CreateInstance` method;
- `StringComparison.Ordinal` or `char` arguments are now used while processing strings;
- Performance improvement of `IsNullable` by removing redundant checks;
- Performance improvements of `IsAnonimous` and `IsClosure` methods by faster string comparison also by using `Type.IsDefined` rather than `Attribute.IsDefined` (the faster way to call the same check) and by reordering operations in criteria to put faster operations first;
- Using stored type references rather than `typeof` operators to eliminate expensive system calls