### PR TITLE
Let array be used as collection in queries natively instead of generic inteface representation

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/ContainsOverKeysCollectionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/ContainsOverKeysCollectionTest.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2013-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
 // Created:    2013.12.30
 

--- a/Orm/Xtensive.Orm.Tests/Linq/ContainsOverKeysCollectionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/ContainsOverKeysCollectionTest.cs
@@ -44,6 +44,25 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTestModel
     [Field]
     public MyEntity2 Entity { get; set; }
   }
+
+  [HierarchyRoot]
+  [KeyGenerator(KeyGeneratorKind.None)]
+  public class ComplexKeyEntity : Entity
+  {
+    [Field, Key(0)]
+    public int Id0 { get; private set; }
+
+    [Field, Key(1)]
+    public int Id1 { get; private set; }
+
+    [Field]
+    public string Name { get; set; }
+
+    public ComplexKeyEntity(int id0, int id1)
+      : base(id0, id1)
+    {
+    }
+  }
 }
 
 namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
@@ -51,8 +70,22 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
   [TestFixture]
   public class ContainsOverKeysCollectionTest : AutoBuildTest
   {
-    private IEnumerable<Key> keysList;
-    private IEnumerable<Key> keysArray; 
+    private IEnumerable<Key> keyListAsEnumerable;
+    private IEnumerable<Key> keyArrayAsEnumerable;
+    private ICollection<Key> keyListAsCollection;
+    private ICollection<Key> keyArrayAsCollection;
+    private List<Key> keyList;
+    private IList<Key> keyListAsInteface;
+    private Key[] keyArray;
+
+    private IEnumerable<Key> complexKeyListAsEnumerable;
+    private IEnumerable<Key> complexKeyArrayAsEnumerable;
+    private ICollection<Key> complexKeyListAsCollection;
+    private ICollection<Key> complexKeyArrayAsCollection;
+    private List<Key> complexKeyList;
+    private IList<Key> complexKeyListAsInteface;
+    private Key[] complexKeyArray;
+
     protected override DomainConfiguration BuildConfiguration()
     {
       var configuration = DomainConfigurationFactory.Create();
@@ -65,139 +98,593 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
     {
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
-        new MyEntity3 {
-          Entity = new MyEntity2() {
-            Entity = new MyEntity {Field = "ABC"}
-          }
-        };
-
-        new MyEntity3 {
-          Entity = new MyEntity2 {
-            Entity = new MyEntity {Field = "DEF"}
-          }
-        };
-
-        new MyEntity3 {
-          Entity = new MyEntity2() {
-            Entity = new MyEntity {Field = "GHI"}
-          }
-        };
-        
-        keysList = session.Query.All<MyEntity>().Select(e => e.Key).ToList();
-        keysArray = session.Query.All<MyEntity>().Select(e => e.Key).ToArray();
+        PopulateEntities();
+        PopulateKeysCollections(session);
         transaction.Complete();
       }
     }
 
     [Test]
-    public void DirectKeyContaisTest()
+    public void ComplexKeyTest()
     {
-      Assert.DoesNotThrow(
-        () => {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity>().Where(e => keysList.Contains(e.Key)).ToList();
-          }
-        });
-      Assert.DoesNotThrow(
-        ()=> {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity>().Where(e => keysArray.Contains(e.Key)).ToList();
-          }
-        });
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<ComplexKeyEntity> result = null;
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyList.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(5));
+        Assert.That(result.All(x => complexKeyList.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyListAsEnumerable.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(5));
+        Assert.That(result.All(x => complexKeyListAsEnumerable.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyListAsCollection.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(5));
+        Assert.That(result.All(x => complexKeyListAsCollection.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyListAsInteface.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(5));
+        Assert.That(result.All(x => complexKeyListAsInteface.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyArray.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(5));
+        Assert.That(result.All(x => complexKeyArray.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyArrayAsEnumerable.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(5));
+        Assert.That(result.All(x => complexKeyArrayAsEnumerable.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyArrayAsCollection.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(5));
+        Assert.That(result.All(x => complexKeyArrayAsCollection.Contains(x.Key)), Is.True);
+      }
     }
 
     [Test]
-    public void OneLevelContainsText()
+    public void DirectKeyContainsTest()
     {
-      Assert.DoesNotThrow(
-        () => {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity2>().Where(e => keysList.Contains(e.Entity.Key)).ToList();
-          }
-        });
-      Assert.DoesNotThrow(
-        ()=> {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity2>().Where(e => keysArray.Contains(e.Entity.Key)).ToList();
-          }
-        });
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity> result = null;
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => keyList.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyList.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => keyListAsEnumerable.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => keyListAsCollection.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsCollection.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => keyListAsInteface.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsInteface.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => keyArray.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArray.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => keyArrayAsEnumerable.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => keyArrayAsCollection.Contains(e.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Key)), Is.True);
+      }
     }
 
     [Test]
-    public void TwoLevelContainsText()
+    public void DirectKeyInTest()
     {
-      Assert.DoesNotThrow(
-        () => {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity3>().Where(e => keysList.Contains(e.Entity.Entity.Key)).ToList();
-          }
-        });
-      Assert.DoesNotThrow(
-        ()=> {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity3>().Where(e => keysArray.Contains(e.Entity.Entity.Key)).ToList();
-          }
-        });
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity> result = null;
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyList)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyList.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyListAsEnumerable)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyListAsCollection)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsCollection.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyListAsInteface)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsInteface.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyArray)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArray.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyArrayAsEnumerable)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyArrayAsCollection)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Key)), Is.True);
+      }
     }
 
     [Test]
-    public void SubQueryTest()
+    public void OneLevelContainsTest()
     {
-      Assert.Throws<QueryTranslationException>(
-        () => {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity3>()
-              .Where(e => keysList.Contains(session.Query.All<MyEntity>().First(el => el.Key==e.Entity.Entity.Key).Key))
-              .ToList();
-          }
-        });
-      Assert.Throws<QueryTranslationException>(
-        () => {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity3>()
-              .Where(e => keysArray.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
-              .ToList();
-          }
-        });
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity2> result = null;
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => keyList.Contains(e.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyList.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => keyListAsEnumerable.Contains(e.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => keyListAsCollection.Contains(e.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsCollection.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => keyListAsInteface.Contains(e.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsInteface.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => keyArray.Contains(e.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => keyArrayAsEnumerable.Contains(e.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => keyArrayAsCollection.Contains(e.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Entity.Key)), Is.True);
+      }
     }
 
     [Test]
-    public void AnonimusTypeKeyContainsTest()
+    public void OneLevelInTest()
     {
-      Assert.Throws<QueryTranslationException>(
-        () => {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity3>().Where(e => keysList.Contains(
-              new {
-                Key = e.Key, 
-                EntityKey = e.Entity.Key, 
-                DoubleEntityKey = e.Entity.Entity.Key
-              }
-              .DoubleEntityKey)).ToList();
-          }
-        });
-      Assert.Throws<QueryTranslationException>(
-        () => {
-          using (var session = Domain.OpenSession())
-          using (var transaction = session.OpenTransaction()) {
-            var query = session.Query.All<MyEntity3>().Where(e => keysArray.Contains(
-              new {
-                Key = e.Key,
-                EntityKey = e.Entity.Key,
-                DoubleEntityKey = e.Entity.Entity.Key
-              }
-              .DoubleEntityKey)).ToList();
-          }
-        });
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity2> result = null;
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyList)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyList.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyListAsEnumerable)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyListAsCollection)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsCollection.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyListAsInteface)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsInteface.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyArray)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyArrayAsEnumerable)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyArrayAsCollection)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Entity.Key)), Is.True);
+      }
+    }
+
+    [Test]
+    public void TwoLevelContainsTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity3> result = null;
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => keyList.Contains(e.Entity.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyList.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => keyListAsEnumerable.Contains(e.Entity.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => keyListAsCollection.Contains(e.Entity.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsCollection.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => keyListAsInteface.Contains(e.Entity.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsInteface.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => keyArray.Contains(e.Entity.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => keyArrayAsEnumerable.Contains(e.Entity.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => keyArrayAsCollection.Contains(e.Entity.Entity.Key)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Entity.Entity.Key)), Is.True);
+      }
+    }
+
+    [Test]
+    public void TwoLevelInTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity3> result = null;
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyList)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyList.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyListAsEnumerable)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyListAsCollection)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsCollection.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyListAsInteface)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyListAsInteface.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyArray)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyArrayAsEnumerable)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Entity.Entity.Key)), Is.True);
+
+        Assert.DoesNotThrow(() =>
+          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyArrayAsCollection)).ToList());
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Entity.Entity.Key)), Is.True);
+      }
+    }
+
+    [Test]
+    public void SubQueryContainsTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity3> result;
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => keyList.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => keyListAsEnumerable.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => keyListAsCollection.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => keyListAsInteface.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => keyArray.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => keyArrayAsEnumerable.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => keyArrayAsCollection.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+          .ToList());
+      }
+    }
+
+    [Test]
+    public void SubQueryInTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity3> result;
+
+        Assert.Throws<QueryTranslationException>(()=>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyList))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyListAsEnumerable))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyListAsCollection))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyListAsInteface))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyArray))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyArrayAsEnumerable))
+          .ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+        result = session.Query.All<MyEntity3>()
+          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyArrayAsCollection))
+          .ToList());
+      }
+    }
+
+    [Test]
+    public void AnonymousTypeKeyContainsTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity3> result;
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => keyListAsEnumerable.Contains(new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => keyList.Contains(new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => keyListAsInteface.Contains(new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => keyListAsCollection.Contains(new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => keyArrayAsEnumerable.Contains(new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => keyArray.Contains(new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => keyArrayAsCollection.Contains(new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey)).ToList());
+      }
+    }
+
+    [Test]
+    public void AnonymousTypeKeyInTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        List<MyEntity3> result;
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey.In(keyList)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey.In(keyListAsEnumerable)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey.In(keyListAsInteface)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey.In(keyListAsCollection)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+           }.DoubleEntityKey.In(keyArray)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => new {
+              Key = e.Key,
+               EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+           }.DoubleEntityKey.In(keyArrayAsEnumerable)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey.In(keyArrayAsCollection)).ToList());
+      }
+    }
+
+    private void PopulateEntities()
+    {
+      new MyEntity3 {
+        Entity = new MyEntity2 {
+          Entity = new MyEntity { Field = "ABC" }
+        }
+      };
+      new MyEntity3 {
+        Entity = new MyEntity2 {
+          Entity = new MyEntity { Field = "DEF" }
+        }
+      };
+      new MyEntity3 {
+        Entity = new MyEntity2 {
+          Entity = new MyEntity { Field = "GHI" }
+        }
+      };
+      new MyEntity3 {
+        Entity = new MyEntity2 {
+          Entity = new MyEntity { Field = "KLM" }
+        }
+      };
+      new MyEntity3 {
+        Entity = new MyEntity2 {
+          Entity = new MyEntity { Field = "NOP" }
+        }
+      };
+      new MyEntity3 {
+        Entity = new MyEntity2 {
+          Entity = new MyEntity { Field = "QRS" }
+        }
+      };
+
+      new ComplexKeyEntity(1, 1) { Name = "1 1" };
+      new ComplexKeyEntity(2, 2) { Name = "2 2" };
+      new ComplexKeyEntity(3, 3) { Name = "3 3" };
+      new ComplexKeyEntity(4, 4) { Name = "4 4" };
+      new ComplexKeyEntity(5, 5) { Name = "5 5" };
+      new ComplexKeyEntity(6, 6) { Name = "6 6" };
+      new ComplexKeyEntity(7, 7) { Name = "7 7" };
+      new ComplexKeyEntity(8, 8) { Name = "8 8" };
+    }
+
+    private void PopulateKeysCollections(Session session)
+    {
+      keyList = session.Query.All<MyEntity>().AsEnumerable().Take(3).Select(e => e.Key).ToList();
+      keyListAsEnumerable = new List<Key>(keyList);
+      keyListAsCollection = new List<Key>(keyList);
+      keyListAsInteface = new List<Key>(keyList);
+
+      keyArray = session.Query.All<MyEntity>().AsEnumerable().Take(3).Select(e => e.Key).ToArray();
+      keyArrayAsEnumerable = keyArray.AsEnumerable().ToArray();
+      keyArrayAsCollection = keyArray.AsEnumerable().ToArray();
+
+      complexKeyList = session.Query.All<ComplexKeyEntity>().Take(5).Select(e => e.Key).ToList();
+      complexKeyListAsEnumerable = new List<Key>(complexKeyList);
+      complexKeyListAsCollection = new List<Key>(complexKeyList);
+      complexKeyListAsInteface = new List<Key>(complexKeyList);
+
+      complexKeyArray = session.Query.All<ComplexKeyEntity>().Take(5).Select(e => e.Key).ToArray();
+      complexKeyArrayAsEnumerable = complexKeyArray.AsEnumerable().ToArray();
+      complexKeyArrayAsCollection = complexKeyArray.AsEnumerable().ToArray();
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Linq/ContainsOverKeysCollectionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/ContainsOverKeysCollectionTest.cs
@@ -5,12 +5,11 @@
 // Created:    2013.12.30
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using Xtensive.Orm.Configuration;
-using Xtensive.Orm.Internals;
 using Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTestModel;
 
 namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTestModel
@@ -63,6 +62,46 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTestModel
     {
     }
   }
+
+  public class TestKeyCollection : IReadOnlyCollection<Key>
+  {
+    private readonly Key[] keys;
+
+    public int Count => keys.Length;
+
+    public IEnumerator<Key> GetEnumerator()
+    {
+      foreach (var key in keys)
+        yield return key;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public TestKeyCollection(Key[] array)
+    {
+      keys = array;
+    }
+  }
+
+  public class TestGenericCollection<TKey> : IReadOnlyCollection<TKey>
+  {
+    private readonly TKey[] keys;
+
+    public int Count => keys.Length;
+
+    public IEnumerator<TKey> GetEnumerator()
+    {
+      foreach (var key in keys)
+        yield return key;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public TestGenericCollection(TKey[] array)
+    {
+      keys = array;
+    }
+  }
 }
 
 namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
@@ -70,21 +109,9 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
   [TestFixture]
   public class ContainsOverKeysCollectionTest : AutoBuildTest
   {
-    private IEnumerable<Key> keyListAsEnumerable;
-    private IEnumerable<Key> keyArrayAsEnumerable;
-    private ICollection<Key> keyListAsCollection;
-    private ICollection<Key> keyArrayAsCollection;
-    private List<Key> keyList;
-    private IList<Key> keyListAsInteface;
     private Key[] keyArray;
-
-    private IEnumerable<Key> complexKeyListAsEnumerable;
-    private IEnumerable<Key> complexKeyArrayAsEnumerable;
-    private ICollection<Key> complexKeyListAsCollection;
-    private ICollection<Key> complexKeyArrayAsCollection;
-    private List<Key> complexKeyList;
-    private IList<Key> complexKeyListAsInteface;
-    private Key[] complexKeyArray;
+    private TestGenericCollection<Key> genericKeyCollection;
+    private TestKeyCollection nonGenericKeyCollection;
 
     protected override DomainConfiguration BuildConfiguration()
     {
@@ -105,73 +132,11 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
     }
 
     [Test]
-    public void ComplexKeyTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var transaction = session.OpenTransaction()) {
-        List<ComplexKeyEntity> result = null;
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyList.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(5));
-        Assert.That(result.All(x => complexKeyList.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyListAsEnumerable.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(5));
-        Assert.That(result.All(x => complexKeyListAsEnumerable.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyListAsCollection.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(5));
-        Assert.That(result.All(x => complexKeyListAsCollection.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyListAsInteface.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(5));
-        Assert.That(result.All(x => complexKeyListAsInteface.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyArray.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(5));
-        Assert.That(result.All(x => complexKeyArray.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyArrayAsEnumerable.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(5));
-        Assert.That(result.All(x => complexKeyArrayAsEnumerable.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<ComplexKeyEntity>().Where(e => complexKeyArrayAsCollection.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(5));
-        Assert.That(result.All(x => complexKeyArrayAsCollection.Contains(x.Key)), Is.True);
-      }
-    }
-
-    [Test]
     public void DirectKeyContainsTest()
     {
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         List<MyEntity> result = null;
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => keyList.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyList.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => keyListAsEnumerable.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => keyListAsCollection.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsCollection.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => keyListAsInteface.Contains(e.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsInteface.Contains(x.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
           result = session.Query.All<MyEntity>().Where(e => keyArray.Contains(e.Key)).ToList());
@@ -179,14 +144,14 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
         Assert.That(result.All(x => keyArray.Contains(x.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => keyArrayAsEnumerable.Contains(e.Key)).ToList());
+          result = session.Query.All<MyEntity>().Where(e => nonGenericKeyCollection.Contains(e.Key)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => keyArrayAsCollection.Contains(e.Key)).ToList());
+          result = session.Query.All<MyEntity>().Where(e => genericKeyCollection.Contains(e.Key)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Key)), Is.True);
       }
     }
 
@@ -196,25 +161,6 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         List<MyEntity> result = null;
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyList)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyList.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyListAsEnumerable)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyListAsCollection)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsCollection.Contains(x.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyListAsInteface)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsInteface.Contains(x.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
           result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyArray)).ToList());
@@ -222,14 +168,14 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
         Assert.That(result.All(x => keyArray.Contains(x.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyArrayAsEnumerable)).ToList());
+          result = session.Query.All<MyEntity>().Where(e => e.Key.In(nonGenericKeyCollection)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity>().Where(e => e.Key.In(keyArrayAsCollection)).ToList());
+          result = session.Query.All<MyEntity>().Where(e => e.Key.In(genericKeyCollection)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Key)), Is.True);
       }
     }
 
@@ -239,25 +185,6 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         List<MyEntity2> result = null;
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => keyList.Contains(e.Entity.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyList.Contains(x.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => keyListAsEnumerable.Contains(e.Entity.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => keyListAsCollection.Contains(e.Entity.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsCollection.Contains(x.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => keyListAsInteface.Contains(e.Entity.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsInteface.Contains(x.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
           result = session.Query.All<MyEntity2>().Where(e => keyArray.Contains(e.Entity.Key)).ToList());
@@ -265,14 +192,14 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
         Assert.That(result.All(x => keyArray.Contains(x.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => keyArrayAsEnumerable.Contains(e.Entity.Key)).ToList());
+          result = session.Query.All<MyEntity2>().Where(e => nonGenericKeyCollection.Contains(e.Entity.Key)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Entity.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => keyArrayAsCollection.Contains(e.Entity.Key)).ToList());
+          result = session.Query.All<MyEntity2>().Where(e => genericKeyCollection.Contains(e.Entity.Key)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Entity.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Key)), Is.True);
       }
     }
 
@@ -282,25 +209,6 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         List<MyEntity2> result = null;
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyList)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyList.Contains(x.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyListAsEnumerable)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyListAsCollection)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsCollection.Contains(x.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyListAsInteface)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsInteface.Contains(x.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
           result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyArray)).ToList());
@@ -308,14 +216,14 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
         Assert.That(result.All(x => keyArray.Contains(x.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyArrayAsEnumerable)).ToList());
+          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(nonGenericKeyCollection)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Entity.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(keyArrayAsCollection)).ToList());
+          result = session.Query.All<MyEntity2>().Where(e => e.Entity.Key.In(genericKeyCollection)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Entity.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Key)), Is.True);
       }
     }
 
@@ -325,25 +233,6 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         List<MyEntity3> result = null;
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => keyList.Contains(e.Entity.Entity.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyList.Contains(x.Entity.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => keyListAsEnumerable.Contains(e.Entity.Entity.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Entity.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => keyListAsCollection.Contains(e.Entity.Entity.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsCollection.Contains(x.Entity.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => keyListAsInteface.Contains(e.Entity.Entity.Key)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsInteface.Contains(x.Entity.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
           result = session.Query.All<MyEntity3>().Where(e => keyArray.Contains(e.Entity.Entity.Key)).ToList());
@@ -351,14 +240,14 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
         Assert.That(result.All(x => keyArray.Contains(x.Entity.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => keyArrayAsEnumerable.Contains(e.Entity.Entity.Key)).ToList());
+          result = session.Query.All<MyEntity3>().Where(e => nonGenericKeyCollection.Contains(e.Entity.Entity.Key)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Entity.Entity.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => keyArrayAsCollection.Contains(e.Entity.Entity.Key)).ToList());
+          result = session.Query.All<MyEntity3>().Where(e => genericKeyCollection.Contains(e.Entity.Entity.Key)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Entity.Entity.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Entity.Key)), Is.True);
       }
     }
 
@@ -368,25 +257,6 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         List<MyEntity3> result = null;
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyList)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyList.Contains(x.Entity.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyListAsEnumerable)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsEnumerable.Contains(x.Entity.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyListAsCollection)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsCollection.Contains(x.Entity.Entity.Key)), Is.True);
-
-        Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyListAsInteface)).ToList());
-        Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyListAsInteface.Contains(x.Entity.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
           result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyArray)).ToList());
@@ -394,14 +264,14 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
         Assert.That(result.All(x => keyArray.Contains(x.Entity.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyArrayAsEnumerable)).ToList());
+          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(nonGenericKeyCollection)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsEnumerable.Contains(x.Entity.Entity.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Entity.Key)), Is.True);
 
         Assert.DoesNotThrow(() =>
-          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(keyArrayAsCollection)).ToList());
+          result = session.Query.All<MyEntity3>().Where(e => e.Entity.Entity.Key.In(genericKeyCollection)).ToList());
         Assert.That(result.Count, Is.EqualTo(3));
-        Assert.That(result.All(x => keyArrayAsCollection.Contains(x.Entity.Entity.Key)), Is.True);
+        Assert.That(result.All(x => keyArray.Contains(x.Entity.Entity.Key)), Is.True);
       }
     }
 
@@ -413,39 +283,19 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
         List<MyEntity3> result;
 
         Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => keyList.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
-          .ToList());
+          result = session.Query.All<MyEntity3>()
+            .Where(e => keyArray.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+            .ToList());
 
         Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => keyListAsEnumerable.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
-          .ToList());
+          result = session.Query.All<MyEntity3>()
+            .Where(e => nonGenericKeyCollection.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+            .ToList());
 
         Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => keyListAsCollection.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
-          .ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => keyListAsInteface.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
-          .ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => keyArray.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
-          .ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => keyArrayAsEnumerable.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
-          .ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => keyArrayAsCollection.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
-          .ToList());
+          result = session.Query.All<MyEntity3>()
+            .Where(e => genericKeyCollection.Contains(session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key))
+            .ToList());
       }
     }
 
@@ -456,40 +306,20 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
       using (var transaction = session.OpenTransaction()) {
         List<MyEntity3> result;
 
-        Assert.Throws<QueryTranslationException>(()=>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyList))
-          .ToList());
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyArray))
+            .ToList());
 
         Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyListAsEnumerable))
-          .ToList());
+          result = session.Query.All<MyEntity3>()
+            .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(nonGenericKeyCollection))
+            .ToList());
 
         Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyListAsCollection))
-          .ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyListAsInteface))
-          .ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyArray))
-          .ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyArrayAsEnumerable))
-          .ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-        result = session.Query.All<MyEntity3>()
-          .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(keyArrayAsCollection))
-          .ToList());
+          result = session.Query.All<MyEntity3>()
+            .Where(e => session.Query.All<MyEntity>().First(el => el.Key == e.Entity.Entity.Key).Key.In(genericKeyCollection))
+            .ToList());
       }
     }
 
@@ -502,46 +332,6 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
 
         Assert.Throws<QueryTranslationException>(() =>
           result = session.Query.All<MyEntity3>()
-            .Where(e => keyListAsEnumerable.Contains(new {
-              Key = e.Key,
-              EntityKey = e.Entity.Key,
-              DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey)).ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-          result = session.Query.All<MyEntity3>()
-            .Where(e => keyList.Contains(new {
-              Key = e.Key,
-              EntityKey = e.Entity.Key,
-              DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey)).ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-          result = session.Query.All<MyEntity3>()
-            .Where(e => keyListAsInteface.Contains(new {
-              Key = e.Key,
-              EntityKey = e.Entity.Key,
-              DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey)).ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-          result = session.Query.All<MyEntity3>()
-            .Where(e => keyListAsCollection.Contains(new {
-              Key = e.Key,
-              EntityKey = e.Entity.Key,
-              DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey)).ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-          result = session.Query.All<MyEntity3>()
-            .Where(e => keyArrayAsEnumerable.Contains(new {
-              Key = e.Key,
-              EntityKey = e.Entity.Key,
-              DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey)).ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-          result = session.Query.All<MyEntity3>()
             .Where(e => keyArray.Contains(new {
               Key = e.Key,
               EntityKey = e.Entity.Key,
@@ -550,7 +340,15 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
 
         Assert.Throws<QueryTranslationException>(() =>
           result = session.Query.All<MyEntity3>()
-            .Where(e => keyArrayAsCollection.Contains(new {
+            .Where(e => nonGenericKeyCollection.Contains(new {
+              Key = e.Key,
+              EntityKey = e.Entity.Key,
+              DoubleEntityKey = e.Entity.Entity.Key
+            }.DoubleEntityKey)).ToList());
+
+        Assert.Throws<QueryTranslationException>(() =>
+          result = session.Query.All<MyEntity3>()
+            .Where(e => genericKeyCollection.Contains(new {
               Key = e.Key,
               EntityKey = e.Entity.Key,
               DoubleEntityKey = e.Entity.Entity.Key
@@ -571,7 +369,7 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
               Key = e.Key,
               EntityKey = e.Entity.Key,
               DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey.In(keyList)).ToList());
+            }.DoubleEntityKey.In(keyArray)).ToList());
 
         Assert.Throws<QueryTranslationException>(() =>
           result = session.Query.All<MyEntity3>()
@@ -579,7 +377,7 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
               Key = e.Key,
               EntityKey = e.Entity.Key,
               DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey.In(keyListAsEnumerable)).ToList());
+            }.DoubleEntityKey.In(nonGenericKeyCollection)).ToList());
 
         Assert.Throws<QueryTranslationException>(() =>
           result = session.Query.All<MyEntity3>()
@@ -587,39 +385,7 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
               Key = e.Key,
               EntityKey = e.Entity.Key,
               DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey.In(keyListAsInteface)).ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-          result = session.Query.All<MyEntity3>()
-            .Where(e => new {
-              Key = e.Key,
-              EntityKey = e.Entity.Key,
-              DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey.In(keyListAsCollection)).ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-          result = session.Query.All<MyEntity3>()
-            .Where(e => new {
-              Key = e.Key,
-              EntityKey = e.Entity.Key,
-              DoubleEntityKey = e.Entity.Entity.Key
-           }.DoubleEntityKey.In(keyArray)).ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-          result = session.Query.All<MyEntity3>()
-            .Where(e => new {
-              Key = e.Key,
-               EntityKey = e.Entity.Key,
-              DoubleEntityKey = e.Entity.Entity.Key
-           }.DoubleEntityKey.In(keyArrayAsEnumerable)).ToList());
-
-        Assert.Throws<QueryTranslationException>(() =>
-          result = session.Query.All<MyEntity3>()
-            .Where(e => new {
-              Key = e.Key,
-              EntityKey = e.Entity.Key,
-              DoubleEntityKey = e.Entity.Entity.Key
-            }.DoubleEntityKey.In(keyArrayAsCollection)).ToList());
+            }.DoubleEntityKey.In(genericKeyCollection)).ToList());
       }
     }
 
@@ -655,36 +421,13 @@ namespace Xtensive.Orm.Tests.Linq.ContainsOverKeysCollectionTest
           Entity = new MyEntity { Field = "QRS" }
         }
       };
-
-      new ComplexKeyEntity(1, 1) { Name = "1 1" };
-      new ComplexKeyEntity(2, 2) { Name = "2 2" };
-      new ComplexKeyEntity(3, 3) { Name = "3 3" };
-      new ComplexKeyEntity(4, 4) { Name = "4 4" };
-      new ComplexKeyEntity(5, 5) { Name = "5 5" };
-      new ComplexKeyEntity(6, 6) { Name = "6 6" };
-      new ComplexKeyEntity(7, 7) { Name = "7 7" };
-      new ComplexKeyEntity(8, 8) { Name = "8 8" };
     }
 
     private void PopulateKeysCollections(Session session)
     {
-      keyList = session.Query.All<MyEntity>().AsEnumerable().Take(3).Select(e => e.Key).ToList();
-      keyListAsEnumerable = new List<Key>(keyList);
-      keyListAsCollection = new List<Key>(keyList);
-      keyListAsInteface = new List<Key>(keyList);
-
       keyArray = session.Query.All<MyEntity>().AsEnumerable().Take(3).Select(e => e.Key).ToArray();
-      keyArrayAsEnumerable = keyArray.AsEnumerable().ToArray();
-      keyArrayAsCollection = keyArray.AsEnumerable().ToArray();
-
-      complexKeyList = session.Query.All<ComplexKeyEntity>().Take(5).Select(e => e.Key).ToList();
-      complexKeyListAsEnumerable = new List<Key>(complexKeyList);
-      complexKeyListAsCollection = new List<Key>(complexKeyList);
-      complexKeyListAsInteface = new List<Key>(complexKeyList);
-
-      complexKeyArray = session.Query.All<ComplexKeyEntity>().Take(5).Select(e => e.Key).ToArray();
-      complexKeyArrayAsEnumerable = complexKeyArray.AsEnumerable().ToArray();
-      complexKeyArrayAsCollection = complexKeyArray.AsEnumerable().ToArray();
+      genericKeyCollection = new TestGenericCollection<Key>(keyArray);
+      nonGenericKeyCollection = new TestKeyCollection(keyArray);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -977,7 +977,7 @@ namespace Xtensive.Orm.Linq
       Expression keyExpression;
 
       if (expression.IsNull())
-        keyExpression = Expression.Constant(null, typeof (Key));
+        keyExpression = Expression.Constant(null, KeyType);
       else if (IsConditionalOrWellknown(expression))
         return keyFieldTypes
           .Select((type, index) => GetConditionalKeyField(expression, type, index))
@@ -990,7 +990,7 @@ namespace Xtensive.Orm.Linq
           expression = Expression.Convert(expression, typeof (IEntity));
         keyExpression = Expression.Condition(
           isNullExpression,
-          Expression.Constant(null, typeof (Key)),
+          Expression.Constant(null, KeyType),
           Expression.MakeMemberAccess(expression, WellKnownMembers.IEntityKey));
       }
       return GetKeyFields(keyExpression, keyFieldTypes);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -26,6 +26,9 @@ namespace Xtensive.Orm.Linq
 {
   internal sealed partial class Translator : QueryableVisitor
   {
+    private static readonly Type KeyType = typeof(Key);
+    private static readonly Type IEnumerableOfKeyType = typeof(IEnumerable<Key>);
+
     public TranslatorState state;
     private readonly TranslatorContext context;
 
@@ -1573,8 +1576,8 @@ namespace Xtensive.Orm.Linq
 
     private bool IsKeyCollection(Type localCollectionType)
     {
-      return (localCollectionType.IsArray && localCollectionType.GetElementType() == typeof(Key))
-        || typeof(IEnumerable<Key>).IsAssignableFrom(localCollectionType);
+      return (localCollectionType.IsArray && localCollectionType.GetElementType() == KeyType)
+        || IEnumerableOfKeyType.IsAssignableFrom(localCollectionType);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2010-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.02.27
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1263,11 +1263,18 @@ namespace Xtensive.Orm.Linq
       var parameter = predicate.Parameters[0];
       ProjectionExpression visitedSource;
       using (state.CreateScope()) {
-        if (source.IsLocalCollection(context) &&
-            (source.Type.IsGenericType && source.Type.GetGenericArguments()[0].IsAssignableFrom(typeof (Key))) ||
-            (source.Type.IsAssignableFrom(typeof (Key)))) {
-          var localCollecctionKeyType = LocalCollectionKeyTypeExtractor.Extract((BinaryExpression)predicate.Body);
-          state.TypeOfEntityStoredInKey = localCollecctionKeyType;
+        if (source.IsLocalCollection(context)) {
+          var sourceType = source.Type;
+          Type itemType = sourceType.IsGenericType
+            ? itemType = sourceType.GetGenericArguments()[0]
+            : sourceType.IsArray
+              ? sourceType.GetElementType()
+              : null;
+
+          if (itemType != null && itemType.IsAssignableFrom(typeof(Key))) {
+            var localCollectionKeyType = LocalCollectionKeyTypeExtractor.Extract((BinaryExpression) predicate.Body);
+            state.TypeOfEntityStoredInKey = localCollectionKeyType;
+          }
         }
         state.IncludeAlgorithm = IncludeAlgorithm.Auto;
         visitedSource = VisitSequence(source);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2020 Xtensive LLC.
+// Copyright (C) 2009-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov


### PR DESCRIPTION
Fix for #49 

- Improves item type detection for local collections used with ```In()``` and ```Contains()``` methods within queries.
- Adds variety of new collection usage examples to the original test for the feature.