### PR TITLE
Fixes corrupted weaving attributes

### DIFF
--- a/Weaver/Xtensive.Orm.Weaver/ProcessorContext.cs
+++ b/Weaver/Xtensive.Orm.Weaver/ProcessorContext.cs
@@ -24,6 +24,8 @@ namespace Xtensive.Orm.Weaver
 
     public bool TranformationPerformed { get; set; }
 
+    public bool ShouldAddReferenceToOrm { get; set; }
+
     public IList<WeavingTask> WeavingTasks { get; set; }
 
     public ModuleDefinition TargetModule { get; set; }
@@ -54,6 +56,7 @@ namespace Xtensive.Orm.Weaver
       References = new ReferenceRegistry();
       PersistentTypes = new List<TypeInfo>();
       AssemblyChecker = new AssemblyChecker();
+      ShouldAddReferenceToOrm = false;
     }
   }
 }


### PR DESCRIPTION
Fixes issue #46.

When a processible project used to have a reference to ```Xtensive.Orm``` but during compilation the reference has lost then ```Weaver``` adds the reference back to target assembly to prevent weaving attributes from being declared as owned by target assembly.