### PR TITLE
Manual Prefetch of EntitySet items

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0795_EntitySetPrefetchDoesNotWork.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0795_EntitySetPrefetchDoesNotWork.cs
@@ -1,0 +1,698 @@
+// Copyright (C) 2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+// Created by: Alexey Kulakov
+// Created:    2020.02.19
+
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Tests.Issues.IssueJira0795_EntitySetPrefetchDoesNotWorkModel;
+using Xtensive.Orm.Validation;
+using Xtensive.Sql;
+using Xtensive.Sql.Dml;
+using Xtensive.Caching;
+using System.Transactions;
+
+namespace Xtensive.Orm.Tests.Issues.IssueJira0795_EntitySetPrefetchDoesNotWorkModel
+{
+  [HierarchyRoot]
+  public class Person : Entity
+  {
+    [Field, Key]
+    public int Id { get; private set; }
+
+    [Field(Length = 100)]
+    public string Name { get; set; }
+
+    [Field(LazyLoad = true)]
+    [Association(PairTo = nameof(IssueJira0795_EntitySetPrefetchDoesNotWorkModel.Sports.Person),
+      OnOwnerRemove = OnRemoveAction.Cascade,
+      OnTargetRemove = OnRemoveAction.Clear)]
+    public EntitySet<Sports> Sports { get; private set; }
+
+    public Person(Session session)
+        : base(session)
+    {
+    }
+  }
+
+  [HierarchyRoot]
+  public class Sports : Entity
+  {
+    [Field, Key]
+    public int Id { get; private set; }
+
+    [Field]
+    public Status Status { get; set; }
+
+    [Field]
+    public double Valor { get; set; }
+
+    [Field]
+    public Person Person { get; private set; }
+
+    public Sports(Session session)
+      : base(session)
+    {
+    }
+  }
+
+  public enum Status
+  {
+    Active = 0,
+    Inactive = 1
+  }
+
+  [HierarchyRoot]
+  public class SomeEntity : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+    [Field]
+    public EntitySetContainer Ref { get; set; }
+  }
+
+  [HierarchyRoot]
+  public class EntitySetContainer : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+    [Field]
+    public EntitySet<EntitySetItem> Items { get; private set; }
+  }
+
+  [HierarchyRoot]
+  public class EntitySetItem : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Issues
+{
+  public class IssueJira0795_EntitySetPrefetchDoesNotWork : AutoBuildTest
+  {
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(Person).Assembly, typeof(Person).Namespace);
+      configuration.UpgradeMode = DomainUpgradeMode.Recreate;
+      return configuration;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        foreach (var sports in session.Query.All<Sports>()) {
+          sports.Remove();
+        }
+        foreach (var person in session.Query.All<Person>()) {
+          person.Remove();
+        }
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public void ClientProfileTest01()
+    {
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var outerSessionPersonId = 0;
+
+      using (var outerSession = Domain.OpenSession(configuration)) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        var sport1 = new Sports(outerSession) { Valor = 10 };
+        var sport2 = new Sports(outerSession) { Valor = 20 };
+
+        _ = person.Sports.Add(sport2);
+        _ = person.Sports.Add(sport1);
+
+        outerSession.SaveChanges();
+        outerSessionPersonId = person.Id;
+
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        var actualCountInStorage = outerSession.Query.All<Sports>().Count();
+
+        Assert.That(actualCountInStorage, Is.EqualTo(2));
+        Assert.That(person, Is.Not.Null);
+        Assert.That(person.Id, Is.EqualTo(outerSessionPersonId));
+
+        var countOuter = 0;
+        foreach (var item in person.Sports) {
+          countOuter++;
+        }
+
+        Assert.That(countOuter, Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration)) {
+          var person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          var countInner = 0;
+          foreach (var item in person1.Sports) {
+            countInner++;
+          }
+          Assert.That(countInner, Is.EqualTo(3));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+
+          Assert.That(actualCountInStorage, Is.EqualTo(3));
+
+          countInner = 0;
+          foreach (var item in person1.Sports) {
+            countInner++;
+          }
+
+          Assert.That(countInner, Is.EqualTo(actualCountInStorage));
+        }
+
+        person.Sports.Prefetch();
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+
+        Assert.That(actualCountInStorage, Is.EqualTo(3));
+
+        countOuter = 0;
+        foreach (var item in person.Sports) {
+          countOuter++;
+        }
+        Assert.That(countOuter, Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileTest02()
+    {
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var outerSessionPersonId = 0;
+
+      using (var outerSession = Domain.OpenSession(configuration)) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+
+        var sport1 = new Sports(outerSession) { Valor = 10 };
+        var sport2 = new Sports(outerSession) { Valor = 20 };
+
+        _ = person.Sports.Add(sport2);
+        _ = person.Sports.Add(sport1);
+
+        outerSession.SaveChanges();
+        outerSessionPersonId = person.Id;
+
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        var actualCountInStorage = outerSession.Query.All<Sports>().Count();
+
+        Assert.That(actualCountInStorage, Is.EqualTo(2));
+        Assert.That(person, Is.Not.Null);
+        Assert.That(person.Id, Is.EqualTo(outerSessionPersonId));
+
+        var countOuter = 0;
+        foreach (var item in person.Sports) {
+          countOuter++;
+        }
+
+        Assert.That(countOuter, Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration)) {
+          var person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          var countInner = 0;
+          foreach (var item in person1.Sports) {
+            countInner++;
+          }
+          Assert.That(countInner, Is.EqualTo(3));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          actualCountInStorage = outerSession.Query.All<Sports>().Count();
+
+          Assert.That(actualCountInStorage, Is.EqualTo(3));
+
+          countInner = 0;
+          foreach (var item in person1.Sports) {
+            countInner++;
+          }
+
+          Assert.That(countInner, Is.EqualTo(actualCountInStorage));
+        }
+
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+
+        Assert.That(actualCountInStorage, Is.EqualTo(3));
+
+        countOuter = 0;
+        foreach (var item in person.Sports) {
+          countOuter++;
+        }
+        Assert.That(countOuter, Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ReadUncommitedTest1()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession())
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>()
+          .Prefetch(p => p.Sports)
+          .FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession())
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(1));
+        person.Sports.Prefetch();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ReadUncommitedTest2()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession())
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession())
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(1));
+
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ReadUncommitedTest3()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession())
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession())
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        using (var innerTx = outerSession.OpenTransaction(TransactionOpenMode.New, IsolationLevel.RepeatableRead)) {
+          actualCountInStorage = outerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+        }
+      }
+    }
+
+    [Test]
+    public void ReadCommittedTest1()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession())
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>()
+          .Prefetch(p => p.Sports)
+          .FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession())
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(1));
+        person.Sports.Prefetch();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ReadCommittedTest2()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession())
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession())
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(1));
+
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ReadCommittedTest3()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession())
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession())
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        using (var innerTx = outerSession.OpenTransaction(TransactionOpenMode.New, IsolationLevel.RepeatableRead)) {
+          actualCountInStorage = outerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+        }
+      }
+    }
+
+    [Test]
+    public void RepeatableReadTest1()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite | StorageProvider.MySql);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession())
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>()
+          .Prefetch(p => p.Sports)
+          .FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession())
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        if (StorageProviderInfo.Instance.Provider == StorageProvider.SqlServer) {
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+        }
+        else {
+          Assert.That(actualCountInStorage, Is.EqualTo(0));
+        }
+        person.Sports.Prefetch();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void RepeatableReadTest2()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite | StorageProvider.MySql);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession())
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession())
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        if (StorageProviderInfo.Instance.Provider == StorageProvider.SqlServer) {
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+        }
+        else {
+          Assert.That(actualCountInStorage, Is.EqualTo(0));
+        }
+
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void RepeatableReadTest3()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite | StorageProvider.MySql);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession())
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession())
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession) { Valor = 30 };
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        using (var innerTx = outerSession.OpenTransaction(TransactionOpenMode.New, IsolationLevel.RepeatableRead)) {
+          actualCountInStorage = outerSession.Query.All<Sports>().Count();
+          if (StorageProviderInfo.Instance.Provider == StorageProvider.SqlServer) {
+            Assert.That(actualCountInStorage, Is.EqualTo(1));
+          }
+          else {
+            Assert.That(actualCountInStorage, Is.EqualTo(0));
+          }
+
+          person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+        }
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0795_EntitySetPrefetchDoesNotWork.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0795_EntitySetPrefetchDoesNotWork.cs
@@ -245,6 +245,623 @@ namespace Xtensive.Orm.Tests.Issues
     }
 
     [Test]
+    public void ClientProfileWithReadUncommitedTest1()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>()
+          .Prefetch(p => p.Sports)
+          .FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(1));
+        person.Sports.Prefetch();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithReadUncommitedTest2()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>()
+          .Prefetch(p => p.Sports)
+          .FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          //rollback
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(0));
+        person.Sports.Prefetch();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithReadUncommitedTest3()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(1));
+
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithReadUncommitedTest4()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          //rollback
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(0));
+
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithReadCommitedTest1()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>()
+          .Prefetch(p => p.Sports)
+          .FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(1));
+        person.Sports.Prefetch();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithReadCommitedTest2()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>()
+          .Prefetch(p => p.Sports)
+          .FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadUncommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          //rollback
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(0));
+        person.Sports.Prefetch();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithReadCommitedTest3()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(1));
+
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithReadCommitedTest4()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.ReadCommitted)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          //rollback
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(0));
+
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithRepeatableReadTest1()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>()
+          .Prefetch(p => p.Sports)
+          .FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        if (StorageProviderInfo.Instance.Provider == StorageProvider.SqlServer) {
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+        }
+        else {
+          Assert.That(actualCountInStorage, Is.EqualTo(0));
+        }
+
+        person.Sports.Prefetch();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithRepeatableReadTest2()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>()
+          .Prefetch(p => p.Sports)
+          .FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          //rollback
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(0));
+        person.Sports.Prefetch();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithRepeatableReadTest3()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+          innerSessionTx.Complete();
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        if (StorageProviderInfo.Instance.Provider == StorageProvider.SqlServer) {
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+        }
+        else {
+          Assert.That(actualCountInStorage, Is.EqualTo(0));
+        }
+
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
+    public void ClientProfileWithRepeatableReadTest4()
+    {
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+
+      using (var outerSession = Domain.OpenSession())
+      using (var tx = outerSession.OpenTransaction()) {
+        var person = new Person(outerSession) { Name = "Jordi" };
+        tx.Complete();
+      }
+
+      var configuration = new SessionConfiguration(SessionOptions.ClientProfile);
+
+      var actualCountInStorage = 0;
+      using (var outerSession = Domain.OpenSession(configuration))
+      using (var outerSessionTx = outerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+
+        var person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+        using (var innerSession = Domain.OpenSession(configuration))
+        using (var innerSessionTx = innerSession.OpenTransaction(IsolationLevel.RepeatableRead)) {
+          var person1 = innerSession.Query.All<Person>()
+            .Prefetch(p => p.Sports)
+            .FirstOrDefault();
+          var sport3 = new Sports(innerSession);
+          sport3.Valor = 30;
+          _ = person1.Sports.Add(sport3);
+          innerSession.SaveChanges();
+
+          actualCountInStorage = innerSession.Query.All<Sports>().Count();
+          Assert.That(actualCountInStorage, Is.EqualTo(1));
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          Assert.That(person1.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+
+          //rollback
+        }
+
+        actualCountInStorage = outerSession.Query.All<Sports>().Count();
+        Assert.That(actualCountInStorage, Is.EqualTo(0));
+
+        Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
+      }
+    }
+
+    [Test]
     public void ReadUncommitedTest1()
     {
       Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0795_EntitySetPrefetchDoesNotWork.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0795_EntitySetPrefetchDoesNotWork.cs
@@ -146,11 +146,7 @@ namespace Xtensive.Orm.Tests.Issues
         Assert.That(person, Is.Not.Null);
         Assert.That(person.Id, Is.EqualTo(outerSessionPersonId));
 
-        var countOuter = 0;
-        foreach (var item in person.Sports) {
-          countOuter++;
-        }
-
+        var countOuter = person.Sports.AsEnumerable().Count();
         Assert.That(countOuter, Is.EqualTo(actualCountInStorage));
 
         using (var innerSession = Domain.OpenSession(configuration)) {
@@ -159,10 +155,7 @@ namespace Xtensive.Orm.Tests.Issues
           _ = person1.Sports.Add(sport3);
           innerSession.SaveChanges();
 
-          var countInner = 0;
-          foreach (var item in person1.Sports) {
-            countInner++;
-          }
+          var countInner = person1.Sports.AsEnumerable().Count();
           Assert.That(countInner, Is.EqualTo(3));
 
           person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
@@ -170,23 +163,21 @@ namespace Xtensive.Orm.Tests.Issues
 
           Assert.That(actualCountInStorage, Is.EqualTo(3));
 
-          countInner = 0;
-          foreach (var item in person1.Sports) {
-            countInner++;
-          }
-
+          countInner = person1.Sports.AsEnumerable().Count();
           Assert.That(countInner, Is.EqualTo(actualCountInStorage));
         }
 
+        // autoprefetch
+        countOuter = person.Sports.AsEnumerable().Count();
+        Assert.That(countOuter, Is.EqualTo(2));
+
+        // force manual prefetch
         person.Sports.Prefetch();
         actualCountInStorage = outerSession.Query.All<Sports>().Count();
 
         Assert.That(actualCountInStorage, Is.EqualTo(3));
 
-        countOuter = 0;
-        foreach (var item in person.Sports) {
-          countOuter++;
-        }
+        countOuter = person.Sports.AsEnumerable().Count();
         Assert.That(countOuter, Is.EqualTo(actualCountInStorage));
       }
     }
@@ -217,11 +208,7 @@ namespace Xtensive.Orm.Tests.Issues
         Assert.That(person, Is.Not.Null);
         Assert.That(person.Id, Is.EqualTo(outerSessionPersonId));
 
-        var countOuter = 0;
-        foreach (var item in person.Sports) {
-          countOuter++;
-        }
-
+        var countOuter = person.Sports.AsEnumerable().Count();
         Assert.That(countOuter, Is.EqualTo(actualCountInStorage));
 
         using (var innerSession = Domain.OpenSession(configuration)) {
@@ -230,10 +217,7 @@ namespace Xtensive.Orm.Tests.Issues
           _ = person1.Sports.Add(sport3);
           innerSession.SaveChanges();
 
-          var countInner = 0;
-          foreach (var item in person1.Sports) {
-            countInner++;
-          }
+          var countInner = person1.Sports.AsEnumerable().Count();
           Assert.That(countInner, Is.EqualTo(3));
 
           person1 = innerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
@@ -241,23 +225,21 @@ namespace Xtensive.Orm.Tests.Issues
 
           Assert.That(actualCountInStorage, Is.EqualTo(3));
 
-          countInner = 0;
-          foreach (var item in person1.Sports) {
-            countInner++;
-          }
-
+          countInner = person1.Sports.AsEnumerable().Count();
           Assert.That(countInner, Is.EqualTo(actualCountInStorage));
         }
 
+        // autoprefetch
+        countOuter = person.Sports.AsEnumerable().Count();
+        Assert.That(countOuter, Is.EqualTo(2));
+
+        //force manual prefetch
         person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
         actualCountInStorage = outerSession.Query.All<Sports>().Count();
 
         Assert.That(actualCountInStorage, Is.EqualTo(3));
 
-        countOuter = 0;
-        foreach (var item in person.Sports) {
-          countOuter++;
-        }
+        countOuter = person.Sports.AsEnumerable().Count();
         Assert.That(countOuter, Is.EqualTo(actualCountInStorage));
       }
     }
@@ -302,9 +284,12 @@ namespace Xtensive.Orm.Tests.Issues
           innerSessionTx.Complete();
         }
 
+        // autoprefetch
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(0));
+
         actualCountInStorage = outerSession.Query.All<Sports>().Count();
         Assert.That(actualCountInStorage, Is.EqualTo(1));
-        person.Sports.Prefetch();
+        person.Sports.Prefetch();// force manual prefetch
         Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
       }
     }
@@ -346,11 +331,14 @@ namespace Xtensive.Orm.Tests.Issues
           innerSessionTx.Complete();
         }
 
+        // autoprefetch
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(0));
+
         actualCountInStorage = outerSession.Query.All<Sports>().Count();
         Assert.That(actualCountInStorage, Is.EqualTo(1));
 
         Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
-        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();// force manual prefetch
         Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
       }
     }
@@ -393,9 +381,11 @@ namespace Xtensive.Orm.Tests.Issues
         }
 
         using (var innerTx = outerSession.OpenTransaction(TransactionOpenMode.New, IsolationLevel.RepeatableRead)) {
+          Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(0));// autoprefetch
+
           actualCountInStorage = outerSession.Query.All<Sports>().Count();
           Assert.That(actualCountInStorage, Is.EqualTo(1));
-          person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();// force manual prefetch
           Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
         }
       }
@@ -441,9 +431,12 @@ namespace Xtensive.Orm.Tests.Issues
           innerSessionTx.Complete();
         }
 
+        // autoprefetch
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(0));
+
         actualCountInStorage = outerSession.Query.All<Sports>().Count();
         Assert.That(actualCountInStorage, Is.EqualTo(1));
-        person.Sports.Prefetch();
+        person.Sports.Prefetch();// force manual prefetch
         Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
       }
     }
@@ -485,11 +478,14 @@ namespace Xtensive.Orm.Tests.Issues
           innerSessionTx.Complete();
         }
 
+        // autoprefetch
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(0));
+
         actualCountInStorage = outerSession.Query.All<Sports>().Count();
         Assert.That(actualCountInStorage, Is.EqualTo(1));
 
         Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
-        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();// force manual prefetch
         Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
       }
     }
@@ -532,9 +528,11 @@ namespace Xtensive.Orm.Tests.Issues
         }
 
         using (var innerTx = outerSession.OpenTransaction(TransactionOpenMode.New, IsolationLevel.RepeatableRead)) {
+          Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(0));// autoprefetch
+
           actualCountInStorage = outerSession.Query.All<Sports>().Count();
           Assert.That(actualCountInStorage, Is.EqualTo(1));
-          person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();// force manual prefetch
           Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
         }
       }
@@ -580,6 +578,9 @@ namespace Xtensive.Orm.Tests.Issues
           innerSessionTx.Complete();
         }
 
+        // autoprefetch
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(0));
+
         actualCountInStorage = outerSession.Query.All<Sports>().Count();
         if (StorageProviderInfo.Instance.Provider == StorageProvider.SqlServer) {
           Assert.That(actualCountInStorage, Is.EqualTo(1));
@@ -587,7 +588,7 @@ namespace Xtensive.Orm.Tests.Issues
         else {
           Assert.That(actualCountInStorage, Is.EqualTo(0));
         }
-        person.Sports.Prefetch();
+        person.Sports.Prefetch();// force manual prefetch
         Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
       }
     }
@@ -629,6 +630,9 @@ namespace Xtensive.Orm.Tests.Issues
           innerSessionTx.Complete();
         }
 
+        // autoprefetch
+        Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(0));
+
         actualCountInStorage = outerSession.Query.All<Sports>().Count();
         if (StorageProviderInfo.Instance.Provider == StorageProvider.SqlServer) {
           Assert.That(actualCountInStorage, Is.EqualTo(1));
@@ -638,7 +642,7 @@ namespace Xtensive.Orm.Tests.Issues
         }
 
         Assert.That(outerSession.Query.All<Sports>().Count(), Is.EqualTo(actualCountInStorage));
-        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+        person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();// force manual prefetch
         Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
       }
     }
@@ -681,6 +685,8 @@ namespace Xtensive.Orm.Tests.Issues
         }
 
         using (var innerTx = outerSession.OpenTransaction(TransactionOpenMode.New, IsolationLevel.RepeatableRead)) {
+          Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(0));// autoprefetch
+
           actualCountInStorage = outerSession.Query.All<Sports>().Count();
           if (StorageProviderInfo.Instance.Provider == StorageProvider.SqlServer) {
             Assert.That(actualCountInStorage, Is.EqualTo(1));
@@ -689,7 +695,7 @@ namespace Xtensive.Orm.Tests.Issues
             Assert.That(actualCountInStorage, Is.EqualTo(0));
           }
 
-          person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();
+          person = outerSession.Query.All<Person>().Prefetch(p => p.Sports).FirstOrDefault();// force manual prefetch
           Assert.That(person.Sports.AsEnumerable().Count(), Is.EqualTo(actualCountInStorage));
         }
       }

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0795_EntitySetPrefetchDoesNotWork.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0795_EntitySetPrefetchDoesNotWork.cs
@@ -651,7 +651,7 @@ namespace Xtensive.Orm.Tests.Issues
     [Test]
     public void ClientProfileWithRepeatableReadTest1()
     {
-      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite | StorageProvider.MySql);
 
       using (var outerSession = Domain.OpenSession())
       using (var tx = outerSession.OpenTransaction()) {
@@ -707,7 +707,7 @@ namespace Xtensive.Orm.Tests.Issues
     [Test]
     public void ClientProfileWithRepeatableReadTest2()
     {
-      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite | StorageProvider.MySql);
 
       using (var outerSession = Domain.OpenSession())
       using (var tx = outerSession.OpenTransaction()) {
@@ -758,7 +758,7 @@ namespace Xtensive.Orm.Tests.Issues
     [Test]
     public void ClientProfileWithRepeatableReadTest3()
     {
-      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite | StorageProvider.MySql);
 
       using (var outerSession = Domain.OpenSession())
       using (var tx = outerSession.OpenTransaction()) {
@@ -813,7 +813,7 @@ namespace Xtensive.Orm.Tests.Issues
     [Test]
     public void ClientProfileWithRepeatableReadTest4()
     {
-      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite);
+      Require.ProviderIsNot(StorageProvider.SqlServerCe | StorageProvider.Sqlite | StorageProvider.MySql);
 
       using (var outerSession = Domain.OpenSession())
       using (var tx = outerSession.OpenTransaction()) {

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -49,10 +49,10 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the owner of this instance.
     /// </summary>
-    public Entity Owner { get { return owner; } }
+    public Entity Owner => owner;
 
     /// <inheritdoc/>
-    Persistent IFieldValueAdapter.Owner { get { return Owner; } }
+    Persistent IFieldValueAdapter.Owner => Owner;
 
     /// <inheritdoc/>
     public FieldInfo Field { get; private set; }
@@ -78,26 +78,24 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the entities contained in this <see cref="EntitySetBase"/>.
     /// </summary>
-    protected internal IEnumerable<IEntity> Entities {
-      get {
-        return InnerGetEntities().ToTransactional(Session);
-      }
-    }
+    protected internal IEnumerable<IEntity> Entities
+      => InnerGetEntities().ToTransactional(Session);
 
     private IEnumerable<IEntity> InnerGetEntities()
     {
-      if (Owner.IsRemoved)
+      if (Owner.IsRemoved) {
         yield break; // WPF tries to enumerate EntitySets of removed Entities
+      }
 
       PrefetchInternal();
       foreach (var key in State) {
         var entity = Session.Query.SingleOrDefault(key);
-        if (entity==null) {
+        if (entity == null) {
           if (!key.IsTemporary(Session.Domain)) {
             Session.RemoveOrCreateRemovedEntity(key.TypeReference.Type.UnderlyingType, key, EntityRemoveReason.Other);
-            EntityState entityState;
-            if (Session.LookupStateInCache(key, out entityState))
+            if (Session.LookupStateInCache(key, out var entityState)) {
               entity = entityState.Entity;
+            }
           }
         }
         yield return entity;
@@ -107,10 +105,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Prefetches the entity set completely - i.e. ensures it is fully loaded.
     /// </summary>
-    public void Prefetch()
-    {
-      Prefetch(null);
-    }
+    public void Prefetch() => Prefetch(null);
 
     /// <summary>
     /// Prefetches the entity set - i.e. ensures it is either completely or partially loaded.
@@ -133,13 +128,13 @@ namespace Xtensive.Orm
     public bool Contains(Key key)
     {
       EnsureOwnerIsNotRemoved();
-      if (key==null || !Field.ItemType.IsAssignableFrom(key.TypeInfo.UnderlyingType))
+      if (key==null || !Field.ItemType.IsAssignableFrom(key.TypeInfo.UnderlyingType)) {
         return false;
+      }
 
-      EntityState entityState;
-      if (Session.LookupStateInCache(key, out entityState))
-        return Contains(key, entityState.TryGetEntity());
-      return Contains(key, null);
+      return Session.LookupStateInCache(key, out var entityState)
+        ? Contains(key, entityState.TryGetEntity())
+        : Contains(key, null);
     }
 
     /// <summary>
@@ -158,20 +153,24 @@ namespace Xtensive.Orm
     /// </summary>
     protected void EnsureOwnerIsNotRemoved()
     {
-      if (Owner.IsRemoved)
+      if (Owner.IsRemoved) {
         throw new InvalidOperationException(Strings.ExEntityIsRemoved);
+      }
     }
 
     #region System-level event-like members
 
     private void SystemInitialize()
     {
-      if (Session.IsSystemLogicOnly)
+      if (Session.IsSystemLogicOnly) {
         return;
+      }
+
       var subscriptionInfo = GetSubscription(EntityEventBroker.InitializeEntitySetEventKey);
-      if (subscriptionInfo.Second!=null)
+      if (subscriptionInfo.Second != null) {
         ((Action<Key, FieldInfo>) subscriptionInfo.Second)
           .Invoke(subscriptionInfo.First, Field);
+      }
       OnInitialize();
     }
 
@@ -181,13 +180,15 @@ namespace Xtensive.Orm
       using (Session.Operations.EnableSystemOperationRegistration()) {
         Session.Events.NotifyEntitySetItemAdding(this, item);
 
-        if (Session.IsSystemLogicOnly)
+        if (Session.IsSystemLogicOnly) {
           return;
+        }
 
         var subscriptionInfo = GetSubscription(EntityEventBroker.AddingEntitySetItemEventKey);
-        if (subscriptionInfo.Second!=null)
+        if (subscriptionInfo.Second != null) {
           ((Action<Key, FieldInfo, Entity>) subscriptionInfo.Second)
             .Invoke(subscriptionInfo.First, Field, item);
+        }
         OnAdding(item);
       }
     }
@@ -198,16 +199,19 @@ namespace Xtensive.Orm
       using (Session.Operations.EnableSystemOperationRegistration()) {
         Session.Events.NotifyEntitySetItemAdd(this, item);
 
-        if (Session.IsSystemLogicOnly)
+        if (Session.IsSystemLogicOnly) {
           return;
+        }
 
-        if (CanBeValidated)
+        if (CanBeValidated) {
           Session.ValidationContext.RegisterForValidation(Owner);
+        }
 
         var subscriptionInfo = GetSubscription(EntityEventBroker.AddEntitySetItemEventKey);
-        if (subscriptionInfo.Second!=null)
+        if (subscriptionInfo.Second != null) {
           ((Action<Key, FieldInfo, Entity>) subscriptionInfo.Second)
             .Invoke(subscriptionInfo.First, Field, item);
+        }
         OnAdd(item);
         NotifyCollectionChanged(NotifyCollectionChangedAction.Add, item, index);
       }
@@ -227,12 +231,14 @@ namespace Xtensive.Orm
       using (Session.Operations.EnableSystemOperationRegistration()) {
         Session.Events.NotifyEntitySetItemRemoving(this, item);
 
-        if (Session.IsSystemLogicOnly)
+        if (Session.IsSystemLogicOnly) {
           return;
+        }
 
         var subscriptionInfo = GetSubscription(EntityEventBroker.RemovingEntitySetItemEventKey);
-        if (subscriptionInfo.Second!=null)
+        if (subscriptionInfo.Second != null) {
           ((Action<Key, FieldInfo, Entity>) subscriptionInfo.Second).Invoke(subscriptionInfo.First, Field, item);
+        }
         OnRemoving(item);
       }
     }
@@ -243,16 +249,20 @@ namespace Xtensive.Orm
       using (Session.Operations.EnableSystemOperationRegistration()) {
         Session.Events.NotifyEntitySetItemRemoved(Owner, this, item);
 
-        if (Session.IsSystemLogicOnly)
+        if (Session.IsSystemLogicOnly) {
           return;
+        }
 
-        if (CanBeValidated)
+        if (CanBeValidated) {
           Session.ValidationContext.RegisterForValidation(Owner);
+        }
 
         var subscriptionInfo = GetSubscription(EntityEventBroker.RemoveEntitySetItemEventKey);
-        if (subscriptionInfo.Second!=null)
+        if (subscriptionInfo.Second != null) {
           ((Action<Key, FieldInfo, Entity>) subscriptionInfo.Second)
             .Invoke(subscriptionInfo.First, Field, item);
+        }
+
         OnRemove(item);
         NotifyCollectionChanged(NotifyCollectionChangedAction.Remove, item, index);
       }
@@ -272,14 +282,17 @@ namespace Xtensive.Orm
       using (Session.Operations.EnableSystemOperationRegistration()) {
         Session.Events.NotifyEntitySetClearing(this);
 
-        if (Session.IsSystemLogicOnly)
+        if (Session.IsSystemLogicOnly) {
           return;
+        }
 
         using (Session.Operations.EnableSystemOperationRegistration()) {
           var subscriptionInfo = GetSubscription(EntityEventBroker.ClearingEntitySetEventKey);
-          if (subscriptionInfo.Second!=null)
+          if (subscriptionInfo.Second != null) {
             ((Action<Key, FieldInfo>) subscriptionInfo.Second)
               .Invoke(subscriptionInfo.First, Field);
+          }
+
           OnClearing();
         }
       }
@@ -291,17 +304,20 @@ namespace Xtensive.Orm
       using (Session.Operations.EnableSystemOperationRegistration()) {
         Session.Events.NotifyEntitySetClear(this);
 
-        if (Session.IsSystemLogicOnly)
+        if (Session.IsSystemLogicOnly) {
           return;
+        }
 
-        if (CanBeValidated)
+        if (CanBeValidated) {
           Session.ValidationContext.RegisterForValidation(Owner);
+        }
 
         using (Session.Operations.EnableSystemOperationRegistration()) {
           var subscriptionInfo = GetSubscription(EntityEventBroker.ClearEntitySetEventKey);
-          if (subscriptionInfo.Second!=null)
+          if (subscriptionInfo.Second != null) {
             ((Action<Key, FieldInfo>) subscriptionInfo.Second)
               .Invoke(subscriptionInfo.First, Field);
+          }
           OnClear();
           NotifyCollectionChanged(NotifyCollectionChangedAction.Reset, null, null);
         }
@@ -350,12 +366,14 @@ namespace Xtensive.Orm
     /// <param name="propertyName">Name of the changed property.</param>
     protected void NotifyPropertyChanged(string propertyName)
     {
-      if (!Session.EntityEvents.HasSubscribers)
+      if (!Session.EntityEvents.HasSubscribers) {
         return;
+      }
       var subscriptionInfo = GetSubscription(EntityEventBroker.PropertyChangedEventKey);
-      if (subscriptionInfo.Second != null)
+      if (subscriptionInfo.Second != null) {
         ((PropertyChangedEventHandler) subscriptionInfo.Second)
           .Invoke(this, new PropertyChangedEventArgs(propertyName));
+      }
     }
 
     /// <summary>
@@ -366,36 +384,44 @@ namespace Xtensive.Orm
     /// <param name="index">The index on the item, if available.</param>
     protected void NotifyCollectionChanged(NotifyCollectionChangedAction action, Entity item, int? index)
     {
-      if (!Session.EntityEvents.HasSubscribers)
+      if (!Session.EntityEvents.HasSubscribers) {
         return;
+      }
+
       var subscriptionInfo = GetSubscription(EntityEventBroker.CollectionChangedEventKey);
       if (subscriptionInfo.Second != null) {
         var handler = (NotifyCollectionChangedEventHandler) subscriptionInfo.Second;
-        if (action==NotifyCollectionChangedAction.Reset)
+        if (action == NotifyCollectionChangedAction.Reset) {
           handler.Invoke(this, new NotifyCollectionChangedEventArgs(action));
+        }
         else if (!index.HasValue) {
-          if (action==NotifyCollectionChangedAction.Remove) {
+          if (action == NotifyCollectionChangedAction.Remove) {
             // Workaround for WPF / non-WPF subscribers
             var invocationList = handler.GetInvocationList();
             foreach (var @delegate in invocationList) {
               var typedDelegate = (NotifyCollectionChangedEventHandler) @delegate;
               var subscriberAssemblyName = @delegate.Method.DeclaringType.Assembly.FullName;
-              if (subscriberAssemblyName.StartsWith(presentationFrameworkAssemblyPrefix, StringComparison.Ordinal))
+              if (subscriberAssemblyName.StartsWith(presentationFrameworkAssemblyPrefix, StringComparison.Ordinal)) {
                 // WPF can't handle "Remove" event w/o item index
                 typedDelegate.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+              }
 #if DEBUG
-              else if (subscriberAssemblyName.StartsWith(storageTestsAssemblyPrefix, StringComparison.Ordinal))
+              else if (subscriberAssemblyName.StartsWith(storageTestsAssemblyPrefix, StringComparison.Ordinal)) {
                 typedDelegate.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+              }
 #endif
-              else
+              else {
                 typedDelegate.Invoke(this, new NotifyCollectionChangedEventArgs(action, item));
+              }
             }
           }
-          else
+          else {
             handler.Invoke(this, new NotifyCollectionChangedEventArgs(action, item));
+          }
         }
-        else
+        else {
           handler.Invoke(this, new NotifyCollectionChangedEventArgs(action, item, index.GetValueOrDefault()));
+        }
       }
       NotifyPropertyChanged("Count");
     }
@@ -408,9 +434,11 @@ namespace Xtensive.Orm
     protected Pair<Key, Delegate> GetSubscription(object eventKey)
     {
       var entityKey = GetOwnerKey(Owner);
-      if (entityKey!=null)
+      if (entityKey != null) {
         return new Pair<Key, Delegate>(entityKey,
           Session.EntityEvents.GetSubscriber(entityKey, Field, eventKey));
+      }
+
       return new Pair<Key, Delegate>(null, null);
     }
 
@@ -495,27 +523,25 @@ namespace Xtensive.Orm
     internal bool Contains(Entity item)
     {
       EnsureOwnerIsNotRemoved();
-      if (item==null || !Field.ItemType.IsAssignableFrom(item.TypeInfo.UnderlyingType))
-        return false;
-      return Contains(item.Key, item);
+      return item != null && Field.ItemType.IsAssignableFrom(item.TypeInfo.UnderlyingType)
+        && Contains(item.Key, item);
     }
 
-    internal bool Add(Entity item)
-    {
-      return Add(item, null, null);
-    }
+    internal bool Add(Entity item) => Add(item, null, null);
 
     internal bool Add(Entity item, SyncContext syncContext, RemovalContext removalContext)
     {
-      if (Contains(item))
+      if (Contains(item)) {
         return false;
+      }
 
       try {
         var operations = Session.Operations;
         using (var scope = operations.BeginRegistration(Operations.OperationType.System)) {
           var itemKey = item.Key;
-          if (operations.CanRegisterOperation)
+          if (operations.CanRegisterOperation) {
             operations.RegisterOperation(new EntitySetItemAddOperation(Owner.Key, Field, itemKey));
+          }
 
           SystemBeforeAdd(item);
 
@@ -536,7 +562,7 @@ namespace Xtensive.Orm
                 TypeReferenceAccuracy.ExactType,
                 combinedTuple);
 
-              Session.CreateOrInitializeExistingEntity(auxiliaryType.UnderlyingType, combinedKey);
+              _ = Session.CreateOrInitializeExistingEntity(auxiliaryType.UnderlyingType, combinedKey);
               Session.ReferenceFieldsChangesRegistry.Register(Owner.Key, itemKey, combinedKey, Field);
             }
 
@@ -547,17 +573,21 @@ namespace Xtensive.Orm
           };
 
           operations.NotifyOperationStarting();
-          if (association.IsPaired)
+          if (association.IsPaired) {
             Session.PairSyncManager.ProcessRecursively(syncContext, removalContext,
               OperationType.Add, association, Owner, item, finalizer);
-          else
+          }
+          else {
             finalizer.Invoke();
+          }
 
           // removalContext is unused here, since Add is never
           // invoked in reference cleanup process directly
 
-          if (!skipOwnerVersionChange)
-            Owner.UpdateVersionInfo(Owner, Field);
+          if (!skipOwnerVersionChange) {
+            _ = Owner.UpdateVersionInfo(Owner, Field);
+          }
+
           SystemAdd(item, index);
           SystemAddCompleted(item, null);
           scope.Complete();
@@ -570,23 +600,22 @@ namespace Xtensive.Orm
       }
     }
 
-    internal bool Remove(Entity item)
-    {
-      return Remove(item, null, null);
-    }
+    internal bool Remove(Entity item) => Remove(item, null, null);
 
     internal bool Remove(Entity item, SyncContext syncContext, RemovalContext removalContext)
     {
-      if (!Contains(item))
+      if (!Contains(item)) {
         return false;
+      }
 
       try {
         var operations = Session.Operations;
         var scope = operations.BeginRegistration(Operations.OperationType.System);
         try {
           var itemKey = item.Key;
-          if (operations.CanRegisterOperation)
+          if (operations.CanRegisterOperation) {
             operations.RegisterOperation(new EntitySetItemRemoveOperation(Owner.Key, Field, itemKey));
+          }
 
           SystemBeforeRemove(item);
 
@@ -617,11 +646,13 @@ namespace Xtensive.Orm
           };
 
           operations.NotifyOperationStarting();
-          if (association.IsPaired)
+          if (association.IsPaired) {
             Session.PairSyncManager.ProcessRecursively(syncContext, removalContext,
               OperationType.Remove, association, Owner, item, finalizer);
-          else
+          }
+          else {
             finalizer.Invoke();
+          }
 
           if (removalContext!=null) {
             // Postponing finalizers (events)
@@ -629,8 +660,10 @@ namespace Xtensive.Orm
               try {
                 try {
                   index = GetItemIndex(State, itemKey); // Necessary, since index can be already changed
-                  if (!skipOwnerVersionChange)
-                    Owner.UpdateVersionInfo(Owner, Field);
+                  if (!skipOwnerVersionChange) {
+                    _ = Owner.UpdateVersionInfo(Owner, Field);
+                  }
+
                   SystemRemove(item, index);
                   SystemRemoveCompleted(item, null);
                   scope.Complete();
@@ -647,16 +680,19 @@ namespace Xtensive.Orm
             return true;
           }
 
-          if (!skipOwnerVersionChange)
-            Owner.UpdateVersionInfo(Owner, Field);
+          if (!skipOwnerVersionChange) {
+            _ = Owner.UpdateVersionInfo(Owner, Field);
+          }
+
           SystemRemove(item, index);
           SystemRemoveCompleted(item, null);
           scope.Complete();
           return true;
         }
         finally {
-          if (removalContext==null)
+          if (removalContext == null) {
             scope.DisposeSafely();
+          }
         }
       }
       catch (Exception e) {
@@ -674,15 +710,16 @@ namespace Xtensive.Orm
       try {
         var operations = Session.Operations;
         using (var scope = operations.BeginRegistration(Operations.OperationType.System)) {
-          if (operations.CanRegisterOperation)
-            operations.RegisterOperation(
-              new EntitySetClearOperation(Owner.Key, Field));
+          if (operations.CanRegisterOperation) {
+            operations.RegisterOperation(new EntitySetClearOperation(Owner.Key, Field));
+          }
 
           SystemBeforeClear();
           operations.NotifyOperationStarting();
 
-          foreach (var entity in Entities.ToList())
-            Remove(entity);
+          foreach (var entity in Entities.ToList()) {
+            _ = Remove(entity);
+          }
 
           SystemClear();
           SystemClearCompleted(null);
@@ -695,20 +732,11 @@ namespace Xtensive.Orm
       }
     }
 
-    internal bool Add(IEntity item)
-    {
-      return Add((Entity) item);
-    }
+    internal bool Add(IEntity item) => Add((Entity) item);
 
-    internal bool Remove(IEntity item)
-    {
-      return Remove((Entity) item);
-    }
+    internal bool Remove(IEntity item) => Remove((Entity) item);
 
-    internal bool Contains(IEntity item)
-    {
-      return Contains((Entity) item);
-    }
+    internal bool Contains(IEntity item) => Contains((Entity) item);
 
     #endregion
 
@@ -718,30 +746,38 @@ namespace Xtensive.Orm
       where TElement: IEntity
     {
       EnsureOwnerIsNotRemoved();
-      foreach (var item in items)
-        Add(item);
+      foreach (var item in items) {
+        _ = Add(item);
+      }
     }
 
     internal void IntersectWith<TElement>(IEnumerable<TElement> other)
       where TElement : IEntity
     {
       EnsureOwnerIsNotRemoved();
-      if (this==other)
+      if (this == other) {
         return;
-      var otherEntities = other.Cast<IEntity>().ToHashSet();
-      foreach (var item in Entities.ToList())
-        if (!otherEntities.Contains(item))
-          Remove(item);
+      }
+
+      var otherEntities = new HashSet<IEntity>(other.Cast<IEntity>());
+      foreach (var item in Entities.ToList()) {
+        if (!otherEntities.Contains(item)) {
+          _ = Remove(item);
+        }
+      }
     }
 
     internal void UnionWith<TElement>(IEnumerable<TElement> other)
       where TElement : IEntity
     {
       EnsureOwnerIsNotRemoved();
-      if (this == other)
+      if (this == other) {
         return;
-      foreach (var item in other)
-        Add(item);
+      }
+
+      foreach (var item in other) {
+        _ = Add(item);
+      }
     }
 
     internal void ExceptWith<TElement>(IEnumerable<TElement> other)
@@ -752,8 +788,9 @@ namespace Xtensive.Orm
         Clear();
         return;
       }
-      foreach (var item in other)
-        Remove(item);
+      foreach (var item in other) {
+        _ = Remove(item);
+      }
     }
 
     #endregion
@@ -772,8 +809,10 @@ namespace Xtensive.Orm
 
     internal bool CheckStateIsLoaded()
     {
-      if (State.IsLoaded)
+      if (State.IsLoaded) {
         return true;
+      }
+
       if (Owner.State.PersistenceState == PersistenceState.New) {
         State.TotalItemCount = State.AddedItemsCount;
         State.IsLoaded = true;
@@ -810,8 +849,10 @@ namespace Xtensive.Orm
 
     private void EnsureCountIsLoaded()
     {
-      if (State.TotalItemCount!=null)
+      if (State.TotalItemCount != null) {
         return;
+      }
+
       using (new ParameterContext().Activate()) {
         ownerParameter.Value = owner;
         var cachedState = GetEntitySetTypeState();
@@ -823,14 +864,17 @@ namespace Xtensive.Orm
     {
       // state check
       var foundInCache = State.Contains(key);
-      if (foundInCache)
+      if (foundInCache) {
         return true;
+      }
+
       var ownerState = Owner.PersistenceState;
       var itemState = item == null
         ? PersistenceState.Synchronized
         : item.PersistenceState;
-      if (PersistenceState.New.In(ownerState, itemState) || State.IsFullyLoaded)
+      if (PersistenceState.New.In(ownerState, itemState) || State.IsFullyLoaded) {
         return false;
+      }
 
       // association check
       if (item != null) {
@@ -845,10 +889,12 @@ namespace Xtensive.Orm
       EnsureIsLoaded(WellKnown.EntitySetPreloadCount);
 
       foundInCache = State.Contains(key);
-      if (foundInCache)
+      if (foundInCache) {
         return true;
-      if (State.IsFullyLoaded)
+      }
+      if (State.IsFullyLoaded) {
         return false;
+      }
 
       bool foundInDatabase;
       using (new ParameterContext().Activate()) {
@@ -857,17 +903,17 @@ namespace Xtensive.Orm
           .Apply(TupleTransformType.TransformedTuple, Owner.Key.Value, key.Value);
         foundInDatabase = entitySetTypeState.SeekProvider.GetRecordSet(Session).FirstOrDefault()!=null;
       }
-      if (foundInDatabase)
+      if (foundInDatabase) {
         State.Register(key);
+      }
       return foundInDatabase;
     }
 
     private static Key GetOwnerKey(Persistent owner)
     {
-      var asFieldValueAdapter = owner as IFieldValueAdapter;
-      if (asFieldValueAdapter != null)
-        return GetOwnerKey(asFieldValueAdapter.Owner);
-      return ((Entity) owner).Key;
+      return owner is IFieldValueAdapter asFieldValueAdapter
+        ? GetOwnerKey(asFieldValueAdapter.Owner)
+        : ((Entity) owner).Key;
     }
 
     private EntitySetTypeState GetEntitySetTypeState()
@@ -907,38 +953,41 @@ namespace Xtensive.Orm
       var seekTransform = new MapTransform(true, keyDescriptor, map);
 
       Func<Tuple, Entity> itemCtor = null;
-      if (association.AuxiliaryType!=null)
+      if (association.AuxiliaryType != null) {
         itemCtor = DelegateHelper.CreateDelegate<Func<Tuple, Entity>>(null,
           association.AuxiliaryType.UnderlyingType, DelegateHelper.AspectedFactoryMethodName,
           ArrayUtils<Type>.EmptyArray);
+      }
+
       return new EntitySetTypeState(seek, seekTransform, itemCtor, entitySet.GetItemCountQueryDelegate(field));
     }
 
     private int? GetItemIndex(EntitySetState state, Key key)
     {
-      if (!state.IsFullyLoaded)
+      if (!state.IsFullyLoaded) {
         return null;
-      if (!Session.EntityEvents.HasSubscribers)
+      }
+      if (!Session.EntityEvents.HasSubscribers) {
         return null;
+      }
       var subscriptionInfo = GetSubscription(EntityEventBroker.CollectionChangedEventKey);
-      if (subscriptionInfo.Second==null)
+      if (subscriptionInfo.Second == null) {
         return null;
+      }
 
       // Ok, it seems there is a reason
       // to waste linear time on calculating this...
-      int i = 0;
+      var i = 0;
       foreach (var cachedKey in state) {
-        if (key==cachedKey)
+        if (key == cachedKey) {
           return i;
+        }
         i++;
       }
       return null;
     }
 
-    internal static void ExecuteOnValidate(EntitySetBase target)
-    {
-      target.OnValidate();
-    }
+    internal static void ExecuteOnValidate(EntitySetBase target) => target.OnValidate();
 
     #endregion
 
@@ -953,7 +1002,7 @@ namespace Xtensive.Orm
     /// <param name="ctorType">The type, which constructor has invoked this method.</param>
     protected void Initialize(Type ctorType)
     {
-      if (ctorType==GetType() && !isInitialized) {
+      if (ctorType == GetType() && !isInitialized) {
         isInitialized = true;
         Initialize();
       }
@@ -962,10 +1011,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Performs initialization of the <see cref="EntitySetBase"/>.
     /// </summary>
-    protected virtual void Initialize()
-    {
-      SystemInitialize();
-    }
+    protected virtual void Initialize() => SystemInitialize();
 
 
     // Constructors
@@ -982,8 +1028,8 @@ namespace Xtensive.Orm
       Field = field;
       State = new EntitySetState(this);
       var association = Field.Associations.Last();
-      if (association.AuxiliaryType!=null && association.IsMaster) {
-        Domain domain = Session.Domain;
+      if (association.AuxiliaryType != null && association.IsMaster) {
+        var domain = Session.Domain;
         var itemType = domain.Model.Types[Field.ItemType];
         auxilaryTypeKeyTransform = new CombineTransform(
           false,
@@ -991,10 +1037,9 @@ namespace Xtensive.Orm
           itemType.Key.TupleDescriptor);
       }
 
-      if (association.Multiplicity!= Multiplicity.ManyToOne && association.Multiplicity!=Multiplicity.OneToMany)
-        skipOwnerVersionChange = false;
-      else
-        skipOwnerVersionChange = Session.Domain.Configuration.VersioningConvention.DenyEntitySetOwnerVersionChange;
+      skipOwnerVersionChange = association.Multiplicity != Multiplicity.ManyToOne && association.Multiplicity != Multiplicity.OneToMany
+        ? false
+        : Session.Domain.Configuration.VersioningConvention.DenyEntitySetOwnerVersionChange;
 
       Initialize(typeof (EntitySetBase));
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/EntitySetState.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntitySetState.cs
@@ -291,9 +291,6 @@ namespace Xtensive.Orm.Internals
 
         lastManualPrefetchId = currentPrefetchOperation.Value;
       }
-      if (isDisconnected) {
-        return true;
-      }
 
       if (Session.Transaction != null) {
         switch (Session.Transaction.Outermost.IsolationLevel) {
@@ -305,6 +302,10 @@ namespace Xtensive.Orm.Internals
           default:
             return false;
         }
+      }
+
+      if (isDisconnected) {
+        return true;
       }
 
       return false;

--- a/Orm/Xtensive.Orm/Orm/Internals/EntitySetState.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntitySetState.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -375,12 +375,11 @@ namespace Xtensive.Orm.Internals
       Rebind();
     }
 
-    public void UpdateCachedState(IEnumerable<Key> keys, long? count)
+    public void UpdateCachedState(IEnumerable<Key> syncronizedKeys, long? count)
     {
       FetchedKeys.Clear();
       var becameRemovedOnSever = new HashSet<Key>(removedKeys.Keys);
-      TotalItemCount = count;
-      foreach (var key in keys) {
+      foreach (var key in syncronizedKeys) {
         if (addedKeys.ContainsKey(key)) {
           _ = addedKeys.Remove(key);
         }
@@ -392,6 +391,10 @@ namespace Xtensive.Orm.Internals
       foreach (var removedOnServer in becameRemovedOnSever) {
         _ = removedKeys.Remove(removedOnServer);
       }
+
+      TotalItemCount = count.HasValue
+        ? FetchedKeys.Count - removedKeys.Count + AddedItemsCount
+        : count;
     }
 
     private void EnsureFetchedKeysIsNotNull()

--- a/Orm/Xtensive.Orm/Orm/Internals/EntitySetState.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntitySetState.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2008.10.14
 
@@ -50,72 +50,63 @@ namespace Xtensive.Orm.Internals
 
     private BackupedState previousState;
 
-    public KeyCache FetchedKeys {
-      get { return State; }
-      set { State = value; }
+    public KeyCache FetchedKeys
+    {
+      get => State;
+      set => State = value;
     }
 
     /// <summary>
     /// Gets total count of elements which entity set contains.
     /// </summary>
-    public long? TotalItemCount {
+    public long? TotalItemCount
+    {
       get {
         EnsureIsActual();
         return totalItemCount;
       }
-      internal set {
-        totalItemCount = value;
-      }
+      internal set => totalItemCount = value;
     }
 
     /// <summary>
     /// Gets the number of cached items.
     /// </summary>
-    public long CachedItemCount { get { return FetchedItemsCount - RemovedItemsCount + AddedItemsCount; } }
+    public long CachedItemCount
+      => FetchedItemsCount - RemovedItemsCount + AddedItemsCount;
 
     /// <summary>
     /// Gets the number of fetched keys.
     /// </summary>
-    public long FetchedItemsCount
-    {
-      get { return FetchedKeys.Count; }
-    }
+    public long FetchedItemsCount => FetchedKeys.Count;
 
     /// <summary>
     /// Gets count of keys which was added but changes are not applyed.
     /// </summary>
-    public int AddedItemsCount
-    {
-      get { return addedKeys.Count; }
-    }
+    public int AddedItemsCount => addedKeys.Count;
 
     /// <summary>
     /// Gets count of keys which was removed but changes are not applied.
     /// </summary>
-    public int RemovedItemsCount
-    {
-      get { return removedKeys.Count; }
-    }
+    public int RemovedItemsCount => removedKeys.Count;
 
     /// <summary>
     /// Gets a value indicating whether state contains all keys which stored in database.
     /// </summary>
-    public bool IsFullyLoaded { get { return TotalItemCount==CachedItemCount; } }
-    
+    public bool IsFullyLoaded => TotalItemCount == CachedItemCount;
+
     /// <summary>
     /// Gets or sets a value indicating whether this instance is loaded.
     /// </summary>
     /// <value>
     /// <see langword="true"/> if this instance is preloaded; otherwise, <see langword="false"/>.
     /// </value>
-    public bool IsLoaded {
+    public bool IsLoaded
+    {
       get {
         EnsureIsActual();
         return isLoaded;
       }
-      internal set {
-        isLoaded = value;
-      }
+      internal set => isLoaded = value;
     }
 
     /// <summary>
@@ -125,9 +116,7 @@ namespace Xtensive.Orm.Internals
     /// <see langword="true"/> if this state has changes; otherwise, <see langword="false"/>.
     /// </value>
     public bool HasChanges
-    {
-      get { return AddedItemsCount!=0 || RemovedItemsCount!=0; }
-    }
+      => AddedItemsCount != 0 || RemovedItemsCount != 0;
 
     /// <summary>
     /// Sets cached keys to <paramref name="keys"/>.
@@ -135,11 +124,12 @@ namespace Xtensive.Orm.Internals
     /// <param name="keys">The keys.</param>
     public void Update(IEnumerable<Key> keys, long? count)
     {
-
-      if (HasChanges)
+      if (HasChanges) {
         UpdateCachedState(keys, count);
-      else
+      }
+      else {
         UpdateSyncedState(keys, count);
+      }
     }
 
     /// <summary>
@@ -149,23 +139,20 @@ namespace Xtensive.Orm.Internals
     /// <returns>Check result.</returns>
     public bool Contains(Key key)
     {
-      if (removedKeys.ContainsKey(key))
+      if (removedKeys.ContainsKey(key)) {
         return false;
-      if (addedKeys.ContainsKey(key))
+      }
+      if (addedKeys.ContainsKey(key)) {
         return true;
-      if (FetchedKeys.ContainsKey(key))
-        return true;
-      return false;
+      }
+      return FetchedKeys.ContainsKey(key);
     }
 
     /// <summary>
     /// Registers the specified fetched key in cached state.
     /// </summary>
     /// <param name="key">The key to register.</param>
-    public void Register(Key key)
-    {
-      FetchedKeys.Add(key);
-    }
+    public void Register(Key key) => FetchedKeys.Add(key);
 
     /// <summary>
     /// Adds the specified key.
@@ -173,13 +160,19 @@ namespace Xtensive.Orm.Internals
     /// <param name="key">The key to add.</param>
     public void Add(Key key)
     {
-      if (removedKeys.ContainsKey(key))
-        removedKeys.Remove(key);
-      else
+      if (removedKeys.ContainsKey(key)) {
+        _ = removedKeys.Remove(key);
+      }
+      else {
         addedKeys[key] = key;
-      if (TotalItemCount!=null)
+      }
+      if (TotalItemCount != null) {
         TotalItemCount++;
-      unchecked { Interlocked.Add(ref version, 1); }
+      }
+
+      unchecked {
+        _ = Interlocked.Add(ref version, 1);
+      }
       Rebind();
     }
 
@@ -189,13 +182,19 @@ namespace Xtensive.Orm.Internals
     /// <param name="key">The key to remove.</param>
     public void Remove(Key key)
     {
-      if (addedKeys.ContainsKey(key))
-        addedKeys.Remove(key);
-      else
+      if (addedKeys.ContainsKey(key)) {
+        _ = addedKeys.Remove(key);
+      }
+      else {
         removedKeys[key] = key;
-      if (TotalItemCount!=null)
+      }
+      if (TotalItemCount!=null) {
         TotalItemCount--;
-      unchecked { Interlocked.Add(ref version, 1); }
+      }
+
+      unchecked {
+        _ = Interlocked.Add(ref version, 1);
+      }
       Rebind();
     }
 
@@ -210,11 +209,15 @@ namespace Xtensive.Orm.Internals
         var currentFetchedKeys = FetchedKeys;
         InitializeFetchedKeys();
 
-        foreach (var currentFetchedKey in currentFetchedKeys)
-          if (!removedKeys.ContainsKey(currentFetchedKey))
+        foreach (var currentFetchedKey in currentFetchedKeys) {
+          if (!removedKeys.ContainsKey(currentFetchedKey)) {
             FetchedKeys.Add(currentFetchedKey);
-        foreach (var addedKey in addedKeys)
+          }
+        }
+
+        foreach (var addedKey in addedKeys) {
           FetchedKeys.Add(addedKey.Value);
+        }
         InitializeDifferenceCollections();
         Rebind();
         return true;
@@ -228,13 +231,15 @@ namespace Xtensive.Orm.Internals
     public void CancelChanges()
     {
       InitializeDifferenceCollections();
-      unchecked { Interlocked.Add(ref version, 1); }
+      unchecked {
+        _ =  Interlocked.Add(ref version, 1);
+      }
       Rebind();
     }
 
     internal void RollbackState()
     {
-      if (previousState!=null) {
+      if (previousState != null) {
         TotalItemCount = previousState.TotalItemCount;
         IsLoaded = previousState.IsLoaded;
         var fetchedKeys = FetchedKeys;
@@ -242,17 +247,20 @@ namespace Xtensive.Orm.Internals
         InitializeFetchedKeys();
         InitializeDifferenceCollections();
 
-        foreach (var fetchedKey in fetchedKeys)
+        foreach (var fetchedKey in fetchedKeys) {
           FetchedKeys.Add(fetchedKey);
+        }
 
         foreach (var addedKey in previousState.AddedKeys) {
-          if (fetchedKeys.ContainsKey(addedKey))
+          if (fetchedKeys.ContainsKey(addedKey)) {
             FetchedKeys.Remove(addedKey);
+          }
           addedKeys.Add(addedKey, addedKey);
         }
         foreach (var removedKey in previousState.RemovedKeys) {
-          if (!FetchedKeys.ContainsKey(removedKey))
+          if (!FetchedKeys.ContainsKey(removedKey)) {
             FetchedKeys.Add(removedKey);
+          }
           removedKeys.Add(removedKey, removedKey);
         }
       }
@@ -277,13 +285,17 @@ namespace Xtensive.Orm.Internals
     internal bool ShouldUseForcePrefetch(Guid? currentPrefetchOperation)
     {
       if (currentPrefetchOperation.HasValue) {
-        if (currentPrefetchOperation.Value == lastManualPrefetchId)
+        if (currentPrefetchOperation.Value == lastManualPrefetchId) {
           return false;
+        }
+
         lastManualPrefetchId = currentPrefetchOperation.Value;
       }
-      if (isDisconnected)
+      if (isDisconnected) {
         return true;
-      if (Session.Transaction != null)
+      }
+
+      if (Session.Transaction != null) {
         switch (Session.Transaction.Outermost.IsolationLevel) {
           case System.Transactions.IsolationLevel.ReadCommitted:
           case System.Transactions.IsolationLevel.ReadUncommitted:
@@ -293,13 +305,16 @@ namespace Xtensive.Orm.Internals
           default:
             return false;
         }
+      }
+
       return false;
     }
 
     internal void SetLastManualPrefetchId(Guid? prefetchOperationId)
     {
-      if (prefetchOperationId.HasValue)
+      if (prefetchOperationId.HasValue) {
         lastManualPrefetchId = prefetchOperationId.Value;
+      }
     }
 
     /// <inheritdoc/>
@@ -310,16 +325,10 @@ namespace Xtensive.Orm.Internals
       base.Invalidate();
     }
 
-    void IInvalidatable.Invalidate()
-    {
-      Invalidate();
-    }
+    void IInvalidatable.Invalidate() => Invalidate();
 
     /// <inheritdoc/>
-    protected override void Refresh()
-    {
-      InitializeFetchedKeys();
-    }
+    protected override void Refresh() => InitializeFetchedKeys();
 
     #region GetEnumerator<...> methods
 
@@ -331,15 +340,18 @@ namespace Xtensive.Orm.Internals
       var addedKeysBeforePersist = addedKeys;
       var removedKeysBeforePersist = removedKeys;
       foreach (var fetchedKey in fetchedKeysBeforePersist) {
-        if (versionSnapshot!=version)
+        if (versionSnapshot != version) {
           throw new InvalidOperationException(Strings.ExCollectionHasBeenChanged);
-        if (!removedKeysBeforePersist.ContainsKey(fetchedKey))
+        }
+
+        if (!removedKeysBeforePersist.ContainsKey(fetchedKey)) {
           yield return fetchedKey;
+        }
       }
       foreach (var addedKey in addedKeysBeforePersist) {
-        if (versionSnapshot!=version)
-          throw new InvalidOperationException(Strings.ExCollectionHasBeenChanged);
-        yield return addedKey.Value;
+        yield return versionSnapshot != version
+          ? throw new InvalidOperationException(Strings.ExCollectionHasBeenChanged)
+          : addedKey.Value;
       }
 
     }
@@ -352,47 +364,46 @@ namespace Xtensive.Orm.Internals
 
     #endregion
 
-
     private void UpdateSyncedState(IEnumerable<Key> keys, long? count)
     {
       FetchedKeys.Clear();
       TotalItemCount = count;
-      foreach (var key in keys)
+      foreach (var key in keys) {
         FetchedKeys.Add(key);
+      }
       Rebind();
     }
 
     public void UpdateCachedState(IEnumerable<Key> keys, long? count)
     {
       FetchedKeys.Clear();
-      var becameRemovedOnSever = removedKeys.Keys.ToHashSet();
+      var becameRemovedOnSever = new HashSet<Key>(removedKeys.Keys);
       TotalItemCount = count;
       foreach (var key in keys) {
-        if (addedKeys.ContainsKey(key))
-          addedKeys.Remove(key);
-        else if (becameRemovedOnSever.Contains(key))
-          becameRemovedOnSever.Remove(key);
+        if (addedKeys.ContainsKey(key)) {
+          _ = addedKeys.Remove(key);
+        }
+        else if (becameRemovedOnSever.Contains(key)) {
+          _ = becameRemovedOnSever.Remove(key);
+        }
         FetchedKeys.Add(key);
       }
-      foreach (var removedOnServer in becameRemovedOnSever)
-        removedKeys.Remove(removedOnServer);
+      foreach (var removedOnServer in becameRemovedOnSever) {
+        _ = removedKeys.Remove(removedOnServer);
+      }
     }
 
     private void EnsureFetchedKeysIsNotNull()
     {
-      if (FetchedKeys==null)
+      if (FetchedKeys == null) {
         InitializeFetchedKeys();
+      }
     }
 
-    private void BackupState()
-    {
-      previousState = new BackupedState(this);
-    }
+    private void BackupState() => previousState = new BackupedState(this);
 
     private void InitializeFetchedKeys()
-    {
-      FetchedKeys = new LruCache<Key, Key>(WellKnown.EntitySetCacheSize, cachedKey => cachedKey);
-    }
+      => FetchedKeys = new LruCache<Key, Key>(WellKnown.EntitySetCacheSize, cachedKey => cachedKey);
 
     private void InitializeDifferenceCollections()
     {

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
 // Created:    2009.09.09
 
@@ -28,35 +28,33 @@ namespace Xtensive.Orm.Internals.Prefetch
     {
       public readonly FieldInfo ReferencingField;
       public readonly int? ItemCountLimit;
-      private int cachedHashCode;
+      private readonly int cachedHashCode;
 
       public bool Equals(CacheKey other)
       {
-        return (ItemCountLimit==null) == (other.ItemCountLimit==null)
+        return (ItemCountLimit == null) == (other.ItemCountLimit == null)
           && Equals(other.ReferencingField, ReferencingField);
       }
 
       public override bool Equals(object obj)
       {
-        if (ReferenceEquals(null, obj))
+        if (ReferenceEquals(null, obj)) {
           return false;
-        if (obj.GetType()!=typeof (CacheKey))
+        }
+        if (obj.GetType() != typeof (CacheKey)) {
           return false;
+        }
         return Equals((CacheKey) obj);
       }
 
-      public override int GetHashCode()
-      {
-        return cachedHashCode;
-      }
-
+      public override int GetHashCode() => cachedHashCode;
 
       // Constructors
 
       public CacheKey(FieldInfo referencingField, int? itemCountLimit)
       {
-        this.ReferencingField = referencingField;
-        this.ItemCountLimit = itemCountLimit;
+        ReferencingField = referencingField;
+        ItemCountLimit = itemCountLimit;
         unchecked {
           cachedHashCode = (ReferencingField.GetHashCode()*397)
                            ^ (ItemCountLimit.HasValue ? 1 : 0);
@@ -69,16 +67,15 @@ namespace Xtensive.Orm.Internals.Prefetch
     private static readonly object itemsQueryCachingRegion = new object();
     private static readonly Parameter<Tuple> ownerParameter = new Parameter<Tuple>(WellKnown.KeyFieldName);
     private static readonly Parameter<int> itemCountLimitParameter = new Parameter<int>("ItemCountLimit");
-    private static readonly MethodInfo getValueMethodDefinition = typeof (Tuple)
-      .GetMethods(BindingFlags.Public | BindingFlags.Instance)
-      .Where(method => method.Name=="GetValue" && method.GetParameters().Length == 1
-        && method.IsGenericMethodDefinition).Single();
+    //private static readonly MethodInfo getValueMethodDefinition = typeof (Tuple)
+    //  .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+    //  .Where(method => method.Name=="GetValue" && method.GetParameters().Length == 1
+    //    && method.IsGenericMethodDefinition).Single();
 
     private readonly Key ownerKey;
     private readonly bool isOwnerCached;
     private readonly PrefetchManager manager;
     private QueryTask itemsQueryTask;
-    private int? cachedHashCode;
     private readonly PrefetchFieldDescriptor referencingFieldDescriptor;
     private readonly CacheKey cacheKey;
 
@@ -90,8 +87,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public void RegisterQueryTask()
     {
-      EntitySetState state;
-      if (isOwnerCached && manager.Owner.LookupState(ownerKey, ReferencingField, out state)) {
+      if (isOwnerCached && manager.Owner.LookupState(ownerKey, ReferencingField, out var state)) {
         if (state == null || (state.IsFullyLoaded && !state.ShouldUseForcePrefetch(referencingFieldDescriptor.PrefetchOperationId))) {
           return;
         }
@@ -103,39 +99,48 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public void UpdateCache()
     {
-      if (itemsQueryTask==null)
+      if (itemsQueryTask == null) {
         return;
+      }
+
       var areToNotifyAboutKeys = !manager.Owner.Session.Domain.Model
         .Types[referencingFieldDescriptor.Field.ItemType].IsLeaf;
       var reader = manager.Owner.Session.Domain.RecordSetReader;
       var records = reader.Read(itemsQueryTask.Result, QueryProvider.Header, manager.Owner.Session);
       var entityKeys = new List<Key>(itemsQueryTask.Result.Count);
-      List<Pair<Key, Tuple>> auxEntities = null;
       var association = ReferencingField.Associations.Last();
-      if (association.AuxiliaryType!=null)
-        auxEntities = new List<Pair<Key, Tuple>>(itemsQueryTask.Result.Count);
+      var auxEntities = (association.AuxiliaryType != null)
+        ? new List<Pair<Key, Tuple>>(itemsQueryTask.Result.Count)
+        : null;
+
       foreach (var record in records) {
-        for (int i = 0; i < record.Count; i++) {
+        for (var i = 0; i < record.Count; i++) {
           var key = record.GetKey(i);
-          if (key==null)
+          if (key == null) {
             continue;
+          }
           var tuple = record.GetTuple(i);
-          if (tuple==null)
+          if (tuple == null) {
             continue;
-          if (association.AuxiliaryType!=null)
-            if (i==0)
+          }
+          if (association.AuxiliaryType != null) {
+            if (i == 0) {
               auxEntities.Add(new Pair<Key, Tuple>(key, tuple));
+            }
             else {
               manager.SaveStrongReference(manager.Owner.UpdateState(key, tuple));
               entityKeys.Add(key);
-              if (areToNotifyAboutKeys)
+              if (areToNotifyAboutKeys) {
                 referencingFieldDescriptor.NotifySubscriber(ownerKey, key);
+              }
             }
+          }
           else {
             manager.SaveStrongReference(manager.Owner.UpdateState(key, tuple));
             entityKeys.Add(key);
-            if (areToNotifyAboutKeys)
+            if (areToNotifyAboutKeys) {
               referencingFieldDescriptor.NotifySubscriber(ownerKey, key);
+            }
           }
         }
       }
@@ -148,28 +153,30 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public bool Equals(EntitySetTask other)
     {
-      if (ReferenceEquals(null, other))
+      if (ReferenceEquals(null, other)) {
         return false;
-      if (ReferenceEquals(this, other))
+      }
+      if (ReferenceEquals(this, other)) {
         return true;
+      }
       return other.cacheKey.Equals(cacheKey);
     }
 
     public override bool Equals(object obj)
     {
-      if (ReferenceEquals(null, obj))
+      if (ReferenceEquals(null, obj)) {
         return false;
-      if (ReferenceEquals(this, obj))
+      }
+      if (ReferenceEquals(this, obj)) {
         return true;
-      if (obj.GetType()!=typeof (EntitySetTask))
+      }
+      if (obj.GetType() != typeof (EntitySetTask)) {
         return false;
+      }
       return Equals((EntitySetTask) obj);
     }
 
-    public override int GetHashCode()
-    {
-      return cacheKey.GetHashCode();
-    }
+    public override int GetHashCode() => cacheKey.GetHashCode();
 
     #region Private / internal methods
 
@@ -178,8 +185,9 @@ namespace Xtensive.Orm.Internals.Prefetch
       var parameterContext = new ParameterContext();
       using (parameterContext.Activate()) {
         ownerParameter.Value = ownerKey.Value;
-        if (ItemCountLimit != null)
+        if (ItemCountLimit != null) {
           itemCountLimitParameter.Value = ItemCountLimit.Value;
+        }
         object key = new Pair<object, CacheKey>(itemsQueryCachingRegion, cacheKey);
         Func<object, object> generator = CreateRecordSetLoadingItems;
         var session = manager.Owner.Session;
@@ -196,14 +204,13 @@ namespace Xtensive.Orm.Internals.Prefetch
       var primaryTargetIndex = association.TargetType.Indexes.PrimaryIndex;
       var resultColumns = new List<int>(primaryTargetIndex.Columns.Count);
       ParameterExpression tupleParameter;
-      CompilableProvider result;
-      if (association.AuxiliaryType == null)
-        result = CreateQueryForDirectAssociation(pair, primaryTargetIndex, resultColumns);
-      else
-        result = CreateQueryForAssociationViaAuxType(pair, primaryTargetIndex, resultColumns);
+      var result = association.AuxiliaryType == null
+        ? CreateQueryForDirectAssociation(pair, primaryTargetIndex, resultColumns)
+        : CreateQueryForAssociationViaAuxType(pair, primaryTargetIndex, resultColumns);
       result = result.Select(resultColumns.ToArray());
-      if (pair.Second.ItemCountLimit != null)
+      if (pair.Second.ItemCountLimit != null) {
         result = result.Take(() => itemCountLimitParameter.Value);
+      }
       return result;
     }
 
@@ -242,10 +249,11 @@ namespace Xtensive.Orm.Internals.Prefetch
     private static void AddResultColumnIndexes(ICollection<int> indexes, IndexInfo index,
       int columnIndexOffset)
     {
-      for (int i = 0; i < index.Columns.Count; i++) {
+      for (var i = 0; i < index.Columns.Count; i++) {
         var column = index.Columns[i];
-        if (PrefetchHelper.IsFieldToBeLoadedByDefault(column.Field))
+        if (PrefetchHelper.IsFieldToBeLoadedByDefault(column.Field)) {
           indexes.Add(i + columnIndexOffset);
+        }
       }
     }
 
@@ -253,15 +261,19 @@ namespace Xtensive.Orm.Internals.Prefetch
     {
       var joiningColumns = new Pair<int>[primaryIndex.KeyColumns.Count];
       var firstColumnIndex = primaryIndex.Columns.IndexOf(primaryIndex.KeyColumns[0].Key);
-      for (int i = 0; i < joiningColumns.Length; i++)
-        if (hasAuxType)
+      for (var i = 0; i < joiningColumns.Length; i++) {
+        if (hasAuxType) {
           joiningColumns[i] =
             new Pair<int>(associationIndex.Columns.IndexOf(associationIndex.ValueColumns[i]),
               firstColumnIndex + i);
-        else
+        }
+        else {
           joiningColumns[i] =
             new Pair<int>(associationIndex.Columns.IndexOf(primaryIndex.KeyColumns[i].Key),
               firstColumnIndex + i);
+        }
+      }
+
       return joiningColumns;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
 // Created:    2009.10.20
 
@@ -24,10 +24,12 @@ namespace Xtensive.Orm.Internals.Prefetch
       var batchExecuted = 0;
       try {
         var rootEntityContainers = containers
-          .Where(container => container.RootEntityContainer!=null)
+          .Where(container => container.RootEntityContainer != null)
           .Select(container => container.RootEntityContainer);
-        foreach (var container in rootEntityContainers)
+        foreach (var container in rootEntityContainers) {
           AddTask(container);
+        }
+
         RegisterAllEntityGroupTasks();
         RegisterAllEntitySetTasks(containers);
 
@@ -39,13 +41,16 @@ namespace Xtensive.Orm.Internals.Prefetch
 
         var referencedEntityContainers = containers
           .Select(container => container.ReferencedEntityContainers)
-          .Where(referencedEntityPrefetchContainers => referencedEntityPrefetchContainers!=null)
+          .Where(referencedEntityPrefetchContainers => referencedEntityPrefetchContainers != null)
           .SelectMany(referencedEntityPrefetchContainers => referencedEntityPrefetchContainers);
-        foreach (var container in referencedEntityContainers)
+        foreach (var container in referencedEntityContainers) {
           AddTask(container);
+        }
 
-        if (tasks.Count==0)
+        if (tasks.Count == 0) {
           return batchExecuted;
+        }
+
         RegisterAllEntityGroupTasks();
 
         batchExecuted += manager.Owner.Session.ExecuteInternalDelayedQueries(skipPersist) ? 1 : 0;
@@ -60,11 +65,10 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     private static void UpdateCacheFromAllEntitySetTasks(IEnumerable<GraphContainer> containers)
     {
-      foreach (var container in containers) {
+      foreach (var container in containers.Where(c => c.EntitySetTasks != null)) {
         var entitySetPrefetchTasks = container.EntitySetTasks;
-        if (entitySetPrefetchTasks!=null) {
-          foreach (var entitySetPrefetchTask in entitySetPrefetchTasks)
-            entitySetPrefetchTask.UpdateCache();
+        foreach (var entitySetPrefetchTask in entitySetPrefetchTasks) {
+          entitySetPrefetchTask.UpdateCache();
         }
       }
     }
@@ -82,10 +86,10 @@ namespace Xtensive.Orm.Internals.Prefetch
     private void AddTask(EntityContainer container)
     {
       var newTask = container.GetTask();
-      if (newTask!=null) {
+      if (newTask != null) {
         var existingTask = tasks[newTask];
         if (existingTask == null) {
-          tasks.Add(newTask);
+          _ = tasks.Add(newTask);
           existingTask = newTask;
         }
         existingTask.AddKey(container.Key, container.ExactType);
@@ -102,8 +106,9 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     private void RegisterAllEntityGroupTasks()
     {
-      foreach (var task in tasks)
+      foreach (var task in tasks) {
         task.RegisterQueryTasks();
+      }
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
@@ -71,11 +71,10 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     private static void RegisterAllEntitySetTasks(IEnumerable<GraphContainer> containers)
     {
-      foreach (var container in containers) {
+      foreach (var container in containers.Where(c => c.EntitySetTasks != null)) {
         var entitySetPrefetchTasks = container.EntitySetTasks;
-        if (entitySetPrefetchTasks!=null) {
-          foreach (var entitySetPrefetchTask in entitySetPrefetchTasks)
-            entitySetPrefetchTask.RegisterQueryTask();
+        foreach (var entitySetPrefetchTask in entitySetPrefetchTasks) {
+          entitySetPrefetchTask.RegisterQueryTask();
         }
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
 // Created:    2009.09.03
 
@@ -34,17 +34,16 @@ namespace Xtensive.Orm.Internals.Prefetch
 
       public override bool Equals(object obj)
       {
-        if (ReferenceEquals(null, obj))
+        if (ReferenceEquals(null, obj)) {
           return false;
-        if (obj.GetType()!=typeof (RootContainerCacheKey))
+        }
+        if (obj.GetType() != typeof (RootContainerCacheKey)) {
           return false;
+        }
         return Equals((RootContainerCacheKey) obj);
       }
 
-      public override int GetHashCode()
-      {
-        return hashCode;
-      }
+      public override int GetHashCode() => hashCode;
 
 
       // Constructors
@@ -97,22 +96,24 @@ namespace Xtensive.Orm.Internals.Prefetch
     {
       ArgumentValidator.EnsureArgumentNotNull(key, "key");
       ArgumentValidator.EnsureArgumentNotNull(descriptors, "fields");
-      if (descriptors.Count==0)
-        return null;
 
+      if (descriptors.Count == 0) {
+        return null;
+      }
       try {
         EnsureKeyTypeCorrespondsToSpecifiedType(key, type);
 
-        EntityState ownerState;
         var currentKey = key;
-        if (!TryGetTupleOfNonRemovedEntity(ref currentKey, out ownerState))
+        if (!TryGetTupleOfNonRemovedEntity(ref currentKey, out var ownerState)) {
           return null;
+        }
+
         var selectedFields = descriptors;
         var currentType = type;
         StrongReferenceContainer hierarchyRootContainer = null;
         var isKeyTypeExact = currentKey.HasExactType
           || currentKey.TypeReference.Type.IsLeaf
-          || currentKey.TypeReference.Type==type;
+          || currentKey.TypeReference.Type == type;
         if (isKeyTypeExact) {
           currentType = currentKey.TypeReference.Type;
           EnsureAllFieldsBelongToSpecifiedType(descriptors, currentType);
@@ -120,21 +121,22 @@ namespace Xtensive.Orm.Internals.Prefetch
         else {
           ArgumentValidator.EnsureArgumentNotNull(currentType, "type");
           EnsureAllFieldsBelongToSpecifiedType(descriptors, currentType);
-          SetUpContainers(currentKey, currentKey.TypeReference.Type,
+          _ = SetUpContainers(currentKey, currentKey.TypeReference.Type,
             PrefetchHelper.GetCachedDescriptorsForFieldsLoadedByDefault(session.Domain, currentKey.TypeReference.Type),
             true, ownerState, true);
           var hierarchyRoot = currentKey.TypeReference.Type;
           selectedFields = descriptors
-            .Where(descriptor => descriptor.Field.DeclaringType!=hierarchyRoot)
+            .Where(descriptor => descriptor.Field.DeclaringType != hierarchyRoot)
             .ToList();
         }
-        SetUpContainers(currentKey, currentType, selectedFields, isKeyTypeExact, ownerState, ReferenceEquals(descriptors, selectedFields));
+        _ = SetUpContainers(currentKey, currentType, selectedFields, isKeyTypeExact, ownerState, ReferenceEquals(descriptors, selectedFields));
 
         StrongReferenceContainer container = null;
-        if (graphContainers.Count >= MaxContainerCount)
+        if (graphContainers.Count >= MaxContainerCount) {
           container = ExecuteTasks();
-        if (referenceContainer!=null) {
-          referenceContainer.JoinIfPossible(container);
+        }
+        if (referenceContainer != null) {
+          _ = referenceContainer.JoinIfPossible(container);
           return referenceContainer;
         }
         return container;
@@ -152,15 +154,16 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public StrongReferenceContainer ExecuteTasks(bool skipPersist)
     {
-      if (graphContainers.Count==0) {
+      if (graphContainers.Count == 0) {
         referenceContainer = null;
         return null;
       }
       try {
         var batchExecuted = fetcher.ExecuteTasks(graphContainers, skipPersist);
         TaskExecutionCount += batchExecuted;
-        foreach (var graphContainer in graphContainers)
+        foreach (var graphContainer in graphContainers) {
           graphContainer.NotifyAboutExtractionOfKeysWithUnknownType();
+        }
         return referenceContainer;
       }
       finally {
@@ -177,10 +180,10 @@ namespace Xtensive.Orm.Internals.Prefetch
     public bool TryGetTupleOfNonRemovedEntity(ref Key key, out EntityState state)
     {
       state = null;
-      bool isRemoved;
-      var entityState = GetCachedEntityState(ref key, out isRemoved);
-      if (isRemoved)
+      var entityState = GetCachedEntityState(ref key, out var isRemoved);
+      if (isRemoved) {
         return false;
+      }
       if (entityState != null) {
         SaveStrongReference(entityState);
         state = entityState;
@@ -194,41 +197,45 @@ namespace Xtensive.Orm.Internals.Prefetch
     {
       var result = GetGraphContainer(key, type, exactType);
       var areAnyColumns = false;
-      var haveColumnsBeenSet = false;
-      if (canUseCache)
-        haveColumnsBeenSet = TrySetCachedColumnIndexes(result, descriptors, state);
+      var haveColumnsBeenSet = canUseCache
+        ? TrySetCachedColumnIndexes(result, descriptors, state)
+        : false;
+
       foreach (var descriptor in descriptors) {
         if (descriptor.Field.IsEntity && descriptor.FetchFieldsOfReferencedEntity && !type.IsAuxiliary) {
           areAnyColumns = true;
           result.RegisterReferencedEntityContainer(state, descriptor);
         }
-        else if (descriptor.Field.IsEntitySet)
+        else if (descriptor.Field.IsEntitySet) {
           result.RegisterEntitySetTask(state, descriptor);
-        else
+        }
+        else {
           areAnyColumns = true;
+        }
       }
-      if (!haveColumnsBeenSet && areAnyColumns)
+      if (!haveColumnsBeenSet && areAnyColumns) {
         result.AddEntityColumns(ExtractColumns(descriptors));
+      }
       return result;
     }
 
     public void SaveStrongReference(EntityState reference)
     {
-      if (referenceContainer==null)
+      if (referenceContainer == null) {
         referenceContainer = new StrongReferenceContainer(null);
-      referenceContainer.Join(new StrongReferenceContainer(reference));
+      }
+      _ = referenceContainer.Join(new StrongReferenceContainer(reference));
     }
 
     public EntityState GetCachedEntityState(ref Key key, out bool isRemoved)
     {
-      EntityState cachedState;
-      if (Owner.LookupState(key, out cachedState)) {
+      if (Owner.LookupState(key, out var cachedState)) {
         if (cachedState == null) {
           isRemoved = false;
           return null;
         }
         key = cachedState.Key;
-        isRemoved = cachedState.PersistenceState==PersistenceState.Removed;
+        isRemoved = cachedState.PersistenceState == PersistenceState.Removed;
         return cachedState.IsTupleLoaded ? cachedState : null;
       }
       isRemoved = false;
@@ -256,26 +263,35 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     private static void EnsureKeyTypeCorrespondsToSpecifiedType(Key key, TypeInfo type)
     {
-      if (type == null || key.TypeReference.Type == type)
+      if (type == null || key.TypeReference.Type == type) {
         return;
-      if (!key.TypeReference.Type.IsInterface && !type.IsInterface)
-        if (key.TypeReference.Type.Hierarchy == type.Hierarchy)
+      }
+
+      if (!key.TypeReference.Type.IsInterface && !type.IsInterface) {
+        if (key.TypeReference.Type.Hierarchy == type.Hierarchy) {
           return;
-        else
+        }
+        else {
           throw new ArgumentException(Strings.ExSpecifiedTypeHierarchyIsDifferentFromKeyHierarchy);
+        }
+      }
+
       if (type.GetInterfaces(true).Contains(key.TypeReference.Type)
-        || key.TypeReference.Type.GetInterfaces(true).Contains(type))
+        || key.TypeReference.Type.GetInterfaces(true).Contains(type)) {
         return;
+      }
+
       throw new ArgumentException(Strings.ExSpecifiedTypeHierarchyIsDifferentFromKeyHierarchy);
     }
 
     private static void EnsureAllFieldsBelongToSpecifiedType(IList<PrefetchFieldDescriptor> descriptors, TypeInfo type)
     {
-      for (int i = 0; i < descriptors.Count; i++) {
+      for (var i = 0; i < descriptors.Count; i++) {
         var declaringType = descriptors[i].Field.DeclaringType;
-        if (type!=declaringType && !declaringType.UnderlyingType.IsAssignableFrom(type.UnderlyingType))
+        if (type != declaringType && !declaringType.UnderlyingType.IsAssignableFrom(type.UnderlyingType)) {
           throw new InvalidOperationException(
-            String.Format(Strings.ExFieldXIsNotDeclaredInTypeYOrInOneOfItsAncestors, descriptors[i].Field, type));
+            string.Format(Strings.ExFieldXIsNotDeclaredInTypeYOrInOneOfItsAncestors, descriptors[i].Field, type));
+        }
       }
     }
 
@@ -284,7 +300,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       var newTaskContainer = new GraphContainer(key, type, exactType, this);
       var registeredTaskContainer = graphContainers[newTaskContainer];
       if (registeredTaskContainer == null) {
-        graphContainers.Add(newTaskContainer);
+        _ = graphContainers.Add(newTaskContainer);
         return newTaskContainer;
       }
       return registeredTaskContainer;
@@ -293,13 +309,12 @@ namespace Xtensive.Orm.Internals.Prefetch
     private static IEnumerable<ColumnInfo> ExtractColumns(IEnumerable<PrefetchFieldDescriptor> descriptors)
     {
       foreach (var descriptor in descriptors) {
-        IEnumerable<ColumnInfo> columns;
-        if (descriptor.Field.IsStructure && !descriptor.FetchLazyFields)
-          columns = descriptor.Field.Columns.Where(column => !column.Field.IsLazyLoad);
-        else
-          columns = descriptor.Field.Columns;
-        foreach (var column in columns)
+        var columns = descriptor.Field.IsStructure && !descriptor.FetchLazyFields
+          ? descriptor.Field.Columns.Where(column => !column.Field.IsLazyLoad)
+          : descriptor.Field.Columns;
+        foreach (var column in columns) {
           yield return column;
+        }
       }
     }
 
@@ -308,9 +323,7 @@ namespace Xtensive.Orm.Internals.Prefetch
     {
       var result = false;
       if (container.RootEntityContainer == null) {
-        SortedDictionary<int, ColumnInfo> columns;
-        List<int> columnsToBeLoaded;
-        GetCachedColumnIndexes(container.Type, descriptors, out columns, out columnsToBeLoaded);
+        GetCachedColumnIndexes(container.Type, descriptors, out var columns, out var columnsToBeLoaded);
         container.CreateRootEntityContainer(columns, state == null ? columnsToBeLoaded : null);
         result = true;
       }


### PR DESCRIPTION
The PR makes Prefetch operation (through ```EntitySet.Prefetch()``` or ```PrefetchExtensions.Prefetch(e=>e.EntitySetField)```) to fetch new items that appeared in database since last fetch, but only in cases when new items are possible. Automatic fetch ( for instance, by enumerator) continue to skip fetching items if an ```EntitySet``` is considered fully loaded. 

Great example to demonstrate issue is concurrent sessions with  SessionOption.ClientProfile option. When one session saves changes without transaction the changes appears for another session. They are visible for ```Session.Query.All<T>()```. Before this PR there was no way to fetch such items to the EntitySet they belongs to.

The problem may occur for sessions with SessionOptions.ServerProfile and some transaction isolation levels. One of concurrent transactions may commit its changes and the changes may appear to another transaction but could not be loaded to EntitySet until this PR.