### PR TITLE
Make Segment struct readonly. Pass it by reference. Access it as field.

### DIFF
--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -312,7 +312,7 @@ namespace Xtensive.Core
     /// Gets the items from the segment.
     /// </summary>
     /// <param name="segment">The segment.</param>
-    public static IEnumerable<int> GetItems(this Segment<int> segment)
+    public static IEnumerable<int> GetItems(this in Segment<int> segment)
     {
       return Enumerable.Range(segment.Offset, segment.Length);
     }

--- a/Orm/Xtensive.Orm/Core/Segment.cs
+++ b/Orm/Xtensive.Orm/Core/Segment.cs
@@ -19,7 +19,7 @@ namespace Xtensive.Core
   /// <typeparam name="T">The type of segment boundaries.</typeparam>
   [Serializable]
   [DebuggerDisplay("Offset = {Offset}, Length = {Length}")]
-  public struct Segment<T>
+  public readonly struct Segment<T>
   {
     private static ArithmeticStruct<T> arithmetic = ArithmeticStruct<T>.Default;
 
@@ -87,7 +87,7 @@ namespace Xtensive.Core
     /// <param name="segment">The segment.</param>
     /// <param name="offsetShift">The offset shift.</param>
     /// <returns>The result of the operator.</returns>
-    public static Segment<T> operator +(Segment<T> segment, T offsetShift)
+    public static Segment<T> operator +(in Segment<T> segment, T offsetShift)
     {
       var newOffset = arithmetic.Add(segment.Offset, offsetShift);
       return new Segment<T>(newOffset, segment.Length);
@@ -99,7 +99,7 @@ namespace Xtensive.Core
     /// <param name="segment">The segment.</param>
     /// <param name="offsetShift">The offset shift.</param>
     /// <returns>The result of the operator.</returns>
-    public static Segment<T> operator -(Segment<T> segment, T offsetShift)
+    public static Segment<T> operator -(in Segment<T> segment, T offsetShift)
     {
       var newOffset = arithmetic.Subtract(segment.Offset, offsetShift);
       return new Segment<T>(newOffset, segment.Length);

--- a/Orm/Xtensive.Orm/Orm/Internals/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/TupleExtensions.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Internals
       return false;
     }
 
-    public static bool ContainsEmptyValues(this Tuple target, Segment<int> segment)
+    public static bool ContainsEmptyValues(this Tuple target, in Segment<int> segment)
     {
       for (int i = segment.Offset; i < segment.EndOffset; i++) {
         var state = target.GetFieldState(i);
@@ -43,7 +43,7 @@ namespace Xtensive.Orm.Internals
       return false;
     }
 
-    public static bool ContainsNonEmptyValues(this Tuple target, Segment<int> segment)
+    public static bool ContainsNonEmptyValues(this Tuple target, in Segment<int> segment)
     {
       for (int i = segment.Offset; i < segment.EndOffset; i++) {
         var state = target.GetFieldState(i);
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Internals
       return false;
     }
 
-    public static bool AreAllColumnsAvalilable(this Tuple target, Segment<int> segment)
+    public static bool AreAllColumnsAvalilable(this Tuple target, in Segment<int> segment)
     {
       for (int i = segment.Offset; i < segment.EndOffset; i++) {
         var state = target.GetFieldState(i);
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Internals
       return true;
     }
 
-    public static bool IsAtLeastOneColumAvailable(this Tuple target, Segment<int> segment)
+    public static bool IsAtLeastOneColumAvailable(this Tuple target, in Segment<int> segment)
     {
       for (int i = segment.Offset; i < segment.EndOffset; i++) {
         var state = target.GetFieldState(i);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using Xtensive.Collections;
 using Xtensive.Core;
 
 namespace Xtensive.Orm.Linq.Expressions
@@ -15,22 +14,22 @@ namespace Xtensive.Orm.Linq.Expressions
   internal class ColumnExpression : ParameterizedExpression,
     IMappedExpression
   {
-    public Segment<int> Mapping { get; private set; }
+    internal readonly Segment<int> Mapping;
 
     public Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
-      var mapping = new Segment<int>(Mapping.Offset + offset, 1);
-      return new ColumnExpression(Type, mapping, OuterParameter, DefaultIfEmpty);
+      var newMapping = new Segment<int>(Mapping.Offset + offset, 1);
+      return new ColumnExpression(Type, newMapping, OuterParameter, DefaultIfEmpty);
     }
 
     public Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
-      var mapping = new Segment<int>(map.IndexOf(Mapping.Offset), 1);
-      return new ColumnExpression(Type, mapping, OuterParameter, DefaultIfEmpty);
+      var newMapping = new Segment<int>(map.IndexOf(Mapping.Offset), 1);
+      return new ColumnExpression(Type, newMapping, OuterParameter, DefaultIfEmpty);
     }
 
     public Expression BindParameter(ParameterExpression parameter)
@@ -63,13 +62,13 @@ namespace Xtensive.Orm.Linq.Expressions
     // Constructors
 
     protected ColumnExpression(
-      Type type, 
-      Segment<int> mapping, 
-      ParameterExpression parameterExpression, 
+      Type type,
+      in Segment<int> mapping,
+      ParameterExpression parameterExpression,
       bool defaultIfEmpty)
       : base(ExtendedExpressionType.Column, type, parameterExpression, defaultIfEmpty)
     {
-      Mapping = mapping;
+      this.Mapping = mapping;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -29,11 +29,6 @@ namespace Xtensive.Orm.Linq
 
     public IEnumerable<Expression> ConstructorArguments { get; private set; }
 
-    public Segment<int> Mapping
-    {
-      get { throw new NotSupportedException(); }
-    }
-
     public Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       Func<Expression, Expression> genericBinder =

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
@@ -21,11 +21,6 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public TypeInfo PersistentType { get; private set; }
 
-    public Segment<int> Mapping
-    {
-      get { throw new NotSupportedException(); }
-    }
-
     public KeyExpression Key { get; private set; }
 
     public List<PersistentFieldExpression> Fields

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -176,7 +176,7 @@ namespace Xtensive.Orm.Linq.Expressions
       TypeInfo persistentType, 
       FieldInfo field, 
       List<PersistentFieldExpression> fields,
-      Segment<int> mapping, 
+      in Segment<int> mapping,
       KeyExpression key, 
       EntityExpression entity, 
       ParameterExpression parameterExpression, 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -43,8 +43,8 @@ namespace Xtensive.Orm.Linq.Expressions
         return result;
       }
 
-      var mapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
-      result = new FieldExpression(ExtendedExpressionType.Field, Field, mapping, OuterParameter, DefaultIfEmpty);
+      var newMapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
+      result = new FieldExpression(ExtendedExpressionType.Field, Field, newMapping, OuterParameter, DefaultIfEmpty);
       if (owner == null) {
         return result;
       }
@@ -72,8 +72,8 @@ namespace Xtensive.Orm.Linq.Expressions
           Owner.Remap(map, processedExpressions);
         return null;
       }
-      var mapping = new Segment<int>(offset, Mapping.Length);
-      result = new FieldExpression(ExtendedExpressionType.Field, Field, mapping, OuterParameter, DefaultIfEmpty);
+      var newMapping = new Segment<int>(offset, Mapping.Length);
+      result = new FieldExpression(ExtendedExpressionType.Field, Field, newMapping, OuterParameter, DefaultIfEmpty);
       if (owner == null)
         return result;
 
@@ -130,7 +130,7 @@ namespace Xtensive.Orm.Linq.Expressions
     protected FieldExpression(
       ExtendedExpressionType expressionType, 
       FieldInfo field, 
-      Segment<int> mapping, 
+      in Segment<int> mapping,
       ParameterExpression parameterExpression, 
       bool defaultIfEmpty)
       : base(expressionType, field.Name, field.ValueType, mapping, field.UnderlyingProperty, parameterExpression, defaultIfEmpty)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
@@ -22,12 +22,6 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public EntityExpression EntityExpression { get; private set; }
 
-    /// <exception cref="NotSupportedException"><c>NotSupportedException</c>.</exception>
-    public Segment<int> Mapping
-    {
-      get { throw new NotSupportedException(); }
-    }
-
     public Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       Expression result;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
@@ -12,7 +12,6 @@ namespace Xtensive.Orm.Linq.Expressions
 {
   internal interface IMappedExpression
   {
-    Segment<int> Mapping { get; }
     Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
     Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
@@ -34,12 +34,12 @@ namespace Xtensive.Orm.Linq.Expressions
     // in case processedExpressions dictionary already contains a result.
     private Expression RemapWithNoCheck(int offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      var mapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
+      var newMapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
 
       FieldExpression Remap(FieldExpression f) => (FieldExpression) f.Remap(offset, processedExpressions);
 
       var fields = KeyFields.Select(Remap).ToArray(KeyFields.Count);
-      var result = new KeyExpression(EntityType, fields, mapping, UnderlyingProperty, OuterParameter, DefaultIfEmpty);
+      var result = new KeyExpression(EntityType, fields, newMapping, UnderlyingProperty, OuterParameter, DefaultIfEmpty);
 
       processedExpressions.Add(this, result);
       return result;
@@ -147,7 +147,7 @@ namespace Xtensive.Orm.Linq.Expressions
     private KeyExpression(
       TypeInfo entityType, 
       IReadOnlyList<FieldExpression> keyFields,
-      Segment<int> segment, 
+      in Segment<int> segment,
       PropertyInfo underlyingProperty, 
       ParameterExpression parameterExpression, 
       bool defaultIfEmpty)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -18,11 +18,6 @@ namespace Xtensive.Orm.Linq.Expressions
   internal class LocalCollectionExpression : ParameterizedExpression,
     IMappedExpression
   {
-    public Segment<int> Mapping
-    {
-      get { return default(Segment<int>); }
-    }
-
     public Expression SourceExpression { get;private set; }
     public IDictionary<MemberInfo, IMappedExpression> Fields { get; set; }
     public Expression MaterializationExpression { get; private set; }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/PersistentFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/PersistentFieldExpression.cs
@@ -15,9 +15,10 @@ namespace Xtensive.Orm.Linq.Expressions
   internal abstract class PersistentFieldExpression : ParameterizedExpression,
     IMappedExpression
   {
+    internal Segment<int> Mapping;
+
     public string Name { get; private set; }
     public PropertyInfo UnderlyingProperty { get; private set; }
-    public virtual Segment<int> Mapping { get; protected set; }
     public abstract Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions);
@@ -35,7 +36,7 @@ namespace Xtensive.Orm.Linq.Expressions
       ExtendedExpressionType expressionType, 
       string name, 
       Type type, 
-      Segment<int> segment, 
+      in Segment<int> segment,
       PropertyInfo underlyingProperty,
       ParameterExpression parameterExpression,
       bool defaultIfEmpty)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
@@ -46,8 +46,8 @@ namespace Xtensive.Orm.Linq.Expressions
       if (processedExpressions.TryGetValue(this, out value))
         return value;
 
-      var mapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
-      var result = new StructureFieldExpression(PersistentType, Field, mapping, OuterParameter, DefaultIfEmpty);
+      var newMapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
+      var result = new StructureFieldExpression(PersistentType, Field, newMapping, OuterParameter, DefaultIfEmpty);
       processedExpressions.Add(this, result);
       var processedFields = Fields
         .Select(f => f.Remap(offset, processedExpressions))
@@ -183,7 +183,7 @@ namespace Xtensive.Orm.Linq.Expressions
     private StructureFieldExpression(
       TypeInfo persistentType, 
       FieldInfo structureField, 
-      Segment<int> mapping, 
+      in Segment<int> mapping,
       ParameterExpression parameterExpression, 
       bool defaultIfEmpty)
       : base(ExtendedExpressionType.StructureField, structureField, mapping, parameterExpression, defaultIfEmpty)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
@@ -23,12 +23,6 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public ApplyParameter ApplyParameter { get; private set; }
 
-    /// <exception cref="NotSupportedException"><c>NotSupportedException</c>.</exception>
-    public virtual Segment<int> Mapping
-    {
-      get { throw new NotSupportedException(); }
-    }
-
     public virtual Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -496,7 +496,7 @@ namespace Xtensive.Orm.Linq.Materialization
       return result;
     }
 
-    private static Tuple GetTupleSegment(Tuple tuple, Segment<int> segment)
+    private static Tuple GetTupleSegment(Tuple tuple, in Segment<int> segment)
     {
       return tuple.GetSegment(segment).ToRegular();
     }

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -60,6 +60,7 @@ namespace Xtensive.Orm.Model
     private int? cachedHashCode;
 
     private IList<IPropertyValidator> validators;
+    private Segment<int> mappingInfo;
 
     #region IsXxx properties
 
@@ -464,7 +465,7 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets <see cref="MappingInfo"/> for current field.
     /// </summary>
-    public Segment<int> MappingInfo { get; private set; }
+    public Segment<int> MappingInfo => mappingInfo;
 
     /// <summary>
     /// Gets the underlying system property.
@@ -710,18 +711,18 @@ namespace Xtensive.Orm.Model
     {
       if (column!=null) {
         if (reflectedType.IsStructure)
-          MappingInfo = new Segment<int>(reflectedType.Columns.IndexOf(column), 1);
+          mappingInfo = new Segment<int>(reflectedType.Columns.IndexOf(column), 1);
         else {
           var primaryIndex = reflectedType.Indexes.PrimaryIndex;
           var indexColumn = primaryIndex.Columns.Where(c => c.Name==column.Name).FirstOrDefault();
           if (indexColumn == null)
             throw new InvalidOperationException();
-          MappingInfo = new Segment<int>(primaryIndex.Columns.IndexOf(indexColumn), 1);
+          mappingInfo = new Segment<int>(primaryIndex.Columns.IndexOf(indexColumn), 1);
         }
       }
       else 
         if (Fields.Count > 0)
-          MappingInfo = new Segment<int>(
+          mappingInfo = new Segment<int>(
             Fields.First().MappingInfo.Offset, Fields.Sum(f => f.IsPrimitive ? f.MappingInfo.Length : 0));
 
       if (IsEntity || IsStructure) {

--- a/Orm/Xtensive.Orm/Tuples/Transform/CutOutTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/CutOutTransform.cs
@@ -56,7 +56,7 @@ namespace Xtensive.Tuples.Transform
     /// <param name="isReadOnly"><see cref="MapTransform.IsReadOnly"/> property value.</param>
     /// <param name="sourceDescriptor">Source tuple descriptor.</param>
     /// <param name="segment">The segment to cut out.</param>
-    public CutOutTransform(bool isReadOnly, TupleDescriptor sourceDescriptor, Segment<int> segment)
+    public CutOutTransform(bool isReadOnly, TupleDescriptor sourceDescriptor, in Segment<int> segment)
       : base(isReadOnly)
     {
       this.segment = segment;

--- a/Orm/Xtensive.Orm/Tuples/Transform/SegmentTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/SegmentTransform.cs
@@ -55,7 +55,7 @@ namespace Xtensive.Tuples.Transform
     /// <param name="isReadOnly"><see cref="MapTransform.IsReadOnly"/> property value.</param>
     /// <param name="sourceDescriptor">Source tuple descriptor.</param>
     /// <param name="segment">The segment to extract.</param>
-    public SegmentTransform(bool isReadOnly, TupleDescriptor sourceDescriptor, Segment<int> segment)
+    public SegmentTransform(bool isReadOnly, TupleDescriptor sourceDescriptor, in Segment<int> segment)
       : base(isReadOnly)
     {
       this.segment = segment;

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -196,7 +196,7 @@ namespace Xtensive.Tuples
     /// <param name="tuple">The <see cref="Tuple"/> to get segment from.</param>
     /// <param name="segment">The <see cref="Segment{T}"/> to cut off.</param>
     /// <returns></returns>
-    public static Tuple GetSegment(this Tuple tuple, Segment<int> segment)
+    public static Tuple GetSegment(this Tuple tuple, in Segment<int> segment)
     {
       var length = segment.Length;
       var map = new int[length];


### PR DESCRIPTION
This gives a runtime an ability not to copy Segments on stack over and over again. Instead it can pass first copy address and access values there.