### PR TITLE
ActiveTransactionIsNoLongerUsableException class instead of general InvalidOperationException

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Exceptions/ActiveTransactionIsNoLongerUsableException.cs
+++ b/Orm/Xtensive.Orm/Orm/Exceptions/ActiveTransactionIsNoLongerUsableException.cs
@@ -1,0 +1,19 @@
+// Copyright (C) 2003-2021 Xtensive LLC.
+// All rights reserved.
+// For conditions of distribution and use, see license.
+
+using System;
+using System.Runtime.Serialization;
+
+
+namespace Xtensive.Orm
+{
+  [Serializable]
+  public class ActiveTransactionIsNoLongerUsableException : InvalidOperationException
+  {
+    public ActiveTransactionIsNoLongerUsableException()
+      : base(Strings.ExActiveTransactionIsNoLongerUsable)
+    {
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Sql/SqlConnection.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlConnection.cs
@@ -498,7 +498,7 @@ namespace Xtensive.Sql
     protected void EnsureTransactionIsAlive()
     {
       if (ActiveTransaction != null && ActiveTransaction.Connection == null)
-        throw new InvalidOperationException(Strings.ExActiveTransactionIsNoLongerUsable);
+        throw new ActiveTransactionIsNoLongerUsableException();
     }
 
     /// <summary>


### PR DESCRIPTION
It is inconvenient to catch InvalidOperationException for transaction reprocessing.
We need more specific exception class