### PR TITLE
CommandProcessors: Use safe dispose for commands

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
@@ -174,7 +174,7 @@ namespace Xtensive.Orm.Providers
       }
       finally {
         if (!shouldReturnReader) {
-          context.ActiveCommand.Dispose();
+          context.ActiveCommand.DisposeSafely();
         }
         ReleaseCommand(context);
       }
@@ -238,7 +238,7 @@ namespace Xtensive.Orm.Providers
       }
       finally {
         if (!shouldReturnReader) {
-          context.ActiveCommand.Dispose();
+          context.ActiveCommand.DisposeSafely();
         }
         ReleaseCommand(context);
       }

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
@@ -101,7 +101,7 @@ namespace Xtensive.Orm.Providers
           }
         }
         finally {
-          context.ActiveCommand.Dispose();
+          context.ActiveCommand.DisposeSafely();
           ReleaseCommand(context);
         }
       }


### PR DESCRIPTION
Same as #118 but for ```6.0```