### PR TITLE
Dedicated Prefetch for DelayedQuery{T}

### DIFF
--- a/Orm/Xtensive.Orm.Manual/Prefetch/PrefetchTest.cs
+++ b/Orm/Xtensive.Orm.Manual/Prefetch/PrefetchTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
@@ -40,9 +40,7 @@ namespace Xtensive.Orm.Manual.Prefetch
     [Association(PairTo = "Manager")]
     public EntitySet<Person> Employees { get; private set; }
 
-    public Key ManagerKey { 
-      get { return GetReferenceKey(TypeInfo.Fields["Manager"]); } 
-    }
+    public Key ManagerKey => GetReferenceKey(TypeInfo.Fields["Manager"]);
 
     public Person(Session session)
       : base(session)
@@ -52,63 +50,84 @@ namespace Xtensive.Orm.Manual.Prefetch
   #endregion
 
   [TestFixture]
-  public class PrefetchTest
+  public class PrefetchTest : AutoBuildTest
   {
-    [Test]
-    public void MainTest()
+    protected override Configuration.DomainConfiguration BuildConfiguration()
     {
       var config = DomainConfigurationFactory.CreateWithoutSessionConfigurations();
       config.UpgradeMode = DomainUpgradeMode.Recreate;
       config.Types.Register(typeof(Person).Assembly, typeof(Person).Namespace);
-      var domain = Domain.Build(config);
+      return config;
+    }
 
-      using (var session = domain.OpenSession())
+    [TearDown]
+    public void ClearContent()
+    {
+      using(var session = Domain.OpenSession())
+      using(var tx = session.OpenTransaction()) {
+        var people = session.Query.All<Person>().ToList();
+        foreach(var person in people) {
+          person.Manager = null;
+        }
+        session.SaveChanges();
+
+        foreach (var person in people) {
+          person.Remove();
+        }
+        tx.Complete();
+      }
+    }
+
+    [Test]
+    public void MainTest()
+    {
+      using (var session = Domain.OpenSession())
       using (var transactionScope = session.OpenTransaction()) {
-
-        var employee = new Person(session) {Name = "Employee", Photo = new byte[] {8, 0}};
-        var manager  = new Person(session) {Name = "Manager",  Photo = new byte[] {8, 0}};
-        manager.Employees.Add(employee);
+        var employee = new Person(session) { Name = "Employee", Photo = new byte[] { 8, 0 } };
+        var manager = new Person(session) { Name = "Manager", Photo = new byte[] { 8, 0 } };
+        _ = manager.Employees.Add(employee);
         transactionScope.Complete();
       }
-  
-      using (var session = domain.OpenSession())
+
+      using (var session = Domain.OpenSession())
       using (var transactionScope = session.OpenTransaction()) {
-        var persons = session.Query.All<Person>()
+        var people = session.Query.All<Person>()
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees // EntitySet Employees
             .Prefetch(e => e.Photo)) // and lazy load field of each of its items
           .Prefetch(p => p.Manager); // Referenced entity
-        foreach (var person in persons) {
+        foreach (var person in people) {
           // some code here...
         }
         transactionScope.Complete();
       }
 
-      using (var session = domain.OpenSession())
+      using (var session = Domain.OpenSession())
       using (var transactionScope = session.OpenTransaction()) {
         var personIds = session.Query.All<Person>().Select(p => p.Id);
-        var prefetchedPersons = session.Query.Many<Person, int>(personIds)
+        var prefetchedPeople = session.Query.Many<Person, int>(personIds)
           .Prefetch(p => new { p.Photo, p.Manager }) // Lazy load field and Referenced entity
           .Prefetch(p => p.Employees // EntitySet Employees
             .Prefetch(e => new { e.Photo, e.Manager })); // and lazy load field and referenced entity of each of its items
-        foreach (var person in prefetchedPersons) {
+        foreach (var person in prefetchedPeople) {
           // some code here...
         }
         transactionScope.Complete();
       }
 
-      using (var session = domain.OpenSession())
+      using (var session = Domain.OpenSession())
       using (var transactionScope = session.OpenTransaction()) {
-        var persons = session.Query.All<Person>()
+        var people = session.Query.All<Person>()
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees.Prefetch(e => e.Photo)) // EntitySet Employees and lazy load field of each of its items with the limit on number of items to be loaded
           .Prefetch(p => p.Manager.Photo); // Referenced entity and lazy load field for each of them
-        foreach (var person in persons) {
-          Assert.IsTrue(DirectStateAccessor.Get(person).GetFieldState("Photo")==PersistentFieldState.Loaded);
-          Assert.IsTrue(DirectStateAccessor.Get(person).GetFieldState("Manager")==PersistentFieldState.Loaded);
+        foreach (var person in people) {
+          var accessor = DirectStateAccessor.Get(person);
+          Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
+          Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
           if (person.ManagerKey != null) {
             Assert.IsNotNull(DirectStateAccessor.Get(session)[person.ManagerKey]);
-            Assert.IsTrue(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo")==PersistentFieldState.Loaded);
+            Assert.That(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
           }
           // some code here...
         }
@@ -119,59 +138,55 @@ namespace Xtensive.Orm.Manual.Prefetch
     [Test]
     public async Task MainAsyncTest()
     {
-      var config = DomainConfigurationFactory.CreateWithoutSessionConfigurations();
-      config.UpgradeMode = DomainUpgradeMode.Recreate;
-      config.Types.Register(typeof(Person).Assembly, typeof(Person).Namespace);
-      var domain = Domain.Build(config);
-
-      await using (var session = await domain.OpenSessionAsync())
+      await using (var session = await Domain.OpenSessionAsync())
       using (var transactionScope = session.OpenTransaction()) {
-        var employee = new Person(session) {Name = "Employee", Photo = new byte[] {8, 0}};
-        var manager = new Person(session) {Name = "Manager", Photo = new byte[] {8, 0}};
-        manager.Employees.Add(employee);
+        var employee = new Person(session) { Name = "Employee", Photo = new byte[] { 8, 0 } };
+        var manager = new Person(session) { Name = "Manager", Photo = new byte[] { 8, 0 } };
+        _ = manager.Employees.Add(employee);
         transactionScope.Complete();
       }
 
-      await using (var session = await domain.OpenSessionAsync())
+      await using (var session = await Domain.OpenSessionAsync())
       using (var transactionScope = session.OpenTransaction()) {
-        var persons = session.Query.All<Person>()
+        var people = session.Query.All<Person>()
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees // EntitySet Employees
             .Prefetch(e => e.Photo)) // and lazy load field of each of its items
           .Prefetch(p => p.Manager) // Referenced entity
           .ExecuteAsync();
-        foreach (var person in await persons) {
+        foreach (var person in await people) {
           // some code here...
         }
         transactionScope.Complete();
       }
 
-      await using (var session = await domain.OpenSessionAsync())
+      await using (var session = await Domain.OpenSessionAsync())
       using (var transactionScope = session.OpenTransaction()) {
         var personIds = session.Query.All<Person>().Select(p => p.Id);
-        var prefetchedPersons = session.Query.Many<Person, int>(personIds)
-          .Prefetch(p => new {p.Photo, p.Manager}) // Lazy load field and Referenced entity
+        var prefetchedPeople = session.Query.Many<Person, int>(personIds)
+          .Prefetch(p => new { p.Photo, p.Manager }) // Lazy load field and Referenced entity
           .Prefetch(p => p.Employees // EntitySet Employees
-            .Prefetch(e => new {e.Photo, e.Manager})) // and lazy load field and referenced entity of each of its items
+            .Prefetch(e => new { e.Photo, e.Manager })) // and lazy load field and referenced entity of each of its items
           .ExecuteAsync();
-        foreach (var person in await prefetchedPersons) {
+        foreach (var person in await prefetchedPeople) {
           // some code here...
         }
         transactionScope.Complete();
       }
 
-      await using (var session = await domain.OpenSessionAsync())
+      await using (var session = await Domain.OpenSessionAsync())
       using (var transactionScope = session.OpenTransaction()) {
-        var persons = session.Query.All<Person>()
+        var people = session.Query.All<Person>()
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees.Prefetch(e => e.Photo)) // EntitySet Employees and lazy load field of each of its items with the limit on number of items to be loaded
           .Prefetch(p => p.Manager.Photo); // Referenced entity and lazy load field for each of them
-        await foreach (var person in persons.AsAsyncEnumerable()) {
-          Assert.IsTrue(DirectStateAccessor.Get(person).GetFieldState("Photo")==PersistentFieldState.Loaded);
-          Assert.IsTrue(DirectStateAccessor.Get(person).GetFieldState("Manager")==PersistentFieldState.Loaded);
-          if (person.ManagerKey!=null) {
+        await foreach (var person in people.AsAsyncEnumerable()) {
+          var accessor = DirectStateAccessor.Get(person);
+          Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
+          Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
+          if (person.ManagerKey != null) {
             Assert.IsNotNull(DirectStateAccessor.Get(session)[person.ManagerKey]);
-            Assert.IsTrue(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo")==PersistentFieldState.Loaded);
+            Assert.That(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
           }
           // some code here...
         }
@@ -182,30 +197,29 @@ namespace Xtensive.Orm.Manual.Prefetch
     [Test]
     public void MultipleBatchesTest()
     {
-      var config = DomainConfigurationFactory.CreateWithoutSessionConfigurations();
-      config.UpgradeMode = DomainUpgradeMode.Recreate;
-      config.Types.Register(typeof (Person).Assembly, typeof (Person).Namespace);
-      var domain = Domain.Build(config);
+      var count = 1000;
 
-      int count = 1000;
-
-      using (var session = domain.OpenSession())
+      using (var session = Domain.OpenSession())
       using (var transactionScope = session.OpenTransaction()) {
+        var people = new Person[count];
+        for (var i = 0; i < count; i++) {
+          people[i] = new Person(session) { Name = i.ToString(), Photo = new[] { (byte) (i % 256) } };
+        }
+        session.SaveChanges();
+
         var random = new Random(10);
-        for (int i = 0; i < count; i++)
-          new Person(session) {Name = i.ToString(), Photo = new[] {(byte) (i % 256)}};
-        var persons = session.Query.All<Person>().OrderBy(p => p.Id).ToArray();
-        for (int i = 0; i<count; i++) {
-          var person = persons[i];
-          if (random.Next(5)>0)
-            person.Manager = persons[random.Next(count)];
+        for (var i = 0; i < count; i++) {
+          var person = people[i];
+          if (random.Next(5) > 0) {
+            person.Manager = people[random.Next(count)];
+          }
         }
         transactionScope.Complete();
       }
 
-      using (var session = domain.OpenSession())
+      using (var session = Domain.OpenSession())
       using (var transactionScope = session.OpenTransaction()) {
-        var prefetchedPersons = (
+        var prefetchedPeople = (
           from person in session.Query.All<Person>()
           orderby person.Name
           select person)
@@ -214,12 +228,14 @@ namespace Xtensive.Orm.Manual.Prefetch
           .Prefetch(p => p.Employees // EntitySet Employees
             .Prefetch(e => e.Photo)) // and lazy load field of each of its items
           .Prefetch(p => p.Manager); // Referenced entity
-        foreach (var person in prefetchedPersons) {
-          Assert.IsTrue(DirectStateAccessor.Get(person).GetFieldState("Photo")==PersistentFieldState.Loaded);
-          Assert.IsTrue(DirectStateAccessor.Get(person).GetFieldState("Manager")==PersistentFieldState.Loaded);
+        foreach (var person in prefetchedPeople) {
+          var accessor = DirectStateAccessor.Get(person);
+          Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
+          Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
           Assert.IsTrue(DirectStateAccessor.Get(person.Employees).IsFullyLoaded);
-          foreach (var employee in person.Employees)
-            Assert.IsTrue(DirectStateAccessor.Get(employee).GetFieldState("Photo")==PersistentFieldState.Loaded);
+          foreach (var employee in person.Employees) {
+            Assert.That(DirectStateAccessor.Get(employee).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
+          }
         }
         transactionScope.Complete();
       }
@@ -228,30 +244,29 @@ namespace Xtensive.Orm.Manual.Prefetch
     [Test]
     public async Task MultipleBatchesAsyncTest()
     {
-      var config = DomainConfigurationFactory.CreateWithoutSessionConfigurations();
-      config.UpgradeMode = DomainUpgradeMode.Recreate;
-      config.Types.Register(typeof(Person).Assembly, typeof(Person).Namespace);
-      var domain = Domain.Build(config);
+      var count = 1000;
 
-      int count = 1000;
-
-      await using (var session = await domain.OpenSessionAsync())
+      await using (var session = await Domain.OpenSessionAsync())
       using (var transactionScope = session.OpenTransaction()){
+        var people = new Person[count];
+        for (var i = 0; i < count; i++) {
+          people[i] = new Person(session) { Name = i.ToString(), Photo = new[] { (byte) (i % 256) } };
+        }
+        session.SaveChanges();
+
         var random = new Random(10);
-        for (int i = 0; i < count; i++)
-          new Person(session) { Name = i.ToString(), Photo = new[] { (byte)(i % 256) } };
-        var persons = session.Query.All<Person>().OrderBy(p => p.Id).ToArray();
-        for (int i = 0; i < count; i++) {
-          var person = persons[i];
-          if (random.Next(5) > 0)
-            person.Manager = persons[random.Next(count)];
+        for (var i = 0; i < count; i++) {
+          var person = people[i];
+          if (random.Next(5) > 0) {
+            person.Manager = people[random.Next(count)];
+          }
         }
         transactionScope.Complete();
       }
 
-      await using (var session = await domain.OpenSessionAsync())
+      await using (var session = await Domain.OpenSessionAsync())
       using (var transactionScope = session.OpenTransaction()) {
-        var prefetchedPersons = (
+        var prefetchedPeople = (
           from person in session.Query.All<Person>()
           orderby person.Name
           select person)
@@ -260,13 +275,102 @@ namespace Xtensive.Orm.Manual.Prefetch
           .Prefetch(p => p.Employees // EntitySet Employees
             .Prefetch(e => e.Photo)) // and lazy load field of each of its items
           .Prefetch(p => p.Manager); // Referenced entity
-        await foreach (var person in prefetchedPersons.AsAsyncEnumerable()) {
-          Assert.IsTrue(DirectStateAccessor.Get(person).GetFieldState("Photo")==PersistentFieldState.Loaded);
-          Assert.IsTrue(DirectStateAccessor.Get(person).GetFieldState("Manager")==PersistentFieldState.Loaded);
+        await foreach (var person in prefetchedPeople.AsAsyncEnumerable()) {
+          var accessor = DirectStateAccessor.Get(person);
+          Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
+          Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
           Assert.IsTrue(DirectStateAccessor.Get(person.Employees).IsFullyLoaded);
           foreach (var employee in person.Employees) {
-            Assert.IsTrue(DirectStateAccessor.Get(employee).GetFieldState("Photo")==PersistentFieldState.Loaded);
+            Assert.That(DirectStateAccessor.Get(employee).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
           }
+        }
+        transactionScope.Complete();
+      }
+    }
+
+    [Test]
+    public void DelayedQueryTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transactionScope = session.OpenTransaction()) {
+        var employee = new Person(session) { Name = "Employee", Photo = new byte[] { 8, 0 } };
+        var manager = new Person(session) { Name = "Manager", Photo = new byte[] { 8, 0 } };
+        _ = manager.Employees.Add(employee);
+        transactionScope.Complete();
+      }
+
+      using (var session = Domain.OpenSession())// no session activation!
+      using (var transactionScope = session.OpenTransaction()) {
+        var people = session.Query.CreateDelayedQuery(q => q.All<Person>())
+          .Prefetch(p => p.Photo) // Lazy load field
+          .Prefetch(p => p.Employees // EntitySet Employees
+            .Prefetch(e => e.Photo)) // and lazy load field of each of its items
+          .Prefetch(p => p.Manager); // Referenced entity
+        foreach (var person in people) {
+          // some code here...
+        }
+        transactionScope.Complete();
+      }
+
+      using (var session = Domain.OpenSession())// no session activation!
+      using (var transactionScope = session.OpenTransaction()) {
+        var people = session.Query.CreateDelayedQuery(q => q.All<Person>())
+          .Prefetch(p => p.Photo) // Lazy load field
+          .Prefetch(p => p.Employees.Prefetch(e => e.Photo)) // EntitySet Employees and lazy load field of each of its items with the limit on number of items to be loaded
+          .Prefetch(p => p.Manager.Photo); // Referenced entity and lazy load field for each of them
+        foreach (var person in people) {
+          var accessor = DirectStateAccessor.Get(person);
+          Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
+          Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
+          if (person.ManagerKey != null) {
+            Assert.IsNotNull(DirectStateAccessor.Get(session)[person.ManagerKey]);
+            Assert.That(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
+          }
+          // some code here...
+        }
+        transactionScope.Complete();
+      }
+    }
+
+    [Test]
+    public async Task DelayedQueryAsyncTest()
+    {
+      await using (var session = await Domain.OpenSessionAsync())
+      using (var transactionScope = session.OpenTransaction()) {
+        var employee = new Person(session) { Name = "Employee", Photo = new byte[] { 8, 0 } };
+        var manager = new Person(session) { Name = "Manager", Photo = new byte[] { 8, 0 } };
+        _ = manager.Employees.Add(employee);
+        transactionScope.Complete();
+      }
+
+      await using (var session = await Domain.OpenSessionAsync())// no session activation!
+      using (var transactionScope = session.OpenTransaction()) {
+        var people = session.Query.CreateDelayedQuery(q => q.All<Person>())
+          .Prefetch(p => p.Photo) // Lazy load field
+          .Prefetch(p => p.Employees // EntitySet Employees
+            .Prefetch(e => e.Photo)) // and lazy load field of each of its items
+          .Prefetch(p => p.Manager); // Referenced entity
+        foreach (var person in people) {
+          // some code here...
+        }
+        transactionScope.Complete();
+      }
+
+      await using (var session = await Domain.OpenSessionAsync())// no session activation!
+      using (var transactionScope = session.OpenTransaction()) {
+        var people = session.Query.CreateDelayedQuery(q => q.All<Person>())
+          .Prefetch(p => p.Photo) // Lazy load field
+          .Prefetch(p => p.Employees.Prefetch(e => e.Photo)) // EntitySet Employees and lazy load field of each of its items with the limit on number of items to be loaded
+          .Prefetch(p => p.Manager.Photo); // Referenced entity and lazy load field for each of them
+        await foreach (var person in people.AsAsyncEnumerable()) {
+          var accessor = DirectStateAccessor.Get(person);
+          Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
+          Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
+          if (person.ManagerKey != null) {
+            Assert.IsNotNull(DirectStateAccessor.Get(session)[person.ManagerKey]);
+            Assert.That(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
+          }
+          // some code here...
         }
         transactionScope.Complete();
       }

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
@@ -14,7 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xtensive.Collections;
 using Xtensive.Collections.Graphs;
-using Xtensive.Orm.Internals;
+using Xtensive.Orm;
 
 
 namespace Xtensive.Core

--- a/Orm/Xtensive.Orm/Orm/DelayedQuery{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/DelayedQuery{T}.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
@@ -10,9 +10,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xtensive.Core;
+using Xtensive.Orm.Internals;
 using Xtensive.Orm.Linq;
 
-namespace Xtensive.Orm.Internals
+namespace Xtensive.Orm
 {
   /// <summary>
   /// Represents a delayed sequence query (query where result can be enumerated after an execution).

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializingReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializingReader.cs
@@ -13,6 +13,7 @@ namespace Xtensive.Orm.Linq.Materialization
 {
   internal interface IMaterializingReader<out TItem>
   {
+    Session Session { get; }
     IEnumerator<TItem> AsEnumerator();
     IAsyncEnumerator<TItem> AsAsyncEnumerator();
   }
@@ -24,6 +25,8 @@ namespace Xtensive.Orm.Linq.Materialization
     private readonly ParameterContext parameterContext;
     private readonly IItemMaterializer<TItem> itemMaterializer;
     private readonly Queue<Action> materializationQueue;
+
+    public Session Session => context.Session;
 
     public IEnumerator<TItem> AsEnumerator()
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializingReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializingReader.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Xtensive LLC.
+// Copyright (C) 2020-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
@@ -11,13 +11,13 @@ using Xtensive.Orm.Rse;
 
 namespace Xtensive.Orm.Linq.Materialization
 {
-  public interface IMaterializingReader<out TItem>
+  internal interface IMaterializingReader<out TItem>
   {
     IEnumerator<TItem> AsEnumerator();
     IAsyncEnumerator<TItem> AsAsyncEnumerator();
   }
 
-  public class MaterializingReader<TItem>: IMaterializingReader<TItem>, IEnumerator<TItem>, IAsyncEnumerator<TItem>
+  internal class MaterializingReader<TItem>: IMaterializingReader<TItem>, IEnumerator<TItem>, IAsyncEnumerator<TItem>
   {
     private readonly RecordSetReader recordSetReader;
     private readonly MaterializationContext context;

--- a/Orm/Xtensive.Orm/Orm/PrefetchExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/PrefetchExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
@@ -35,6 +35,21 @@ namespace Xtensive.Orm
       }
 
       return Prefetch(source, Session.Demand(), expression);
+    }
+
+    /// <summary>
+    /// Registers fields specified by <paramref name="expression"/> for prefetch.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the element of the source sequence.</typeparam>
+    /// <typeparam name="TFieldValue">The type of the field's value to be prefetched.</typeparam>
+    /// <param name="source">The source query.</param>
+    /// <param name="expression">The expression specifying a field to be prefetched.</param>
+    /// <returns>An <see cref="IEnumerable{TElement}"/> of source items.</returns>
+    public static PrefetchQuery<TElement> Prefetch<TElement, TFieldValue>(
+      this DelayedQuery<TElement> source,
+      Expression<Func<TElement, TFieldValue>> expression)
+    {
+      return new PrefetchQuery<TElement>(source.Session, source).RegisterPath(expression);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/PrefetchExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/PrefetchExtensions.cs
@@ -57,6 +57,27 @@ namespace Xtensive.Orm
     /// </summary>
     /// <typeparam name="TElement">The type of the element of the source sequence.</typeparam>
     /// <typeparam name="TFieldValue">The type of the field's value to be prefetched.</typeparam>
+    /// <param name="source">The source query.</param>
+    /// <param name="expression">The expression specifying a field to be prefetched.</param>
+    /// <returns>An <see cref="IEnumerable{TElement}"/> of source items.</returns>
+    public static PrefetchQuery<TElement> Prefetch<TElement, TFieldValue>(
+      this QueryResult<TElement> source,
+      Expression<Func<TElement, TFieldValue>> expression)
+    {
+      var session = source.Reader.Session;
+      if (session != null) {
+        return new PrefetchQuery<TElement>(session, source).RegisterPath(expression);
+      }
+      return new PrefetchQuery<TElement>(Session.Demand(), source).RegisterPath(expression);
+    }
+
+
+
+    /// <summary>
+    /// Registers fields specified by <paramref name="expression"/> for prefetch.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the element of the source sequence.</typeparam>
+    /// <typeparam name="TFieldValue">The type of the field's value to be prefetched.</typeparam>
     /// <param name="source">The source sequence.</param>
     /// <param name="expression">The expression specifying a field to be prefetched.</param>
     /// <returns>An <see cref="IEnumerable{TElement}"/> of source items.</returns>

--- a/Orm/Xtensive.Orm/Orm/PrefetchExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/PrefetchExtensions.cs
@@ -64,7 +64,7 @@ namespace Xtensive.Orm
       this QueryResult<TElement> source,
       Expression<Func<TElement, TFieldValue>> expression)
     {
-      var session = source.Reader.Session;
+      var session = source.Session;
       if (session != null) {
         return new PrefetchQuery<TElement>(session, source).RegisterPath(expression);
       }


### PR DESCRIPTION
Helps to avoid session activation in cases like
```csharp
var result = session.Query.CreateDelayedQuery(q => q.All<Authors>().Where(s => s.Id.In(request.AuthorsToFetch)))
    .Prefetch(s => s.Books)
    .ToList();
```