### PR TITLE
Zombie check before transaction commit or rollback

### DIFF
--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/Connection.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/Connection.cs
@@ -98,6 +98,74 @@ namespace Xtensive.Sql.Drivers.SqlServer
     }
 
     /// <inheritdoc/>
+    public override void Commit()
+    {
+      EnsureIsNotDisposed();
+      EnsureTransactionIsActive();
+
+      try {
+        if (!IsTransactionZombied()) {
+          ActiveTransaction.Commit();
+        }
+      }
+      finally {
+        ActiveTransaction.Dispose();
+        ClearActiveTransaction();
+      }
+    }
+
+    /// <inheritdoc/>
+    public override async Task CommitAsync(CancellationToken token = default)
+    {
+      EnsureIsNotDisposed();
+      EnsureTransactionIsActive();
+
+      try {
+        if (!IsTransactionZombied()) {
+          await ActiveTransaction.CommitAsync(token).ConfigureAwait(false);
+        }
+      }
+      finally {
+        await ActiveTransaction.DisposeAsync().ConfigureAwait(false);
+        ClearActiveTransaction();
+      }
+    }
+
+    /// <inheritdoc/>
+    public override void Rollback()
+    {
+      EnsureIsNotDisposed();
+      EnsureTransactionIsActive();
+
+      try {
+        if (!IsTransactionZombied()) {
+          ActiveTransaction.Rollback();
+        }
+      }
+      finally {
+        ActiveTransaction.Dispose();
+        ClearActiveTransaction();
+      }
+    }
+
+    /// <inheritdoc/>
+    public override async Task RollbackAsync(CancellationToken token = default)
+    {
+      EnsureIsNotDisposed();
+      EnsureTransactionIsActive();
+
+      try {
+        if (!IsTransactionZombied()) {
+          await ActiveTransaction.RollbackAsync(token).ConfigureAwait(false);
+        }
+      }
+      finally {
+        await ActiveTransaction.DisposeAsync().ConfigureAwait(false);
+        ClearActiveTransaction();
+      }
+    }
+
+    /// <inheritdoc/>
     public override void MakeSavepoint(string name)
     {
       EnsureIsNotDisposed();
@@ -198,6 +266,11 @@ namespace Xtensive.Sql.Drivers.SqlServer
           throw;
         }
       }
+    }
+
+    private bool IsTransactionZombied()
+    {
+      return ActiveTransaction != null && ActiveTransaction.Connection == null;
     }
 
     // Constructors


### PR DESCRIPTION
Suggested fix #77

The fix is applied only for SQL Server. The PR checks whether transaction is became zombie before commit or rollback. This happens when some exception appeared and rolled back existing transaction (in this case an attempt to rollback to save point when ```DbReader``` is active).

User will have original exception (e.g. inability to perform rollback to save point due to open reader) instead of overlapping exception from outermost ```TransactionScope.Dispose()```