### PR TITLE
Makes IEnumberable<T>.Contains work with Bulk operations

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations.Tests/ContainsTest.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations.Tests/ContainsTest.cs
@@ -1,0 +1,111 @@
+// Copyright (C) 2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Xtensive.Orm.BulkOperations.ContainsTestModel;
+using Xtensive.Orm.Configuration;
+
+namespace Xtensive.Orm.BulkOperations.ContainsTestModel
+{
+  [HierarchyRoot]
+  [KeyGenerator(KeyGeneratorKind.None)]
+  public class TagType : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+
+    [Field]
+    public int ProjectedValueAdjustment { get; set; }
+
+    public TagType(Session session, long id)
+      :base(session, id)
+    {
+    }
+  }
+}
+
+namespace Xtensive.Orm.BulkOperations.Tests
+{
+  public class ContainsTest : AutoBuildTest
+  {
+    private long[] tagIds;
+
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(TagType).Assembly, typeof(TagType).Namespace);
+      return configuration;
+    }
+
+    protected override void PopulateData()
+    {
+      tagIds = Enumerable.Range(0, 100).Select(i => (long) i).ToArray();
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        foreach (var id in tagIds.Concat(Enumerable.Repeat(1000, 1).Select(i => (long) i)))
+          new TagType(session, id) { ProjectedValueAdjustment = -1 };
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public void Test1()
+    {
+      using (var session = Domain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        var updatedRows = session.Query.All<TagType>()
+          .Where(t => t.Id.In(tagIds))
+          .Set(t => t.ProjectedValueAdjustment, 2)
+          .Update();
+        Assert.That(updatedRows, Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == 2 && t.Id <= 200), Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == -1 && t.Id > 700), Is.EqualTo(1));
+      }
+    }
+
+    [Test]
+    public void Test2()
+    {
+      using (var session = Domain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        var updatedRows = session.Query.All<TagType>()
+          .Where(t => t.Id.In(IncludeAlgorithm.ComplexCondition, tagIds))
+          .Set(t => t.ProjectedValueAdjustment, 2)
+          .Update();
+        Assert.That(updatedRows, Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == 2 && t.Id <= 200), Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == -1 && t.Id > 700), Is.EqualTo(1));
+      }
+    }
+
+    [Test]
+    public void Test3()
+    {
+      using (var session = Domain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        Assert.Throws<NotSupportedException>(() => session.Query.All<TagType>()
+          .Where(t => t.Id.In(IncludeAlgorithm.TemporaryTable, tagIds))
+          .Set(t => t.ProjectedValueAdjustment, 2)
+          .Update());
+      }
+    }
+
+    [Test]
+    public void Test4()
+    {
+      using (var session = Domain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        var updatedRows = session.Query.All<TagType>()
+          .Where(t => tagIds.Contains(t.Id))
+          .Set(t => t.ProjectedValueAdjustment, 2)
+          .Update();
+        Assert.That(updatedRows, Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == 2 && t.Id <= 200), Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == -1 && t.Id > 700), Is.EqualTo(1));
+      }
+    }
+  }
+}

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -39,7 +39,7 @@ namespace Xtensive.Orm.BulkOperations
           var methodInfo = ex.Method;
           //rewrite localCollection.Contains(entity.SomeField) -> entity.SomeField.In(localCollection)
           if (methodInfo.DeclaringType == typeof(Enumerable) &&
-              string.Equals(methodInfo.Name, "Contains", StringComparison.OrdinalIgnoreCase) &&
+              string.Equals(methodInfo.Name, "Contains", StringComparison.Ordinal) &&
               ex.Arguments.Count == 2) {
             var localCollection = ex.Arguments[0];//IEnumerable<T>
             var valueToCheck = ex.Arguments[1];

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -24,9 +24,9 @@ namespace Xtensive.Orm.BulkOperations
 
     private static MethodInfo GetInMethod()
     {
-      foreach (var method in typeof (QueryableExtensions).GetMethods().Where(a=>a.Name == "In")) {
+      foreach (var method in typeof (QueryableExtensions).GetMethods().Where(a => string.Equals(a.Name, "In", StringComparison.Ordinal))) {
         var parameters = method.GetParameters();
-        if (parameters.Length == 3 && parameters[2].ParameterType.Name == "IEnumerable`1")
+        if (parameters.Length == 3 && string.Equals(parameters[2].ParameterType.Name, "IEnumerable`1", StringComparison.Ordinal))
           return method;
       }
       return null;
@@ -39,7 +39,7 @@ namespace Xtensive.Orm.BulkOperations
           var methodInfo = ex.Method;
           //rewrite localCollection.Contains(entity.SomeField) -> entity.SomeField.In(localCollection)
           if (methodInfo.DeclaringType == typeof(Enumerable) &&
-              methodInfo.Name == "Contains" &&
+              string.Equals(methodInfo.Name, "Contains", StringComparison.OrdinalIgnoreCase) &&
               ex.Arguments.Count == 2) {
             var localCollection = ex.Arguments[0];//IEnumerable<T>
             var valueToCheck = ex.Arguments[1];
@@ -49,7 +49,7 @@ namespace Xtensive.Orm.BulkOperations
           }
 
           if (methodInfo.DeclaringType == typeof(QueryableExtensions) &&
-              methodInfo.Name == "In" &&
+              string.Equals(methodInfo.Name, "In", StringComparison.Ordinal) &&
               ex.Arguments.Count > 1) {
             if (ex.Arguments[1].Type == typeof(IncludeAlgorithm)) {
               var algorithm = (IncludeAlgorithm) ex.Arguments[1].Invoke();


### PR DESCRIPTION
As in main assembly it rewrites calls like localCollection.Contains(value) with usage of In extension method like value.In(IncludeAlgorithm.ComplexCondition, localCollection)

Fix for issue #20 
