### PR TITLE
Do not call OrmLog.DebugXxx in case Debug level logging is not enabled

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -22,9 +21,7 @@ using Xtensive.Orm.Linq;
 using Xtensive.Orm.Logging;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Providers;
-using Xtensive.Orm.Rse.Providers;
 using Xtensive.Orm.Upgrade;
-using Xtensive.Orm.Upgrade.Model;
 using Xtensive.Sql;
 using Xtensive.Sql.Info;
 
@@ -45,7 +42,7 @@ namespace Xtensive.Orm
     private bool isDisposed;
     private Session singleConnectionOwner;
 
-    private bool IsDebugEventLoggingEnabled { get; set; }
+    private readonly bool isDebugEventLoggingEnabled;
 
     /// <summary>
     /// Occurs when new <see cref="Session"/> is open and activated.
@@ -242,7 +239,7 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(configuration, "configuration");
       configuration.Lock(true);
 
-      if (IsDebugEventLoggingEnabled) {
+      if (isDebugEventLoggingEnabled) {
         OrmLog.Debug(Strings.LogOpeningSessionX, configuration);
       }
 
@@ -383,7 +380,7 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(configuration, "configuration");
       configuration.Lock(true);
 
-      if (IsDebugEventLoggingEnabled) {
+      if (isDebugEventLoggingEnabled) {
         OrmLog.Debug(Strings.LogOpeningSessionX, configuration);
       }
 
@@ -456,7 +453,7 @@ namespace Xtensive.Orm
       UpgradeContextCookie = upgradeContextCookie;
       SingleConnection = singleConnection;
       StorageNodeManager = new StorageNodeManager(Handlers);
-      IsDebugEventLoggingEnabled = OrmLog.IsLogged(LogLevel.Debug); // Just to cache this value
+      isDebugEventLoggingEnabled = OrmLog.IsLogged(LogLevel.Debug); // Just to cache this value
     }
 
     /// <inheritdoc/>
@@ -467,7 +464,7 @@ namespace Xtensive.Orm
           return;
         isDisposed = true;
 
-        if (IsDebugEventLoggingEnabled) {
+        if (isDebugEventLoggingEnabled) {
           OrmLog.Debug(Strings.LogDomainIsDisposing);
         }
 

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -19,6 +19,7 @@ using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Internals;
 using Xtensive.Orm.Internals.Prefetch;
 using Xtensive.Orm.Linq;
+using Xtensive.Orm.Logging;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Providers;
 using Xtensive.Orm.Rse.Providers;
@@ -43,6 +44,8 @@ namespace Xtensive.Orm
     
     private bool isDisposed;
     private Session singleConnectionOwner;
+
+    private bool IsDebugEventLoggingEnabled { get; set; }
 
     /// <summary>
     /// Occurs when new <see cref="Session"/> is open and activated.
@@ -239,7 +242,9 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(configuration, "configuration");
       configuration.Lock(true);
 
-      OrmLog.Debug(Strings.LogOpeningSessionX, configuration);
+      if (IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogOpeningSessionX, configuration);
+      }
 
       Session session;
 
@@ -378,7 +383,9 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(configuration, "configuration");
       configuration.Lock(true);
 
-      OrmLog.Debug(Strings.LogOpeningSessionX, configuration);
+      if (IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogOpeningSessionX, configuration);
+      }
 
       Session session;
       if (SingleConnection!=null) {
@@ -449,6 +456,7 @@ namespace Xtensive.Orm
       UpgradeContextCookie = upgradeContextCookie;
       SingleConnection = singleConnection;
       StorageNodeManager = new StorageNodeManager(Handlers);
+      IsDebugEventLoggingEnabled = OrmLog.IsLogged(LogLevel.Debug); // Just to cache this value
     }
 
     /// <inheritdoc/>
@@ -459,7 +467,9 @@ namespace Xtensive.Orm
           return;
         isDisposed = true;
 
-        OrmLog.Debug(Strings.LogDomainIsDisposing);
+        if (IsDebugEventLoggingEnabled) {
+          OrmLog.Debug(Strings.LogDomainIsDisposing);
+        }
 
         NotifyDisposing();
         Services.Dispose();

--- a/Orm/Xtensive.Orm/Orm/Entity.cs
+++ b/Orm/Xtensive.Orm/Orm/Entity.cs
@@ -482,7 +482,9 @@ namespace Xtensive.Orm
 
     internal void SystemBeforeRemove()
     {
-      OrmLog.Debug(Strings.LogSessionXRemovingKeyY, Session, Key);
+      if (Session.IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXRemovingKeyY, Session, Key);
+      }
 
       Session.SystemEvents.NotifyEntityRemoving(this);
       using (Session.Operations.EnableSystemOperationRegistration()) {
@@ -527,7 +529,9 @@ namespace Xtensive.Orm
     internal override sealed void SystemBeforeInitialize(bool materialize)
     {
       State.Entity = this;
-      OrmLog.Debug(Strings.LogSessionXMaterializingYKeyZ, Session, GetType().GetShortName(), State.Key);
+      if (Session.IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXMaterializingYKeyZ, Session, GetType().GetShortName(), State.Key);
+      }
 
       if (Session.IsSystemLogicOnly || materialize) 
         return;
@@ -613,11 +617,9 @@ namespace Xtensive.Orm
     {
       if (!Session.Configuration.Supports(SessionOptions.ReadRemovedObjects))
         EnsureNotRemoved();
-
-      // getting of field value is frequent operation and access to resources
-      // will slow down execution significantly
-      if (OrmLog.IsLogged(LogLevel.Debug))
+      if (Session.IsDebugEventLoggingEnabled) {
         OrmLog.Debug(Strings.LogSessionXGettingValueKeyYFieldZ, Session, Key, field);
+      }
 
       EnsureIsFetched(field);
 
@@ -665,7 +667,9 @@ namespace Xtensive.Orm
     {
       EnsureNotRemoved();
 
-      OrmLog.Debug(Strings.LogSessionXSettingValueKeyYFieldZ, Session, Key, field);
+      if (Session.IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXSettingValueKeyYFieldZ, Session, Key, field);
+      }
 
       if (field.IsPrimaryKey)
         throw new NotSupportedException(string.Format(Strings.ExUnableToSetKeyFieldXExplicitly, field.Name));

--- a/Orm/Xtensive.Orm/Orm/Key.cs
+++ b/Orm/Xtensive.Orm/Orm/Key.cs
@@ -119,7 +119,9 @@ namespace Xtensive.Orm
       if (IsTemporary(domain))
         return TypeReference.Type;
 
-      OrmLog.Debug(Strings.LogSessionXResolvingKeyYExactTypeIsUnknownFetchIsRequired, session, this);
+      if (session.IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXResolvingKeyYExactTypeIsUnknownFetchIsRequired, session, this);
+      }
 
       var entityState = session.Handler.FetchEntityState(this);
       if (entityState==null || entityState.IsNotAvailableOrMarkedAsRemoved)

--- a/Orm/Xtensive.Orm/Orm/Operations/Internals/OperationRegistrationScope.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/Internals/OperationRegistrationScope.cs
@@ -65,7 +65,9 @@ namespace Xtensive.Orm.Operations
       KeyByIdentifier.Add(identifier, key);
       IdentifierByKey.Add(key, identifier);
 
-      OrmLog.Debug(Strings.LogSessionXEntityWithKeyYIdentifiedAsZ, Owner.Session, key, identifier);
+      if (Owner.Session.IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXEntityWithKeyYIdentifiedAsZ, Owner.Session, key, identifier);
+      }
     }
 
     

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -287,7 +287,10 @@ namespace Xtensive.Orm
       using (var tx = session.OpenAutoTransaction()) {
         EntityState state;
         if (!session.LookupStateInCache(key, out state)) {
-          OrmLog.Debug(Strings.LogSessionXResolvingKeyYExactTypeIsZ, session, key, key.HasExactType ? Strings.Known : Strings.Unknown);
+          if (session.IsDebugEventLoggingEnabled) {
+            OrmLog.Debug(Strings.LogSessionXResolvingKeyYExactTypeIsZ, session, key, key.HasExactType ? Strings.Known : Strings.Unknown);
+          }
+
           state = session.Handler.FetchEntityState(key);
         }
         else if (state.Tuple==null) {

--- a/Orm/Xtensive.Orm/Orm/Session.Cache.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Cache.cs
@@ -29,7 +29,9 @@ namespace Xtensive.Orm
 
     internal void Invalidate()
     {
-      OrmLog.Debug(Strings.LogSessionXInvalidate, this);
+      if (IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXInvalidate, this);
+      }
 
       ClearChangeRegistry();
       InvalidateCachedEntities();
@@ -65,7 +67,10 @@ namespace Xtensive.Orm
           Persist(PersistReason.RemapEntityKeys);
           Invalidate();
         }
-        OrmLog.Debug(Strings.LogSessionXRemappingEntityKeys, this);
+        if (IsDebugEventLoggingEnabled) {
+          OrmLog.Debug(Strings.LogSessionXRemappingEntityKeys, this);
+        }
+
         foreach (var entityState in EntityChangeRegistry.GetItems(PersistenceState.New)) {
           var key = entityState.Key;
           var remappedKey = keyMapping.TryRemapKey(key);
@@ -119,8 +124,9 @@ namespace Xtensive.Orm
       };
       EntityStateCache.Add(result);
 
-      OrmLog.Debug(Strings.LogSessionXCachingY, this, result);
-      return;
+      if (IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXCachingY, this, result);
+      }
     }
 
     internal void InitializeEntity(Entity entity, bool materialize)
@@ -164,7 +170,10 @@ namespace Xtensive.Orm
         result.PersistenceState = PersistenceState.New;
       }
 
-      OrmLog.Debug(Strings.LogSessionXCachingY, this, result);
+      if (IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXCachingY, this, result);
+      }
+
       return result;
     }
 
@@ -212,7 +221,9 @@ namespace Xtensive.Orm
         }
         result.Update(tuple);
         result.IsStale = isStale;
-        OrmLog.Debug(Strings.LogSessionXUpdatingCacheY, this, result);
+        if (IsDebugEventLoggingEnabled) {
+          OrmLog.Debug(Strings.LogSessionXUpdatingCacheY, this, result);
+        }
       }
       return result;
     }
@@ -246,7 +257,10 @@ namespace Xtensive.Orm
         PersistenceState = PersistenceState.Synchronized
       };
       EntityStateCache.Add(result);
-      OrmLog.Debug(Strings.LogSessionXCachingY, this, result);
+      if (IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXCachingY, this, result);
+      }
+
       return result;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Session.Persist.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Persist.cs
@@ -88,7 +88,9 @@ namespace Xtensive.Orm
         try {
           using (this.OpenSystemLogicOnlyRegion()) {
             DemandTransaction();
-            OrmLog.Debug(Strings.LogSessionXPersistingReasonY, this, reason);
+            if (IsDebugEventLoggingEnabled) {
+              OrmLog.Debug(Strings.LogSessionXPersistingReasonY, this, reason);
+            }
 
             EntityChangeRegistry itemsToPersist;
             if (performPinning) {
@@ -132,7 +134,9 @@ namespace Xtensive.Orm
                 EntitySetChangeRegistry.Clear();
                 NonPairedReferencesRegistry.Clear();
               }
-              OrmLog.Debug(Strings.LogSessionXPersistCompleted, this);
+              if (IsDebugEventLoggingEnabled) {
+                OrmLog.Debug(Strings.LogSessionXPersistCompleted, this);
+              }
             }
           }
           SystemEvents.NotifyPersisted();

--- a/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
@@ -148,7 +148,9 @@ namespace Xtensive.Orm
 
     internal void CommitTransaction(Transaction transaction)
     {
-      OrmLog.Debug(Strings.LogSessionXCommittingTransaction, this);
+      if (IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXCommittingTransaction, this);
+      }
 
       SystemEvents.NotifyTransactionPrecommitting(transaction);
       Events.NotifyTransactionPrecommitting(transaction);
@@ -169,7 +171,10 @@ namespace Xtensive.Orm
     internal void RollbackTransaction(Transaction transaction)
     {
       try {
-        OrmLog.Debug(Strings.LogSessionXRollingBackTransaction, this);
+        if (IsDebugEventLoggingEnabled) {
+          OrmLog.Debug(Strings.LogSessionXRollingBackTransaction, this);
+        }
+
         SystemEvents.NotifyTransactionRollbacking(transaction);
         Events.NotifyTransactionRollbacking(transaction);
       }
@@ -226,12 +231,18 @@ namespace Xtensive.Orm
 
       switch (transaction.State) {
       case TransactionState.Committed:
-        OrmLog.Debug(Strings.LogSessionXCommittedTransaction, this);
+        if (IsDebugEventLoggingEnabled) {
+          OrmLog.Debug(Strings.LogSessionXCommittedTransaction, this);
+        }
+
         SystemEvents.NotifyTransactionCommitted(transaction);
         Events.NotifyTransactionCommitted(transaction);
         break;
       case TransactionState.RolledBack:
-        OrmLog.Debug(Strings.LogSessionXRolledBackTransaction, this);
+        if (IsDebugEventLoggingEnabled) {
+          OrmLog.Debug(Strings.LogSessionXRolledBackTransaction, this);
+        }
+
         SystemEvents.NotifyTransactionRollbacked(transaction);
         Events.NotifyTransactionRollbacked(transaction);
         break;
@@ -292,8 +303,10 @@ namespace Xtensive.Orm
 
     private TransactionScope OpenTransactionScope(Transaction transaction)
     {
-      OrmLog.Debug(Strings.LogSessionXOpeningTransaction, this);
-      
+      if (IsDebugEventLoggingEnabled) {
+        OrmLog.Debug(Strings.LogSessionXOpeningTransaction, this);
+      }
+
       SystemEvents.NotifyTransactionOpening(transaction);
       Events.NotifyTransactionOpening(transaction);
 
@@ -301,9 +314,10 @@ namespace Xtensive.Orm
       transaction.Begin();
 
       IDisposable logIndentScope = null;
-      if (IsDebugEventLoggingEnabled)
+      if (IsDebugEventLoggingEnabled) {
         logIndentScope = OrmLog.DebugRegion(Strings.LogSessionXTransaction, this);
-      
+      }
+
       SystemEvents.NotifyTransactionOpened(transaction);
       Events.NotifyTransactionOpened(transaction);
 

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -575,7 +575,9 @@ namespace Xtensive.Orm
       if (isDisposed)
         return;
       try {
-        OrmLog.Debug(Strings.LogSessionXDisposing, this);
+        if (IsDebugEventLoggingEnabled) {
+          OrmLog.Debug(Strings.LogSessionXDisposing, this);
+        }
 
         SystemEvents.NotifyDisposing();
         Events.NotifyDisposing();


### PR DESCRIPTION
It is too expensive to get values of Strings.Xxx properties when those are not needed for actual logging