### PR TITLE
Allocation free scopes

### DIFF
--- a/Orm/Xtensive.Orm/Collections/BindingCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/BindingCollection.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.03.12
 

--- a/Orm/Xtensive.Orm/Orm/Linq/LinqBindingCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/LinqBindingCollection.cs
@@ -19,10 +19,13 @@ namespace Xtensive.Orm.Linq
     private readonly Dictionary<ParameterExpression, IEnumerable<ParameterExpression>> linkedParameters
       = new Dictionary<ParameterExpression, IEnumerable<ParameterExpression>>();
 
-    public override IDisposable Add(ParameterExpression key, ProjectionExpression value)
+    public override BindingScope Add(ParameterExpression key, ProjectionExpression value)
     {
-      if (!key.Type.IsAssignableFrom(value.ItemProjector.Type))
-        throw new ArgumentException(Strings.ExParameterExpressionMustHaveSameTypeAsProjectionExpressionItemProjector, "key");
+      if (!key.Type.IsAssignableFrom(value.ItemProjector.Type)) {
+        throw new ArgumentException(
+          Strings.ExParameterExpressionMustHaveSameTypeAsProjectionExpressionItemProjector, nameof(key));
+      }
+
       return base.Add(key, value);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/LinqBindingCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/LinqBindingCollection.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
 // Created:    2009.06.30
 

--- a/Orm/Xtensive.Orm/Orm/Linq/LinqBindingCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/LinqBindingCollection.cs
@@ -15,6 +15,26 @@ namespace Xtensive.Orm.Linq
   [Serializable]
   internal class LinqBindingCollection : BindingCollection<ParameterExpression, ProjectionExpression>
   {
+    internal readonly ref struct ParameterScope
+    {
+      private readonly LinqBindingCollection owner;
+      private readonly IReadOnlyCollection<ParameterExpression> parameters;
+
+      public void Dispose()
+      {
+        var linkedParameters = owner.linkedParameters;
+        foreach (var parameter in parameters) {
+          linkedParameters.Remove(parameter);
+        }
+      }
+
+      public ParameterScope(LinqBindingCollection owner, IReadOnlyCollection<ParameterExpression> parameters)
+      {
+        this.owner = owner;
+        this.parameters = parameters;
+      }
+    }
+
     private readonly Dictionary<ParameterExpression, IEnumerable<ParameterExpression>> linkedParameters
       = new Dictionary<ParameterExpression, IEnumerable<ParameterExpression>>();
 
@@ -54,26 +74,6 @@ namespace Xtensive.Orm.Linq
             base.ReplaceBound(parameter, newProjection);
           }
         }
-      }
-    }
-
-    internal readonly ref struct ParameterScope
-    {
-      private readonly LinqBindingCollection owner;
-      private readonly IReadOnlyCollection<ParameterExpression> parameters;
-
-      public void Dispose()
-      {
-        var linkedParameters = owner.linkedParameters;
-        foreach (var parameter in parameters) {
-          linkedParameters.Remove(parameter);
-        }
-      }
-
-      public ParameterScope(LinqBindingCollection owner, IReadOnlyCollection<ParameterExpression> parameters)
-      {
-        this.owner = owner;
-        this.parameters = parameters;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1072,7 +1072,7 @@ namespace Xtensive.Orm.Linq
       var visitedSource = Visit(source);
       var sequence = VisitSequence(visitedSource);
 
-      IDisposable indexBinding = null;
+      var indexBinding = BindingCollection<ParameterExpression, ProjectionExpression>.BindingScope.Empty;
       if (collectionSelector.Parameters.Count==2) {
         var indexProjection = GetIndexBinding(collectionSelector, ref sequence);
         indexBinding = context.Bindings.Add(collectionSelector.Parameters[1], indexProjection);
@@ -1191,7 +1191,7 @@ namespace Xtensive.Orm.Linq
     {
       var parameter = le.Parameters[0];
       ProjectionExpression visitedSource = VisitSequence(expression);
-      IDisposable indexBinding = null;
+      var indexBinding = BindingCollection<ParameterExpression, ProjectionExpression>.BindingScope.Empty;
       if (le.Parameters.Count==2) {
         var indexProjection = GetIndexBinding(le, ref visitedSource);
         indexBinding = context.Bindings.Add(le.Parameters[1], indexProjection);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.02.27
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriterState.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriterState.cs
@@ -5,8 +5,6 @@
 // Created:    2010.01.21
 
 using System;
-using Xtensive.Core;
-
 
 namespace Xtensive.Orm.Rse.Transformation
 {
@@ -56,12 +54,25 @@ namespace Xtensive.Orm.Rse.Transformation
       };
     }
 
-    public IDisposable CreateScope()
+    internal readonly ref struct SkipTakeRewriterScope
+    {
+      private readonly SkipTakeRewriter rewriter;
+      private readonly SkipTakeRewriterState prevState;
+
+      public void Dispose() => rewriter.State = prevState;
+
+      public SkipTakeRewriterScope(SkipTakeRewriter rewriter, SkipTakeRewriterState prevState)
+      {
+        this.rewriter = rewriter;
+        this.prevState = prevState;
+      }
+    }
+
+    public SkipTakeRewriterScope CreateScope()
     {
       var currentState = rewriter.State;
-      var newState = new SkipTakeRewriterState(currentState);
-      rewriter.State = newState;
-      return new Disposable(_ => rewriter.State = currentState);
+      rewriter.State = new SkipTakeRewriterState(currentState);
+      return new SkipTakeRewriterScope(rewriter, currentState);
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriterState.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriterState.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2010-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
 // Created:    2010.01.21
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriterState.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriterState.cs
@@ -10,6 +10,20 @@ namespace Xtensive.Orm.Rse.Transformation
 {
   internal sealed class SkipTakeRewriterState
   {
+    internal readonly ref struct SkipTakeRewriterScope
+    {
+      private readonly SkipTakeRewriter rewriter;
+      private readonly SkipTakeRewriterState prevState;
+
+      public void Dispose() => rewriter.State = prevState;
+
+      public SkipTakeRewriterScope(SkipTakeRewriter rewriter, SkipTakeRewriterState prevState)
+      {
+        this.rewriter = rewriter;
+        this.prevState = prevState;
+      }
+    }
+
     private readonly SkipTakeRewriter rewriter;
 
     public Func<int> Skip { get; private set; }
@@ -52,20 +66,6 @@ namespace Xtensive.Orm.Rse.Transformation
         var value = valueSelector();
         return value > 0 ? value : 0;
       };
-    }
-
-    internal readonly ref struct SkipTakeRewriterScope
-    {
-      private readonly SkipTakeRewriter rewriter;
-      private readonly SkipTakeRewriterState prevState;
-
-      public void Dispose() => rewriter.State = prevState;
-
-      public SkipTakeRewriterScope(SkipTakeRewriter rewriter, SkipTakeRewriterState prevState)
-      {
-        this.rewriter = rewriter;
-        this.prevState = prevState;
-      }
     }
 
     public SkipTakeRewriterScope CreateScope()


### PR DESCRIPTION
In this PR several scopes are converted to `readonly ref struct`s to make sure no heap allocation happens in those cases.