### PR TITLE
Expression performance

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
@@ -1,15 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.05.05
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using Xtensive.Core;
 using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm.Linq.Expressions
@@ -71,7 +69,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
 
       var keyExpression = (KeyExpression) Key.Remap(map, processedExpressions);
-      if (keyExpression==null) {
+      if (keyExpression == null) {
         return null;
       }
 
@@ -139,9 +137,10 @@ namespace Xtensive.Orm.Linq.Expressions
       var typeInfo = entityExpression.PersistentType;
       foreach (var nestedField in typeInfo.Fields.Except(entityExpression.Fields.OfType<FieldExpression>().Select(field=>field.Field))) {
         var nestedFieldExpression = BuildNestedFieldExpression(nestedField, offset);
-        var fieldExpression = nestedFieldExpression as FieldExpression;
-        if (fieldExpression!=null)
+        if (nestedFieldExpression is FieldExpression fieldExpression) {
           fieldExpression.Owner = entityExpression;
+        }
+
         entityExpression.fields.Add(nestedFieldExpression);
       }
     }
@@ -200,14 +199,22 @@ namespace Xtensive.Orm.Linq.Expressions
 
     private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, int offset)
     {
-      if (nestedField.IsPrimitive)
+      if (nestedField.IsPrimitive) {
         return FieldExpression.CreateField(nestedField, offset);
-      if (nestedField.IsStructure)
+      }
+
+      if (nestedField.IsStructure) {
         return StructureFieldExpression.CreateStructure(nestedField, offset);
-      if (nestedField.IsEntity)
+      }
+
+      if (nestedField.IsEntity) {
         return EntityFieldExpression.CreateEntityField(nestedField, offset);
-      if (nestedField.IsEntitySet)
-          return EntitySetExpression.CreateEntitySet(nestedField);
+      }
+
+      if (nestedField.IsEntitySet) {
+        return EntitySetExpression.CreateEntitySet(nestedField);
+      }
+
       throw new NotSupportedException(string.Format(Strings.ExNestedFieldXIsNotSupported, nestedField.Attributes));
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -16,15 +16,14 @@ namespace Xtensive.Orm.Linq.Expressions
   internal sealed class EntityFieldExpression : FieldExpression,
     IEntityExpression
   {
-    public TypeInfo PersistentType { get; private set; }
-    public List<PersistentFieldExpression> Fields { get; private set; }
-    public KeyExpression Key { get; private set; }
+    private readonly List<PersistentFieldExpression> fields;
+
+    public TypeInfo PersistentType { get; }
+    public List<PersistentFieldExpression> Fields => fields;
+    public KeyExpression Key { get; }
     public EntityExpression Entity { get; private set; }
 
-    public bool IsNullable 
-    { 
-      get { return Owner != null && Owner.IsNullable || Field.IsNullable; }
-    }
+    public bool IsNullable => (Owner != null && Owner.IsNullable) || Field.IsNullable;
 
     public void RegisterEntityExpression(int offset)
     {
@@ -34,24 +33,27 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public override Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap)
+      if (!CanRemap) {
         return this;
+      }
 
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
+      if (processedExpressions.TryGetValue(this, out var result)) {
         return result;
+      }
 
-      var fields = Fields
-        .Select(f => f.Remap(offset, processedExpressions))
-        .Cast<PersistentFieldExpression>()
-        .ToList();
+      var newFields = new List<PersistentFieldExpression>(fields.Count);
+      foreach (var field in fields) {
+        // Do not convert to LINQ. We want to avoid a closure creation here.
+        newFields.Add((PersistentFieldExpression) field.Remap(offset, processedExpressions));
+      }
+
       var keyExpression = (KeyExpression) Key.Remap(offset, processedExpressions);
-      var entity = Entity!=null
-        ? (EntityExpression) Entity.Remap(offset, processedExpressions)
-        : null;
-      result = new EntityFieldExpression(PersistentType, Field, fields, keyExpression.Mapping, keyExpression, entity, OuterParameter, DefaultIfEmpty);
-      if (Owner==null)
+      var entity = (EntityExpression) Entity?.Remap(offset, processedExpressions);
+      result = new EntityFieldExpression(
+        PersistentType, Field, newFields, keyExpression.Mapping, keyExpression, entity, OuterParameter, DefaultIfEmpty);
+      if (Owner==null) {
         return result;
+      }
 
       processedExpressions.Add(this, result);
       Owner.Remap(offset, processedExpressions);
@@ -60,57 +62,68 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public override Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap)
+      if (!CanRemap) {
         return this;
-
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
-        return result;
-
-      List<PersistentFieldExpression> fields;
-      using (new SkipOwnerCheckScope()) {
-        fields = Fields
-          .Select(f => f.Remap(map, processedExpressions))
-          .Where(f => f!=null)
-          .Cast<PersistentFieldExpression>()
-          .ToList();
       }
-      if (fields.Count!=Fields.Count) {
+
+      if (processedExpressions.TryGetValue(this, out var result)) {
+        return result;
+      }
+
+      var newFields = new List<PersistentFieldExpression>(fields.Count);
+      using (new SkipOwnerCheckScope()) {
+        foreach (var field in fields) {
+          // Do not convert to LINQ. We want to avoid a closure creation here.
+          var mappedField = (PersistentFieldExpression) field.Remap(map, processedExpressions);
+          if (mappedField == null) {
+            continue;
+          }
+
+          newFields.Add(mappedField);
+        }
+      }
+
+      if (newFields.Count!=Fields.Count) {
         processedExpressions.Add(this, null);
         return null;
       }
+
       var keyExpression = (KeyExpression) Key.Remap(map, processedExpressions);
       EntityExpression entity;
-      using (new SkipOwnerCheckScope())
-        entity = Entity!=null
-          ? (EntityExpression) Entity.Remap(map, processedExpressions)
-          : null;
-      result = new EntityFieldExpression(PersistentType, Field, fields, keyExpression.Mapping, keyExpression, entity, OuterParameter, DefaultIfEmpty);
-      if (Owner==null)
+      using (new SkipOwnerCheckScope()) {
+        entity = (EntityExpression) Entity?.Remap(map, processedExpressions);
+      }
+
+      result = new EntityFieldExpression(
+        PersistentType, Field, newFields, keyExpression.Mapping, keyExpression, entity, OuterParameter, DefaultIfEmpty);
+      if (Owner==null) {
         return result;
+      }
 
       processedExpressions.Add(this, result);
       Owner.Remap(map, processedExpressions);
       return result;
     }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression BindParameter(
+      ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
+      if (processedExpressions.TryGetValue(this, out var result)) {
         return result;
+      }
 
-      var fields = Fields
-        .Select(f => f.BindParameter(parameter, processedExpressions))
-        .Cast<PersistentFieldExpression>()
-        .ToList();
+      var newFields = new List<PersistentFieldExpression>(fields.Count);
+      foreach (var field in fields) {
+        // Do not convert to LINQ. We want to avoid a closure creation here.
+        newFields.Add((PersistentFieldExpression) field.BindParameter(parameter, processedExpressions));
+      }
       var keyExpression = (KeyExpression) Key.BindParameter(parameter, processedExpressions);
-      var entity = Entity!=null
-        ? (EntityExpression) Entity.BindParameter(parameter, processedExpressions)
-        : null;
-      result = new EntityFieldExpression(PersistentType, Field, fields, Mapping, keyExpression, entity, parameter, DefaultIfEmpty);
-      if (Owner==null)
+      var entity = (EntityExpression) Entity?.BindParameter(parameter, processedExpressions);
+      result = new EntityFieldExpression(
+        PersistentType, Field, newFields, Mapping, keyExpression, entity, parameter, DefaultIfEmpty);
+      if (Owner==null) {
         return result;
+      }
 
       processedExpressions.Add(this, result);
       Owner.BindParameter(parameter, processedExpressions);
@@ -119,21 +132,22 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
+      if (processedExpressions.TryGetValue(this, out var result)) {
         return result;
+      }
 
-      var fields = Fields
-        .Select(f => f.RemoveOuterParameter(processedExpressions))
-        .Cast<PersistentFieldExpression>()
-        .ToList();
+      var newFields = new List<PersistentFieldExpression>(fields.Count);
+      foreach (var field in fields) {
+        // Do not convert to LINQ. We want to avoid a closure creation here.
+        newFields.Add((PersistentFieldExpression) field.RemoveOuterParameter(processedExpressions));
+      }
       var keyExpression = (KeyExpression) Key.RemoveOuterParameter(processedExpressions);
-      var entity = Entity!=null
-        ? (EntityExpression) Entity.RemoveOuterParameter(processedExpressions)
-        : null;
-      result = new EntityFieldExpression(PersistentType, Field, fields, Mapping, keyExpression, entity, null, DefaultIfEmpty);
-      if (Owner==null)
+      var entity = (EntityExpression) Entity?.RemoveOuterParameter(processedExpressions);
+      result = new EntityFieldExpression(
+        PersistentType, Field, newFields, Mapping, keyExpression, entity, null, DefaultIfEmpty);
+      if (Owner==null) {
         return result;
+      }
 
       processedExpressions.Add(this, result);
       Owner.RemoveOuterParameter(processedExpressions);
@@ -173,18 +187,18 @@ namespace Xtensive.Orm.Linq.Expressions
     // Constructors
 
     private EntityFieldExpression(
-      TypeInfo persistentType, 
-      FieldInfo field, 
+      TypeInfo persistentType,
+      FieldInfo field,
       List<PersistentFieldExpression> fields,
       in Segment<int> mapping,
-      KeyExpression key, 
-      EntityExpression entity, 
-      ParameterExpression parameterExpression, 
+      KeyExpression key,
+      EntityExpression entity,
+      ParameterExpression parameterExpression,
       bool defaultIfEmpty)
       : base(ExtendedExpressionType.EntityField, field, mapping, parameterExpression, defaultIfEmpty)
     {
       PersistentType = persistentType;
-      Fields = fields;
+      this.fields = fields;
       Key = key;
       Entity = entity;
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -1,12 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.05.06
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
@@ -51,7 +50,7 @@ namespace Xtensive.Orm.Linq.Expressions
       var entity = (EntityExpression) Entity?.Remap(offset, processedExpressions);
       result = new EntityFieldExpression(
         PersistentType, Field, newFields, keyExpression.Mapping, keyExpression, entity, OuterParameter, DefaultIfEmpty);
-      if (Owner==null) {
+      if (Owner == null) {
         return result;
       }
 
@@ -83,7 +82,7 @@ namespace Xtensive.Orm.Linq.Expressions
         }
       }
 
-      if (newFields.Count!=Fields.Count) {
+      if (newFields.Count != Fields.Count) {
         processedExpressions.Add(this, null);
         return null;
       }
@@ -96,7 +95,7 @@ namespace Xtensive.Orm.Linq.Expressions
 
       result = new EntityFieldExpression(
         PersistentType, Field, newFields, keyExpression.Mapping, keyExpression, entity, OuterParameter, DefaultIfEmpty);
-      if (Owner==null) {
+      if (Owner == null) {
         return result;
       }
 
@@ -121,7 +120,7 @@ namespace Xtensive.Orm.Linq.Expressions
       var entity = (EntityExpression) Entity?.BindParameter(parameter, processedExpressions);
       result = new EntityFieldExpression(
         PersistentType, Field, newFields, Mapping, keyExpression, entity, parameter, DefaultIfEmpty);
-      if (Owner==null) {
+      if (Owner == null) {
         return result;
       }
 
@@ -145,7 +144,7 @@ namespace Xtensive.Orm.Linq.Expressions
       var entity = (EntityExpression) Entity?.RemoveOuterParameter(processedExpressions);
       result = new EntityFieldExpression(
         PersistentType, Field, newFields, Mapping, keyExpression, entity, null, DefaultIfEmpty);
-      if (Owner==null) {
+      if (Owner == null) {
         return result;
       }
 
@@ -154,10 +153,8 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override FieldExpression RemoveOwner()
-    {
-      return new EntityFieldExpression(PersistentType, Field, Fields, Mapping, Key, Entity, OuterParameter, DefaultIfEmpty);
-    }
+    public override FieldExpression RemoveOwner() =>
+      new EntityFieldExpression(PersistentType, Field, Fields, Mapping, Key, Entity, OuterParameter, DefaultIfEmpty);
 
     public static EntityFieldExpression CreateEntityField(FieldInfo entityField, int offset)
     {
@@ -174,6 +171,7 @@ namespace Xtensive.Orm.Linq.Expressions
       var keyExpression = KeyExpression.Create(persistentType, offset + mappingInfo.Offset);
       var fields = new List<PersistentFieldExpression>(keyFields.Count + 1) {keyExpression};
       foreach (var field in keyFields) {
+        // Do not convert to LINQ. We want to avoid a closure creation here.
         fields.Add(BuildNestedFieldExpression(field, offset + mappingInfo.Offset));
       }
 
@@ -182,10 +180,14 @@ namespace Xtensive.Orm.Linq.Expressions
 
     private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, int offset)
     {
-      if (nestedField.IsPrimitive)
+      if (nestedField.IsPrimitive) {
         return CreateField(nestedField, offset);
-      if (nestedField.IsEntity)
+      }
+
+      if (nestedField.IsEntity) {
         return CreateEntityField(nestedField, offset);
+      }
+
       throw new NotSupportedException(string.Format(Strings.ExNestedFieldXIsNotSupported, nestedField.Attributes));
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -119,9 +119,12 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public static FieldExpression CreateField(FieldInfo field, int offset)
     {
-      if (!field.IsPrimitive)
+      if (!field.IsPrimitive) {
         throw new ArgumentException(string.Format(Strings.ExFieldXIsNotPrimitive, field.Name), "field");
-      var mapping = new Segment<int>(field.MappingInfo.Offset + offset, field.MappingInfo.Length);
+      }
+
+      ref var mappingInfo = ref field.mappingInfo;
+      var mapping = new Segment<int>(mappingInfo.Offset + offset, mappingInfo.Length);
       return new FieldExpression(ExtendedExpressionType.Field, field, mapping, null, false);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -1,16 +1,14 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.05.05
 
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Reflection;
 using Xtensive.Core;
 using FieldInfo=Xtensive.Orm.Model.FieldInfo;
-using Xtensive.Collections;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
@@ -23,9 +21,8 @@ namespace Xtensive.Orm.Linq.Expressions
     public virtual IPersistentExpression Owner
     {
       get => owner;
-      internal set
-      {
-        if (owner!=null) {
+      internal set {
+        if (owner != null) {
           throw Exceptions.AlreadyInitialized("Owner");
         }
 
@@ -56,26 +53,32 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public override Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap)
+      if (!CanRemap) {
         return this;
+      }
 
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
+      if (processedExpressions.TryGetValue(this, out var result)) {
         return result;
+      }
 
       var offset = map.IndexOf(Mapping.Offset);
       if (offset < 0) {
-        if (owner == null && !SkipOwnerCheckScope.IsActive)
+        if (owner == null && !SkipOwnerCheckScope.IsActive) {
           throw new InvalidOperationException(Strings.ExUnableToRemapFieldExpression);
+        }
+
         processedExpressions.Add(this, null);
-        if (owner != null)
+        if (owner != null) {
           Owner.Remap(map, processedExpressions);
+        }
+
         return null;
       }
       var newMapping = new Segment<int>(offset, Mapping.Length);
       result = new FieldExpression(ExtendedExpressionType.Field, Field, newMapping, OuterParameter, DefaultIfEmpty);
-      if (owner == null)
+      if (owner == null) {
         return result;
+      }
 
       processedExpressions.Add(this, result);
       Owner.Remap(map, processedExpressions);
@@ -84,13 +87,14 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
+      if (processedExpressions.TryGetValue(this, out var result)) {
         return result;
+      }
 
       result = new FieldExpression(ExtendedExpressionType.Field, Field, Mapping, parameter, DefaultIfEmpty);
-      if (owner == null)
+      if (owner == null) {
         return result;
+      }
 
       processedExpressions.Add(this, result);
       Owner.BindParameter(parameter, processedExpressions);
@@ -99,28 +103,27 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
+      if (processedExpressions.TryGetValue(this, out var result)) {
         return result;
+      }
 
       result = new FieldExpression(ExtendedExpressionType.Field, Field, Mapping, null, DefaultIfEmpty);
-      if (owner == null)
+      if (owner == null) {
         return result;
+      }
 
       processedExpressions.Add(this, result);
       Owner.RemoveOuterParameter(processedExpressions);
       return result;
     }
 
-    public virtual FieldExpression RemoveOwner()
-    {
-      return new FieldExpression(ExtendedExpressionType.Field, Field, Mapping, OuterParameter, DefaultIfEmpty);
-    }
+    public virtual FieldExpression RemoveOwner() =>
+      new FieldExpression(ExtendedExpressionType.Field, Field, Mapping, OuterParameter, DefaultIfEmpty);
 
     public static FieldExpression CreateField(FieldInfo field, int offset)
     {
       if (!field.IsPrimitive) {
-        throw new ArgumentException(string.Format(Strings.ExFieldXIsNotPrimitive, field.Name), "field");
+        throw new ArgumentException(string.Format(Strings.ExFieldXIsNotPrimitive, field.Name), nameof(field));
       }
 
       ref var mappingInfo = ref field.mappingInfo;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -5,7 +5,6 @@
 // Created:    2009.05.06
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Linq.Expressions.Visitors;
@@ -139,9 +138,12 @@ namespace Xtensive.Orm.Linq.Expressions
           var joinedIndex = typeInfo.Indexes.PrimaryIndex;
           var joinedRs = joinedIndex.GetQuery().Alias(Context.GetNextAlias());
           var keySegment = entityExpression.Key.Mapping;
-          var keyPairs = keySegment.GetItems()
-            .Select((leftIndex, rightIndex) => new Pair<int>(leftIndex, rightIndex))
-            .ToArray();
+          var keyPairs = new Pair<int>[keySegment.Length];
+          var rightIndex = 0;
+          foreach (var leftIndex in keySegment.GetItems()) {
+            keyPairs[rightIndex] = new Pair<int>(leftIndex, rightIndex);
+            rightIndex++;
+          }
           var offset = dataSource.Header.Length;
           var dataSourceAsJoin = dataSource as JoinProvider;
           dataSource = entityExpression.IsNullable || (dataSourceAsJoin!=null && dataSourceAsJoin.JoinType==JoinType.LeftOuter)
@@ -158,9 +160,12 @@ namespace Xtensive.Orm.Linq.Expressions
           var joinedIndex = typeInfo.Indexes.PrimaryIndex;
           var joinedRs = joinedIndex.GetQuery().Alias(Context.GetNextAlias());
           var keySegment = entityFieldExpression.Mapping;
-          var keyPairs = keySegment.GetItems()
-            .Select((leftIndex, rightIndex) => new Pair<int>(leftIndex, rightIndex))
-            .ToArray();
+          var keyPairs = new Pair<int>[keySegment.Length];
+          var rightIndex = 0;
+          foreach (var leftIndex in keySegment.GetItems()) {
+            keyPairs[rightIndex] = new Pair<int>(leftIndex, rightIndex);
+            rightIndex++;
+          }
           var offset = dataSource.Header.Length;
           var dataSourceAsJoin = dataSource as JoinProvider;
           dataSource = entityFieldExpression.IsNullable || (dataSourceAsJoin!=null && dataSourceAsJoin.JoinType==JoinType.LeftOuter)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -4,6 +4,7 @@
 // Created by: Alexis Kochetov
 // Created:    2009.05.06
 
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xtensive.Core;
@@ -122,7 +123,7 @@ namespace Xtensive.Orm.Linq.Expressions
           foreach (var fieldInfo in typeInfo.Fields) {
             var isUsedInEntityExpression = false;
             foreach (var entityField in entityExpression.Fields) {
-              if (entityField.Name == fieldInfo.Name) {
+              if (string.Equals(entityField.Name, fieldInfo.Name, StringComparison.Ordinal)) {
                 isUsedInEntityExpression = true;
                 break;
               }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.05.06
 
@@ -20,16 +20,17 @@ namespace Xtensive.Orm.Linq.Expressions
   internal class ItemProjectorExpression : ExtendedExpression
   {
     public CompilableProvider DataSource { get; set; }
-    public TranslatorContext Context { get; private set; }
-    public Expression Item { get; private set; }
+    public TranslatorContext Context { get; }
+    public Expression Item { get; }
 
-    public bool IsPrimitive { get { return CheckItemIsPrimitive(Item); } }
+    public bool IsPrimitive => CheckItemIsPrimitive(Item);
 
-    private bool CheckItemIsPrimitive(Expression item)
+    private static bool CheckItemIsPrimitive(Expression item)
     {
-      var extendedItem = item.StripCasts() as ExtendedExpression;
-      if (extendedItem==null)
+      if (!(item.StripCasts() is ExtendedExpression extendedItem)) {
         return false;
+      }
+
       switch (extendedItem.ExtendedType) {
         case ExtendedExpressionType.Column:
         case ExtendedExpressionType.Field:
@@ -42,49 +43,46 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public List<int> GetColumns(ColumnExtractionModes columnExtractionModes)
-    {
-      return ColumnGatherer.GetColumns(Item, columnExtractionModes);
-    }
+    public List<int> GetColumns(ColumnExtractionModes columnExtractionModes) =>
+      ColumnGatherer.GetColumns(Item, columnExtractionModes);
 
-    public List<Pair<int, Expression>> GetColumnsAndExpressions(ColumnExtractionModes columnExtractionModes)
-    {
-      return ColumnGatherer.GetColumnsAndExpressions(Item, columnExtractionModes);
-    }
+    public List<Pair<int, Expression>> GetColumnsAndExpressions(ColumnExtractionModes columnExtractionModes) =>
+      ColumnGatherer.GetColumnsAndExpressions(Item, columnExtractionModes);
 
     public ItemProjectorExpression Remap(CompilableProvider dataSource, int offset)
     {
-      if (offset==0)
+      if (offset == 0) {
         return new ItemProjectorExpression(Item, dataSource, Context);
-      var item = GenericExpressionVisitor<IMappedExpression>.Process(Item, mapped => mapped.Remap(offset, new Dictionary<Expression, Expression>()));
+      }
+
+      var item = GenericExpressionVisitor<IMappedExpression>
+        .Process(Item, mapped => mapped.Remap(offset, new Dictionary<Expression, Expression>()));
       return new ItemProjectorExpression(item, dataSource, Context);
     }
 
     public ItemProjectorExpression Remap(CompilableProvider dataSource, int[] columnMap)
     {
-      var item = GenericExpressionVisitor<IMappedExpression>.Process(Item, mapped => mapped.Remap(columnMap, new Dictionary<Expression, Expression>()));
+      var item = GenericExpressionVisitor<IMappedExpression>
+        .Process(Item, mapped => mapped.Remap(columnMap, new Dictionary<Expression, Expression>()));
       return new ItemProjectorExpression(item, dataSource, Context);
     }
 
-    public LambdaExpression ToLambda(TranslatorContext context)
-    {
-      return ExpressionMaterializer.MakeLambda(Item, context);
-    }
+    public LambdaExpression ToLambda(TranslatorContext context) => ExpressionMaterializer.MakeLambda(Item, context);
 
-    public MaterializationInfo Materialize(TranslatorContext context, IEnumerable<Parameter<Tuple>> tupleParameters)
-    {
-      return ExpressionMaterializer.MakeMaterialization(this, context, tupleParameters);
-    }
+    public MaterializationInfo Materialize(TranslatorContext context, IEnumerable<Parameter<Tuple>> tupleParameters) =>
+      ExpressionMaterializer.MakeMaterialization(this, context, tupleParameters);
 
     public ItemProjectorExpression BindOuterParameter(ParameterExpression parameter)
     {
-      var item = GenericExpressionVisitor<IMappedExpression>.Process(Item, mapped => mapped.BindParameter(parameter, new Dictionary<Expression, Expression>()));
+      var item = GenericExpressionVisitor<IMappedExpression>
+        .Process(Item, mapped => mapped.BindParameter(parameter, new Dictionary<Expression, Expression>()));
       return new ItemProjectorExpression(item, DataSource, Context);
     }
 
     public ItemProjectorExpression RemoveOuterParameter()
     {
-      var item = GenericExpressionVisitor<IMappedExpression>.Process(Item, mapped => mapped.RemoveOuterParameter(new Dictionary<Expression, Expression>()));
+      var item = GenericExpressionVisitor<IMappedExpression>
+        .Process(Item, mapped => mapped.RemoveOuterParameter(new Dictionary<Expression, Expression>()));
       return new ItemProjectorExpression(item, DataSource, Context);
     }
 
@@ -114,8 +112,7 @@ namespace Xtensive.Orm.Linq.Expressions
     {
       var dataSource = DataSource;
       var newItem = new ExtendedExpressionReplacer(e => {
-        if (e is EntityExpression) {
-          var entityExpression = (EntityExpression) e;
+        if (e is EntityExpression entityExpression) {
           var typeInfo = entityExpression.PersistentType;
 
           // Converted from LINQ to get rid of 2 closure allocations 
@@ -133,8 +130,10 @@ namespace Xtensive.Orm.Linq.Expressions
               break;
             }
           }
-          if (all)
+
+          if (all) {
             return entityExpression;
+          }
 
           var joinedIndex = typeInfo.Indexes.PrimaryIndex;
           var joinedRs = joinedIndex.GetQuery().Alias(Context.GetNextAlias());
@@ -146,17 +145,19 @@ namespace Xtensive.Orm.Linq.Expressions
             rightIndex++;
           }
           var offset = dataSource.Header.Length;
-          var dataSourceAsJoin = dataSource as JoinProvider;
-          dataSource = entityExpression.IsNullable || (dataSourceAsJoin!=null && dataSourceAsJoin.JoinType==JoinType.LeftOuter)
-            ? dataSource.LeftJoin(joinedRs, keyPairs)
-            : dataSource.Join(joinedRs, keyPairs);
+          dataSource = entityExpression.IsNullable
+            || (dataSource is JoinProvider dataSourceAsJoin && dataSourceAsJoin.JoinType == JoinType.LeftOuter)
+              ? dataSource.LeftJoin(joinedRs, keyPairs)
+              : dataSource.Join(joinedRs, keyPairs);
           EntityExpression.Fill(entityExpression, offset);
           return entityExpression;
         }
-        if (e is EntityFieldExpression) {
-          var entityFieldExpression = (EntityFieldExpression)e;
-          if (entityFieldExpression.Entity != null)
+
+        if (e is EntityFieldExpression entityFieldExpression) {
+          if (entityFieldExpression.Entity != null) {
             return entityFieldExpression.Entity;
+          }
+
           var typeInfo = entityFieldExpression.PersistentType;
           var joinedIndex = typeInfo.Indexes.PrimaryIndex;
           var joinedRs = joinedIndex.GetQuery().Alias(Context.GetNextAlias());
@@ -168,28 +169,26 @@ namespace Xtensive.Orm.Linq.Expressions
             rightIndex++;
           }
           var offset = dataSource.Header.Length;
-          var dataSourceAsJoin = dataSource as JoinProvider;
-          dataSource = entityFieldExpression.IsNullable || (dataSourceAsJoin!=null && dataSourceAsJoin.JoinType==JoinType.LeftOuter)
-            ? dataSource.LeftJoin(joinedRs, keyPairs)
-            : dataSource.Join(joinedRs, keyPairs);
+          dataSource = entityFieldExpression.IsNullable
+            || (dataSource is JoinProvider dataSourceAsJoin && dataSourceAsJoin.JoinType == JoinType.LeftOuter)
+              ? dataSource.LeftJoin(joinedRs, keyPairs)
+              : dataSource.Join(joinedRs, keyPairs);
           entityFieldExpression.RegisterEntityExpression(offset);
           return entityFieldExpression.Entity;
         }
-        if (e is FieldExpression) {
-          var fe = (FieldExpression) e;
-          if (fe.ExtendedType==ExtendedExpressionType.Field)
-            return fe.RemoveOwner();
+
+        if (e is FieldExpression fe && fe.ExtendedType == ExtendedExpressionType.Field) {
+          return fe.RemoveOwner();
         }
+
         return null;
       })
         .Replace(Item);
       return new ItemProjectorExpression(newItem, dataSource, Context);
     }
 
-    public override string ToString()
-    {
-      return string.Format("ItemProjectorExpression: IsPrimitive = {0} Item = {1}, DataSource = {2}", IsPrimitive, Item, DataSource);
-    }
+    public override string ToString() =>
+      $"ItemProjectorExpression: IsPrimitive = {IsPrimitive} Item = {Item}, DataSource = {DataSource}";
 
 
     // Constructors
@@ -201,8 +200,8 @@ namespace Xtensive.Orm.Linq.Expressions
       Context = context;
       var newApplyParameter = Context.GetApplyParameter(dataSource);
       var applyParameterReplacer = new ExtendedExpressionReplacer(ex =>
-        ex is SubQueryExpression
-          ? ((SubQueryExpression) ex).ReplaceApplyParameter(newApplyParameter)
+        ex is SubQueryExpression queryExpression
+          ? queryExpression.ReplaceApplyParameter(newApplyParameter)
           : null);
       Item = applyParameterReplacer.Replace(expression);
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
 // Created:    2009.09.29
 
@@ -53,6 +53,7 @@ namespace Xtensive.Orm.Linq.Expressions
         // Do not convert to LINQ. We intentionally avoiding closure creation here
         processedFields.Add((PersistentFieldExpression) field.Remap(offset, processedExpressions));
       }
+
       result.Fields = processedFields;
       result.isNullable = isNullable;
       return result;
@@ -111,6 +112,7 @@ namespace Xtensive.Orm.Linq.Expressions
         // Do not convert to LINQ. We intentionally avoiding closure creation here
         processedFields.Add((PersistentFieldExpression) field.BindParameter(parameter, processedExpressions));
       }
+
       result.Fields = processedFields;
       return result;
     }
@@ -146,17 +148,24 @@ namespace Xtensive.Orm.Linq.Expressions
         // Do not convert to LINQ. We intentionally avoiding closure creation here
         destinationFields.Add(BuildNestedFieldExpression(field, mapping.Offset));
       }
+
       return result;
     }
 
     private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, int offset)
     {
-      if (nestedField.IsPrimitive)
+      if (nestedField.IsPrimitive) {
         return FieldExpression.CreateField(nestedField, offset);
-      if (nestedField.IsStructure)
+      }
+
+      if (nestedField.IsStructure) {
         return StructureFieldExpression.CreateStructure(nestedField, offset);
-      if (nestedField.IsEntity)
+      }
+
+      if (nestedField.IsEntity) {
         return EntityFieldExpression.CreateEntityField(nestedField, offset);
+      }
+
       throw new NotSupportedException(string.Format(Strings.ExNestedFieldXIsNotSupported, nestedField.Attributes));
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.05.05
 
@@ -50,6 +50,7 @@ namespace Xtensive.Orm.Linq.Expressions
         // Do not convert to LINQ. We want to avoid a closure creation here.
         processedFields.Add((PersistentFieldExpression) field.Remap(offset, processedExpressions));
       }
+
       if (Owner == null) {
         result.fields = processedFields;
         return result;
@@ -98,6 +99,7 @@ namespace Xtensive.Orm.Linq.Expressions
         result.fields = processedFields;
         return result;
       }
+
       result.Fields = processedFields;
       Owner.Remap(map, processedExpressions);
       return result;
@@ -153,7 +155,7 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public override FieldExpression RemoveOwner()
     {
-      if (Owner==null) {
+      if (Owner == null) {
         return this;
       }
 
@@ -163,6 +165,7 @@ namespace Xtensive.Orm.Linq.Expressions
       foreach (var field in fields) {
         result.fields.Add(((FieldExpression) field).RemoveOwner());
       }
+
       return result;
     }
 
@@ -188,12 +191,18 @@ namespace Xtensive.Orm.Linq.Expressions
 // ReSharper disable RedundantNameQualifier
     private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, int offset)
     {
-      if (nestedField.IsPrimitive)
+      if (nestedField.IsPrimitive) {
         return FieldExpression.CreateField(nestedField, offset);
-      if (nestedField.IsStructure)
+      }
+
+      if (nestedField.IsStructure) {
         return StructureFieldExpression.CreateStructure(nestedField, offset);
-      if (nestedField.IsEntity)
+      }
+
+      if (nestedField.IsEntity) {
         return EntityFieldExpression.CreateEntityField(nestedField, offset);
+      }
+
       throw new NotSupportedException(string.Format(Strings.ExNestedFieldXIsNotSupported, nestedField.Attributes));
     }
 // ReSharper restore RedundantNameQualifier

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Model
     private int? cachedHashCode;
 
     private IList<IPropertyValidator> validators;
-    private Segment<int> mappingInfo;
+    internal Segment<int> mappingInfo;
 
     #region IsXxx properties
 
@@ -720,14 +720,14 @@ namespace Xtensive.Orm.Model
           mappingInfo = new Segment<int>(primaryIndex.Columns.IndexOf(indexColumn), 1);
         }
       }
-      else 
-        if (Fields.Count > 0)
-          mappingInfo = new Segment<int>(
-            Fields.First().MappingInfo.Offset, Fields.Sum(f => f.IsPrimitive ? f.MappingInfo.Length : 0));
+      else if (Fields.Count > 0) {
+        mappingInfo = new Segment<int>(
+          Fields[0].mappingInfo.Offset, Fields.Sum(f => f.IsPrimitive ? f.mappingInfo.Length : 0));
+      }
 
       if (IsEntity || IsStructure) {
         valueExtractor = new SegmentTransform(
-          false, reflectedType.TupleDescriptor, new Segment<int>(MappingInfo.Offset, MappingInfo.Length));
+          false, reflectedType.TupleDescriptor, new Segment<int>(mappingInfo.Offset, mappingInfo.Length));
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2007.09.10
 


### PR DESCRIPTION
A bunch of performance improvements for XxxExpression types. These improvements mostly related to memory allocation. We avoiding closure allocation in several cases plus we pre-allocate `List`s when eventual length is known. Additionally on critical paths we use `StringComparison.Ordinal`.
The rest of the changes is code formatting improvements.