### PR TITLE
Fixes some problems that caused failed tests in Xtensive.Orm.Tests.Core

### DIFF
--- a/Extensions/TestCommon/TestCommon.csproj
+++ b/Extensions/TestCommon/TestCommon.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Extensions/Xtensive.Orm.BulkOperations.Tests/Xtensive.Orm.BulkOperations.Tests.csproj
+++ b/Extensions/Xtensive.Orm.BulkOperations.Tests/Xtensive.Orm.BulkOperations.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Localization.Tests/Xtensive.Orm.Localization.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Localization.Tests/Xtensive.Orm.Localization.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Logging.NLog.Tests/Xtensive.Orm.Logging.NLog.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Logging.NLog.Tests/Xtensive.Orm.Logging.NLog.Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Logging.log4net.Tests/Xtensive.Orm.Logging.log4net.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Logging.log4net.Tests/Xtensive.Orm.Logging.log4net.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Xtensive.Orm.Reprocessing.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Xtensive.Orm.Reprocessing.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Security.Tests/Xtensive.Orm.Security.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Security.Tests/Xtensive.Orm.Security.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Tracking.Tests/Xtensive.Orm.Tracking.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Tracking.Tests/Xtensive.Orm.Tracking.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Orm/Xtensive.Orm.Tests.Core/Collections/ChainedBufferTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Collections/ChainedBufferTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alena Mikshina
@@ -10,7 +10,7 @@ using System.Linq;
 using NUnit.Framework;
 using Xtensive.Collections;
 
-namespace Xtensive.Tests.Collections
+namespace Xtensive.Orm.Tests.Core.Collections
 {
   [TestFixture]
   public class ChainedBufferTest

--- a/Orm/Xtensive.Orm.Tests.Core/Comparison/ComparerProviderTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Comparison/ComparerProviderTests.cs
@@ -1,10 +1,12 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2007.12.17
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using NUnit.Framework;
 using Xtensive.Comparison;
@@ -26,7 +28,33 @@ namespace Xtensive.Orm.Tests.Core.Comparison
     [Test]
     public void SerializationTest()
     {
-      AdvancedComparer<short> comparer = AdvancedComparer<short>.Default;
+      SerializationTest<int[]>();
+      SerializationTest<Guid>();
+      SerializationTest<bool>();
+      SerializationTest<byte>();
+      SerializationTest<sbyte>();
+      SerializationTest<short>();
+      SerializationTest<int>();
+      SerializationTest<long>();
+      SerializationTest<ushort>();
+      SerializationTest<uint>();
+      SerializationTest<ulong>();
+      SerializationTest<float>();
+      SerializationTest<double>();
+      SerializationTest<decimal>();
+      SerializationTest<Direction>();
+      SerializationTest<IEnumerable<int>>();
+      SerializationTest<char>();
+      SerializationTest<string>();
+      SerializationTest<short?>();
+      SerializationTest<Pair<int>>();
+      SerializationTest<Pair<int, long>>();
+      SerializationTest<Xtensive.Tuples.Tuple>();
+    }
+
+    private void SerializationTest<T>()
+    {
+      var comparer = AdvancedComparer<T>.Default;
       Assert.IsNotNull(comparer.Compare);
       var deserializedComparer = Cloner.Clone(comparer);
       Assert.IsNotNull(deserializedComparer.Compare);
@@ -38,7 +66,7 @@ namespace Xtensive.Orm.Tests.Core.Comparison
     public void GettingDefaultComparerPerformanceTest()
     {
       GettingDefaultComparerLoop(100);
-      int count = 1000000;
+      var count = 1000000;
       using (new Measurement("Getting default comparer", count)) {
         GettingDefaultComparerLoop(count);
       }
@@ -46,42 +74,43 @@ namespace Xtensive.Orm.Tests.Core.Comparison
 
     private static void GettingDefaultComparerLoop(int count)
     {
-      for (int i = 0; i < count; i++) {
-        ComparerProvider.Default.GetComparer<bool>();
-        ComparerProvider.Default.GetComparer<byte>();
-        ComparerProvider.Default.GetComparer<char>();
-        ComparerProvider.Default.GetComparer<short>();
-        ComparerProvider.Default.GetComparer<ushort>();
-        ComparerProvider.Default.GetComparer<int>();
-        ComparerProvider.Default.GetComparer<uint>();
-        ComparerProvider.Default.GetComparer<long>();
-        ComparerProvider.Default.GetComparer<ulong>();
-        ComparerProvider.Default.GetComparer<string>();
+      for (var i = 0; i < count; i++) {
+        _ = ComparerProvider.Default.GetComparer<bool>();
+        _ = ComparerProvider.Default.GetComparer<byte>();
+        _ = ComparerProvider.Default.GetComparer<char>();
+        _ = ComparerProvider.Default.GetComparer<short>();
+        _ = ComparerProvider.Default.GetComparer<ushort>();
+        _ = ComparerProvider.Default.GetComparer<int>();
+        _ = ComparerProvider.Default.GetComparer<uint>();
+        _ = ComparerProvider.Default.GetComparer<long>();
+        _ = ComparerProvider.Default.GetComparer<ulong>();
+        _ = ComparerProvider.Default.GetComparer<string>();
       }
     }
 
 
     private class TestClass
     {
+#pragma warning disable IDE0044, IDE0051 // Add readonly modifier + Remove unused private members
       private string x;
       private int y;
+#pragma warning restore IDE0044, IDE0051 // Add readonly modifier + Remove unused private members
     }
-     
 
     [Test]
     public void ClassTest()
     {
-      AdvancedComparerStruct<TestClass> dd = AdvancedComparerStruct<TestClass>.System;
+      _ = AdvancedComparerStruct<TestClass>.System;
     }
 
     [Test]
     public void Int32ComparerTest()
     {
-      int o1 = 1;
-      int o2 = 2;
-      AdvancedComparer<int> comparer = AdvancedComparer<int>.Default;
+      var o1 = 1;
+      var o2 = 2;
+      var comparer = AdvancedComparer<int>.Default;
       Assert.IsNotNull(comparer);
-      Assert.AreEqual("Int32Comparer", comparer.Implementation.GetType().Name);
+      Assert.AreEqual(nameof(Int32Comparer), comparer.Implementation.GetType().Name);
       Assert.Greater(comparer.Compare(o2,o1), 0);
       Assert.IsTrue(comparer.ValueRangeInfo.HasMinValue);
       Assert.IsTrue(comparer.ValueRangeInfo.HasMaxValue);
@@ -95,22 +124,22 @@ namespace Xtensive.Orm.Tests.Core.Comparison
     [Test]
     public void StringComparerTest()
     {
-      string o1 = "1";
-      string o2 = "2";
-      AdvancedComparer<string> comparer = AdvancedComparer<string>.Default;
+      var o1 = "1";
+      var o2 = "2";
+      var comparer = AdvancedComparer<string>.Default;
       Assert.IsNotNull(comparer);
       Assert.AreEqual("StringComparer", comparer.Implementation.GetType().Name);
       Assert.Greater(comparer.Compare(o2,o1), 0);
       Assert.IsTrue(comparer.ValueRangeInfo.HasMinValue);
       Assert.IsFalse(comparer.ValueRangeInfo.HasMaxValue);
       Assert.AreEqual(null, comparer.ValueRangeInfo.MinValue);
-      AssertEx.ThrowsInvalidOperationException(delegate {string s = comparer.ValueRangeInfo.MaxValue;});
+      AssertEx.ThrowsInvalidOperationException(delegate { var s = comparer.ValueRangeInfo.MaxValue; });
 
-      char z = char.MaxValue;
-      char y = unchecked ((char) (char.MaxValue - 1));
-      char a = char.MinValue;
-            
-      string str = "BCD";
+      var z = char.MaxValue;
+      var y = unchecked ((char) (char.MaxValue - 1));
+      var a = char.MinValue;
+
+      var str = "BCD";
       str = comparer.GetNearestValue(str, Direction.Negative);
       Assert.AreEqual("BCC" + z, str);
       str = comparer.GetNearestValue(str, Direction.Negative);
@@ -135,95 +164,13 @@ namespace Xtensive.Orm.Tests.Core.Comparison
       Assert.IsNull(comparer.GetNearestValue(string.Empty, Direction.Negative));
       Assert.AreEqual(string.Empty, comparer.GetNearestValue(null, Direction.Positive));
       Assert.AreEqual(char.MaxValue.ToString(), comparer.GetNearestValue(char.MaxValue.ToString(), Direction.Positive));
-      AssertEx.Throws<ArgumentOutOfRangeException>(delegate { comparer.GetNearestValue(str, Direction.None); });
+      AssertEx.Throws<ArgumentOutOfRangeException>(delegate { _ = comparer.GetNearestValue(str, Direction.None); });
     }
-
-//    [Test]
-//    public void EntireComparerTest()
-//    {
-//      AdvancedComparer<Entire<int>> comparer = AdvancedComparer<Entire<int>>.Default;
-//      Assert.IsNotNull(comparer);
-//      Assert.AreEqual("EntireComparer`1", comparer.Implementation.GetType().Name);
-//      Assert.AreEqual(comparer.Compare((Entire<int>)Entire<int>.Create(InfinityType.Positive), (Entire<int>)Entire<int>.Create(InfinityType.Positive)), 0);
-//      Assert.AreEqual(comparer.Compare((Entire<int>)Entire<int>.Create(InfinityType.Negative), (Entire<int>)Entire<int>.Create(InfinityType.Negative)), 0);
-//      Assert.Greater(comparer.Compare((Entire<int>)Entire<int>.Create(InfinityType.Positive), (Entire<int>)Entire<int>.Create(InfinityType.Negative)), 0);
-//      Assert.Greater(comparer.Compare((Entire<int>)Entire<int>.Create(InfinityType.Positive), (Entire<int>)Entire<int>.Create(100)), 0);
-//      Assert.Less(comparer.Compare((Entire<int>)Entire<int>.Create(InfinityType.Negative), (Entire<int>)Entire<int>.Create(InfinityType.Positive)), 0);
-//      Assert.Less(comparer.Compare((Entire<int>)Entire<int>.Create(InfinityType.Negative), (Entire<int>)Entire<int>.Create(100)), 0);
-//      Assert.IsTrue(comparer.ValueRangeInfo.HasMinValue);
-//      Assert.IsTrue(comparer.ValueRangeInfo.HasMaxValue);
-//      Assert.IsTrue(comparer.ValueRangeInfo.HasDeltaValue);
-//      Assert.AreEqual(Entire<int>.MinValue, comparer.ValueRangeInfo.MinValue);
-//      Assert.AreEqual(Entire<int>.MaxValue, comparer.ValueRangeInfo.MaxValue);
-//      Assert.AreEqual(Entire<int>.Create(1), comparer.ValueRangeInfo.DeltaValue);      
-//    }
-
-//    [Test]
-//    public void EntireInterfaceComparerTest()
-//    {
-//      AdvancedComparer<IEntire<int>> comparer = AdvancedComparer<IEntire<int>>.Default;
-//      Assert.IsNotNull(comparer);
-//      Assert.AreEqual("EntireInterfaceComparer`1", comparer.Implementation.GetType().Name);
-//      Assert.AreEqual(comparer.Compare(Entire<int>.Create(InfinityType.Positive), Entire<int>.Create(InfinityType.Positive)), 0);
-//      Assert.AreEqual(comparer.Compare(Entire<int>.Create(InfinityType.Negative), Entire<int>.Create(InfinityType.Negative)), 0);
-//      Assert.Greater(comparer.Compare(Entire<int>.Create(InfinityType.Positive), Entire<int>.Create(InfinityType.Negative)), 0);
-//      Assert.Greater(comparer.Compare(Entire<int>.Create(InfinityType.Positive), Entire<int>.Create(100)), 0);
-//      Assert.Less(comparer.Compare(Entire<int>.Create(InfinityType.Negative), Entire<int>.Create(InfinityType.Positive)), 0);
-//      Assert.Less(comparer.Compare(Entire<int>.Create(InfinityType.Negative), Entire<int>.Create(100)), 0);
-//      Assert.AreNotEqual(comparer.Compare(new Entire<int>(1, Direction.Positive), new Entire<int>(2)), 0);
-//      Assert.IsTrue(comparer.ValueRangeInfo.HasMinValue);
-//      Assert.IsTrue(comparer.ValueRangeInfo.HasMaxValue);
-//      Assert.IsTrue(comparer.ValueRangeInfo.HasDeltaValue);
-//      Assert.AreEqual(Entire<int>.MinValue, comparer.ValueRangeInfo.MinValue);
-//      Assert.AreEqual(Entire<int>.MaxValue, comparer.ValueRangeInfo.MaxValue);
-//      Assert.AreEqual(Entire<int>.Create(1), comparer.ValueRangeInfo.DeltaValue);
-//    }
-
-//    [Test]
-//    public void ReversedComparerTest()
-//    {
-//      {
-//        AdvancedComparer<Reversed<int>> comparer = AdvancedComparer<Reversed<int>>.Default;
-//        Assert.IsNotNull(comparer);
-//        Assert.AreEqual("ReversedComparer`1", comparer.Implementation.GetType().Name);
-//        Assert.Less(comparer.Compare(10, 1), 0);
-//        Assert.Greater(comparer.Compare(1, 10), 0);
-//        Assert.AreEqual(comparer.Compare(10, 10), 0);
-//        Assert.IsTrue(comparer.ValueRangeInfo.HasMinValue);
-//        Assert.IsTrue(comparer.ValueRangeInfo.HasMaxValue);
-//        Assert.IsTrue(comparer.ValueRangeInfo.HasDeltaValue);
-//        Assert.AreEqual(new Reversed<int>(int.MaxValue), new Reversed<int>(int.MaxValue));
-//        Assert.AreEqual(new Reversed<int>(int.MaxValue), comparer.ValueRangeInfo.MinValue);
-//        Assert.AreEqual(new Reversed<int>(int.MinValue), comparer.ValueRangeInfo.MaxValue);
-//        Assert.AreEqual(new Reversed<int>(1), comparer.ValueRangeInfo.DeltaValue);
-//      }
-//
-//      {
-//        AdvancedComparer<Reversed<int?>> comparer = AdvancedComparer<Reversed<int?>>.Default;
-//        Assert.IsNotNull(comparer);
-//        Assert.AreEqual("ReversedComparer`1", comparer.Implementation.GetType().Name);
-//        Assert.Less(comparer.Compare(10, 1), 0);
-//        Assert.Greater(comparer.Compare(1, 10), 0);
-//        Assert.AreEqual(comparer.Compare(10, 10), 0);
-//        Assert.Greater(comparer.Compare(1, 10), 0);
-//        Assert.Less(comparer.Compare(10, 1), 0);
-//        Assert.AreEqual(comparer.Compare(10, 10), 0);
-//        Assert.Greater(comparer.Compare(null, 10), 0);
-//        Assert.AreEqual(comparer.Compare(null, null), 0);
-//        Assert.Less(comparer.Compare(10, null), 0);
-//        Assert.IsTrue(comparer.ValueRangeInfo.HasMinValue);
-//        Assert.IsTrue(comparer.ValueRangeInfo.HasMaxValue);
-//        Assert.IsTrue(comparer.ValueRangeInfo.HasDeltaValue);
-//        Assert.AreEqual(new Reversed<int?>(int.MaxValue), comparer.ValueRangeInfo.MinValue);
-//        Assert.AreEqual(new Reversed<int?>(), comparer.ValueRangeInfo.MaxValue);
-//        Assert.AreEqual(new Reversed<int?>(1), comparer.ValueRangeInfo.DeltaValue);
-//      }
-//    }
 
     [Test]
     public void NullableComparerTest()
     {
-      AdvancedComparer<int?> comparer = AdvancedComparer<int?>.Default;
+      var comparer = AdvancedComparer<int?>.Default;
       Assert.IsNotNull(comparer);
       Assert.AreEqual("NullableComparer`1", comparer.Implementation.GetType().Name);
       Assert.Greater(comparer.Compare(10, 1), 0);
@@ -246,7 +193,7 @@ namespace Xtensive.Orm.Tests.Core.Comparison
     [Test]
     public void EnumComparerTest()
     {
-      AdvancedComparer<Direction> comparer = AdvancedComparer<Direction>.System;
+      var comparer = AdvancedComparer<Direction>.System;
       Assert.IsNotNull(comparer);
       Assert.AreEqual("EnumComparer`2", comparer.Implementation.GetType().Name);
       Assert.Greater(comparer.Compare(Direction.Positive, Direction.Negative), 0);
@@ -273,9 +220,9 @@ namespace Xtensive.Orm.Tests.Core.Comparison
     [Test]
     public void CustomComparerTest()
     {
-      Wrapper<int> o1 = new Wrapper<int>(1);
-      Wrapper<int> o2 = new Wrapper<int>(2);
-      AdvancedComparer<Wrapper<int>> comparer = AdvancedComparer<Wrapper<int>>.Default;
+      var o1 = new Wrapper<int>(1);
+      var o2 = new Wrapper<int>(2);
+      var comparer = AdvancedComparer<Wrapper<int>>.Default;
       Assert.IsNotNull(comparer);
       AssertEx.IsPatternMatch(comparer.Implementation.GetType().Name, "WrapperComparer*");
       Assert.Greater(comparer.Compare(o2,o1), 0);
@@ -284,9 +231,9 @@ namespace Xtensive.Orm.Tests.Core.Comparison
     [Test]
     public void CustomComparerTest2()
     {
-      Wrapper2<int, int> o1 = new Wrapper2<int, int>(0,1);
-      Wrapper2<int, int> o2 = new Wrapper2<int, int>(0,2);
-      AdvancedComparer<Wrapper2<int, int>> comparer = AdvancedComparer<Wrapper2<int, int>>.Default;
+      var o1 = new Wrapper2<int, int>(0,1);
+      var o2 = new Wrapper2<int, int>(0,2);
+      var comparer = AdvancedComparer<Wrapper2<int, int>>.Default;
       Assert.IsNotNull(comparer);
       AssertEx.IsPatternMatch(comparer.Implementation.GetType().Name, "Wrapper2Comparer*");
       Assert.Greater(comparer.Compare(o2,o1), 0);
@@ -295,9 +242,9 @@ namespace Xtensive.Orm.Tests.Core.Comparison
     [Test]
     public void InheritedComparerTest()
     {
-      Wrapper2a<int, int> o1 = new Wrapper2a<int, int>(0,1);
-      Wrapper2a<int, int> o2 = new Wrapper2a<int, int>(0,2);
-      AdvancedComparer<Wrapper2a<int, int>> comparer = AdvancedComparer<Wrapper2a<int, int>>.Default;
+      var o1 = new Wrapper2a<int, int>(0,1);
+      var o2 = new Wrapper2a<int, int>(0,2);
+      var comparer = AdvancedComparer<Wrapper2a<int, int>>.Default;
       Assert.IsNotNull(comparer);
       AssertEx.IsPatternMatch(comparer.Implementation.GetType().Name, "BaseComparerWrapper*");
       Assert.AreEqual(comparer.Compare(o2,o1), 0);
@@ -306,50 +253,12 @@ namespace Xtensive.Orm.Tests.Core.Comparison
     [Test]
     public void CastingComparerTest()
     {
-      Wrapper1<int> o1 = new Wrapper1<int>(1);
-      Wrapper1<int> o2 = new Wrapper1<int>(2);
-      AdvancedComparer<Wrapper<int>> comparer = AdvancedComparer<Wrapper1<int>>.Default.Cast<Wrapper<int>>();
+      var o1 = new Wrapper1<int>(1);
+      var o2 = new Wrapper1<int>(2);
+      var comparer = AdvancedComparer<Wrapper1<int>>.Default.Cast<Wrapper<int>>();
       Assert.IsNotNull(comparer);
       AssertEx.IsPatternMatch(comparer.Implementation.GetType().Name, "CastingComparer*");
       Assert.Greater(comparer.Compare(o2,o1), 0);
-    }
-
-//    [Test]
-//    public void TupleEntireComparerTest()
-//    {
-//      List<Type> fields = new List<Type>(3);
-//      fields.AddRange(new Type[] {typeof(int), typeof(bool), typeof(string)});
-//      TupleDescriptor tupleDescriptor = TupleDescriptor.Create(fields);
-//      Tuple tuple = Tuple.Create(tupleDescriptor);
-//      tuple.SetValue(0, 1);
-//      tuple.SetValue(1, true);
-//      tuple.SetValue(2, "TupleEntire");
-//      IEntire<Tuple> entire1 = Entire<Tuple>.Create(tuple);
-//      IEntire<Tuple> entire2 = Entire<Tuple>.Create(tuple);
-//      AdvancedComparer<IEntire<Tuple>> comparer = AdvancedComparer<IEntire<Tuple>>.Default;
-//      AssertEx.IsPatternMatch(comparer.Implementation.GetType().Name, "EntireInterfaceComparer*");
-//
-////      entire2.Shift(1);
-////      Assert.IsFalse(c.Equals(entire1, entire2));
-////      Assert.AreEqual(-1, c.Compare(entire1, entire2));
-////
-////      entire1.Shift();
-////      Assert.IsFalse(c.Equals(entire1, entire2));
-////      Assert.AreEqual(1, c.Compare(entire1, entire2));
-////
-////      entire2.Shift();
-////      Assert.IsTrue(c.Equals(entire1, entire2));
-////      Assert.AreEqual(0, c.Compare(entire1, entire2));
-//    }
-
-    int ToReflect1(Direction d)
-    {
-      return (int) d;
-    }
-
-    Direction ToReflect2(int i)
-    {
-      return (Direction) i;
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests.Core/DotNetFramework/ThreadingTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/DotNetFramework/ThreadingTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alex Yakunin
@@ -162,6 +162,7 @@ namespace Xtensive.Orm.Tests.Core.DotNetFramework
           Thread thread = Thread.CurrentThread;
           using (new Measurement("Execute", log ? MeasurementOptions.Log : 0, passCount))
             for (int j = 0; j < passCount; j++) {
+              
               IAsyncResult r = d.BeginInvoke(null, null);
               d.EndInvoke(r);
             }
@@ -197,12 +198,14 @@ namespace Xtensive.Orm.Tests.Core.DotNetFramework
           LockTest(sf, 256);
           LockTest(sf, 1024);
         }
-        InvokeAsyncTest(sf, 1);
-        if (!warmup) {
-          InvokeAsyncTest(sf, 2);
-          InvokeAsyncTest(sf, 4);
-          InvokeAsyncTest(sf, 8);
-        }
+        // Commented out due to lack of support for BeginInvoke/EndInvoke
+        // and using tasks and async/await is probably what original purpose of the test
+        //InvokeAsyncTest(sf, 1);
+        //if (!warmup) {
+        //  InvokeAsyncTest(sf, 2);
+        //  InvokeAsyncTest(sf, 4);
+        //  InvokeAsyncTest(sf, 8);
+        //}
       }
     }
 

--- a/Orm/Xtensive.Orm.Tests.Core/GlobalTestSetup.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/GlobalTestSetup.cs
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using NUnit.Framework;
+using Xtensive.Orm.Logging;
+
+namespace Xtensive.Orm.Tests.Core
+{
+  [SetUpFixture]
+  public class GlobalTestSetup
+  {
+    [OneTimeSetUp]
+    public void RunBeforeAnyTests()
+    {
+      var configuraion = GetType().GetConfigurationForAssembly();
+      LogManager.Default.Initialize(configuraion);
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Logging/WriteToLogTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Logging/WriteToLogTests.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2013-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
 // Created:    2013.10.14
 
@@ -18,55 +18,51 @@ namespace Xtensive.Orm.Tests.Core.Logging
   {
     private const string filePath = "Log.txt";
 
-    [OneTimeSetUp]
-    public void SetUp()
-    {
-      LogManager.Default.Initialize(Configuration);
-    }
-
     [Test]
     public void OrmLogTest()
     {
-      if (File.Exists(filePath))
+      if (File.Exists(filePath)) {
         File.Delete(filePath);
+      }
+
       OrmLog.Debug("Test message", null);
       OrmLog.Debug("Test message with parameter {0}", new object[] { 1 });
-      OrmLog.Debug(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = OrmLog.Debug(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       OrmLog.Debug("Test message", new object[] { 1 });
       OrmLog.Debug("Test message {0}", null);
-      OrmLog.Debug(new Exception("Some exeption"));
+      _ = OrmLog.Debug(new Exception("Some exeption"));
       OrmLog.Debug(null, new object[] { 1 });
 
       OrmLog.Info("Test message", null);
       OrmLog.Info("Test message with parameter {0}", new object[] { 1 });
-      OrmLog.Info(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = OrmLog.Info(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       OrmLog.Info("Test message", new object[] { 1 });
       OrmLog.Info("Test message {0}", null);
-      OrmLog.Info(new Exception("Some exeption"));
+      _ = OrmLog.Info(new Exception("Some exeption"));
       OrmLog.Info(null, new object[] { 1 });
 
       OrmLog.Warning("Test message", null);
       OrmLog.Warning("Test message with parameter {0}", new object[] { 1 });
-      OrmLog.Warning(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = OrmLog.Warning(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       OrmLog.Warning("Test message", new object[] { 1 });
       OrmLog.Warning("Test message {0}", null);
-      OrmLog.Warning(new Exception("Some exeption"));
+      _ = OrmLog.Warning(new Exception("Some exeption"));
       OrmLog.Warning(null, new object[] { 1 });
 
       OrmLog.Error("Test message", null);
       OrmLog.Error("Test message with parameter {0}", new object[] { 1 });
-      OrmLog.Error(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = OrmLog.Error(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       OrmLog.Error("Test message", new object[] { 1 });
       OrmLog.Error("Test message {0}", null);
-      OrmLog.Error(new Exception("Some exeption"));
+      _ = OrmLog.Error(new Exception("Some exeption"));
       OrmLog.Error(null, new object[] { 1 });
 
       OrmLog.FatalError("Test message", null);
       OrmLog.FatalError("Test message with parameter {0}", new object[] { 1 });
-      OrmLog.FatalError(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = OrmLog.FatalError(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       OrmLog.FatalError("Test message", new object[] { 1 });
       OrmLog.FatalError("Test message {0}", null);
-      OrmLog.FatalError(new Exception("Some exeption"));
+      _ = OrmLog.FatalError(new Exception("Some exeption"));
       OrmLog.FatalError(null, new object[] { 1 });
 
       Assert.IsTrue(File.Exists(filePath));
@@ -80,42 +76,42 @@ namespace Xtensive.Orm.Tests.Core.Logging
         File.Delete(filePath);
       BuildLog.Debug("Test message", null);
       BuildLog.Debug("Test message with parameter {0}", new object[] { 1 });
-      BuildLog.Debug(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = BuildLog.Debug(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       BuildLog.Debug("Test message", new object[] { 1 });
       BuildLog.Debug("Test message {0}", null);
-      BuildLog.Debug(new Exception("Some exeption"));
+      _ = BuildLog.Debug(new Exception("Some exeption"));
       BuildLog.Debug(null, new object[] { 1 });
 
       BuildLog.Info("Test message", null);
       BuildLog.Info("Test message with parameter {0}", new object[] { 1 });
-      BuildLog.Info(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = BuildLog.Info(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       BuildLog.Info("Test message", new object[] { 1 });
       BuildLog.Info("Test message {0}", null);
-      BuildLog.Info(new Exception("Some exeption"));
+      _ = BuildLog.Info(new Exception("Some exeption"));
       BuildLog.Info(null, new object[] { 1 });
 
       BuildLog.Warning("Test message", null);
       BuildLog.Warning("Test message with parameter {0}", new object[] { 1 });
-      BuildLog.Warning(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = BuildLog.Warning(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       BuildLog.Warning("Test message", new object[] { 1 });
       BuildLog.Warning("Test message {0}", null);
-      BuildLog.Warning(new Exception("Some exeption"));
+      _ = BuildLog.Warning(new Exception("Some exeption"));
       BuildLog.Warning(null, new object[] { 1 });
 
       BuildLog.Error("Test message", null);
       BuildLog.Error("Test message with parameter {0}", new object[] { 1 });
-      BuildLog.Error(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = BuildLog.Error(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       BuildLog.Error("Test message", new object[] { 1 });
       BuildLog.Error("Test message {0}", null);
-      BuildLog.Error(new Exception("Some exeption"));
+      _ = BuildLog.Error(new Exception("Some exeption"));
       BuildLog.Error(null, new object[] { 1 });
 
       BuildLog.FatalError("Test message", null);
       BuildLog.FatalError("Test message with parameter {0}", new object[] { 1 });
-      BuildLog.FatalError(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = BuildLog.FatalError(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       BuildLog.FatalError("Test message", new object[] { 1 });
       BuildLog.FatalError("Test message {0}", null);
-      BuildLog.FatalError(new Exception("Some exeption"));
+      _ = BuildLog.FatalError(new Exception("Some exeption"));
       BuildLog.FatalError(null, new object[] { 1 });
 
       Assert.IsTrue(File.Exists(filePath));
@@ -178,42 +174,42 @@ namespace Xtensive.Orm.Tests.Core.Logging
         File.Delete(filePath);
       SqlLog.Debug("Test message", null);
       SqlLog.Debug("Test message with parameter {0}", new object[] { 1 });
-      SqlLog.Debug(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = SqlLog.Debug(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       SqlLog.Debug("Test message", new object[] { 1 });
       SqlLog.Debug("Test message {0}", null);
-      SqlLog.Debug(new Exception("Some exeption"));
+      _ = SqlLog.Debug(new Exception("Some exeption"));
       SqlLog.Debug(null, new object[] { 1 });
 
       SqlLog.Info("Test message", null);
       SqlLog.Info("Test message with parameter {0}", new object[] { 1 });
-      SqlLog.Info(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = SqlLog.Info(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       SqlLog.Info("Test message", new object[] { 1 });
       SqlLog.Info("Test message {0}", null);
-      SqlLog.Info(new Exception("Some exeption"));
+      _ = SqlLog.Info(new Exception("Some exeption"));
       SqlLog.Info(null, new object[] { 1 });
 
       SqlLog.Warning("Test message", null);
       SqlLog.Warning("Test message with parameter {0}", new object[] { 1 });
-      SqlLog.Warning(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = SqlLog.Warning(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       SqlLog.Warning("Test message", new object[] { 1 });
       SqlLog.Warning("Test message {0}", null);
-      SqlLog.Warning(new Exception("Some exeption"));
+      _ = SqlLog.Warning(new Exception("Some exeption"));
       SqlLog.Warning(null, new object[] { 1 });
 
       SqlLog.Error("Test message", null);
       SqlLog.Error("Test message with parameter {0}", new object[] { 1 });
-      SqlLog.Error(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = SqlLog.Error(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       SqlLog.Error("Test message", new object[] { 1 });
       SqlLog.Error("Test message {0}", null);
-      SqlLog.Error(new Exception("Some exeption"));
+      _ = SqlLog.Error(new Exception("Some exeption"));
       SqlLog.Error(null, new object[] { 1 });
 
       SqlLog.FatalError("Test message", null);
       SqlLog.FatalError("Test message with parameter {0}", new object[] { 1 });
-      SqlLog.FatalError(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
+      _ = SqlLog.FatalError(new Exception("Some exception"), "Test message with parameter {0}", new object[] { 1 });
       SqlLog.FatalError("Test message", new object[] { 1 });
       SqlLog.FatalError("Test message {0}", null);
-      SqlLog.FatalError(new Exception("Some exeption"));
+      _ = SqlLog.FatalError(new Exception("Some exeption"));
       SqlLog.FatalError(null, new object[] { 1 });
 
       Assert.IsTrue(File.Exists(filePath));

--- a/Orm/Xtensive.Orm.Tests.Core/Xtensive.Orm.Tests.Core.csproj
+++ b/Orm/Xtensive.Orm.Tests.Core/Xtensive.Orm.Tests.Core.csproj
@@ -27,7 +27,7 @@
     <!--<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
  
 </Project>

--- a/Orm/Xtensive.Orm.Tests.Sql/Xtensive.Orm.Tests.Sql.csproj
+++ b/Orm/Xtensive.Orm.Tests.Sql/Xtensive.Orm.Tests.Sql.csproj
@@ -23,7 +23,7 @@
     <!-- <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" /> -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xtensive.Orm.PostgreSql\Xtensive.Orm.PostgreSql.csproj" />

--- a/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
+++ b/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="Npgsql" Version="4.0.5" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="System.CodeDom" Version="4.4.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />

--- a/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
@@ -7,9 +7,8 @@
 using System;
 using System.Globalization;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Core;
-
-
 
 namespace Xtensive.Comparison
 {
@@ -201,6 +200,7 @@ namespace Xtensive.Comparison
       Culture = (cultureId != int.MinValue) ? CultureInfo.GetCultureInfo(cultureId) : null;
     }
 
+    [SecurityCritical]
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
     {
       if(info == null) {

--- a/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alex Yakunin
@@ -6,6 +6,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.Serialization;
 using Xtensive.Core;
 
 
@@ -16,8 +17,9 @@ namespace Xtensive.Comparison
   /// Describes how to compare values of comparable objects.
   /// </summary>
   [Serializable]
-  public struct ComparisonRule : 
-    IEquatable<ComparisonRule>
+  public struct ComparisonRule :
+    IEquatable<ComparisonRule>,
+    ISerializable
   {
     /// <summary>
     /// Predefined rule with <see cref="Direction"/> = <see cref="Core.Direction.None"/>.
@@ -50,7 +52,7 @@ namespace Xtensive.Comparison
     /// </summary>
     /// <returns>The same rule, but with inverted direction.</returns>
     public ComparisonRule Invert()
-    {      
+    {
       return new ComparisonRule((Direction)(-((int)Direction)), Culture);     
     }
 
@@ -187,6 +189,27 @@ namespace Xtensive.Comparison
     {
       Direction = direction;
       Culture = culture;
+    }
+
+    private ComparisonRule(SerializationInfo info, StreamingContext context)
+    {
+      if (info == null) {
+        throw new ArgumentNullException(nameof(info));
+      }
+      Direction = (Direction) info.GetSByte(nameof(Direction));
+      var cultureId = info.GetInt32(nameof(Culture));
+      Culture = (cultureId != int.MinValue) ? CultureInfo.GetCultureInfo(cultureId) : null;
+    }
+
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+      if(info == null) {
+        throw new ArgumentNullException(nameof(info));
+      }
+      info.AddValue(nameof(Direction), (sbyte) Direction);
+
+      var cultureId = (Culture != null) ? Culture.LCID : int.MinValue;
+      info.AddValue(nameof(Culture), cultureId);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/ArrayComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/ArrayComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
 // Created:    2008.01.16
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -13,63 +14,64 @@ namespace Xtensive.Comparison
     ISystemComparer<T[]>
   {
     protected override IAdvancedComparer<T[]> CreateNew(ComparisonRules rules)
-    {
-      return new ArrayComparer<T>(Provider, ComparisonRules.Combine(rules));
-    }
+      => new ArrayComparer<T>(Provider, ComparisonRules.Combine(rules));
 
     public override int Compare(T[] x, T[] y)
     {
-      if (x==null) {
-        if (y==null)
-          return 0;
-        return -DefaultDirectionMultiplier;
+      if (x == null) {
+        return y == null ? 0 : -DefaultDirectionMultiplier;
       }
-      if (y==null)
+      if (y == null) {
         return DefaultDirectionMultiplier;
-      int minLength = x.Length;
-      int result = -minLength - 1;
+      }
+
+      var minLength = x.Length;
+      var result = -minLength - 1;
       if (minLength > y.Length) {
         minLength = y.Length;
         result = minLength + 1;
       }
-      for (int i = 0; i < minLength;) {
-        int r = BaseComparer.Compare(x[i], y[i]);
+      for (var i = 0; i < minLength;) {
+        var r = BaseComparer.Compare(x[i], y[i]);
         i++;
-        if (r==0)
+        if (r == 0) {
           continue;
-        if (r > 0)
-          return i;
-        return -i;
+        }
+        return r > 0 ? i : -i;
       }
-      return result * (int)ComparisonRules.GetDefaultRuleDirection(minLength);
+      return result * (int) ComparisonRules.GetDefaultRuleDirection(minLength);
     }
 
     public override bool Equals(T[] x, T[] y)
     {
-      if (x==null) {
-        if (y==null)
-          return true;
+      if (x == null) {
+        return y == null;
+      }
+      if (y == null) {
         return false;
       }
-      if (y==null)
+      var r = x.Length - y.Length;
+      if (r != 0) {
         return false;
-      int r = x.Length - y.Length;
-      if (r!=0)
-        return false;
-      for (int i = x.Length - 1; i >= 0; i--) {
-        if (!BaseComparer.Equals(x[i], y[i]))
+      }
+      for (var i = x.Length - 1; i >= 0; i--) {
+        if (!BaseComparer.Equals(x[i], y[i])) {
           return false;
+        }
       }
       return true;
     }
 
     public override int GetHashCode(T[] obj)
     {
-      if (obj==null)
+      if (obj == null) {
         return 0;
-      int hashCode = 0;
-      for (int i = 0; i<obj.Length; i++)
+      }
+      var hashCode = 0;
+      for (var i = 0; i<obj.Length; i++) {
         hashCode ^= BaseComparer.GetHashCode(obj[i]);
+      }
+
       return hashCode;
     }
 
@@ -80,6 +82,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<T[]>(true, null, false, null, false, null);
+    }
+
+    public ArrayComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/AssemblyComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/AssemblyComparer.cs
@@ -1,11 +1,12 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.22
 
 using System;
 using System.Reflection;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -14,43 +15,39 @@ namespace Xtensive.Comparison
     ISystemComparer<Assembly>
   {
     protected override IAdvancedComparer<Assembly> CreateNew(ComparisonRules rules)
-    {
-      return new AssemblyComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new AssemblyComparer(Provider, ComparisonRules.Combine(rules));
 
     public override int Compare(Assembly x, Assembly y)
     {
-      if (ReferenceEquals(x, y))
+      if (ReferenceEquals(x, y)) {
         return 0;
+      }
       if (x == null) {
-        if (y == null)
-          return 0;
-        else
-          return -DefaultDirectionMultiplier;
+        return y == null ? 0 : -DefaultDirectionMultiplier;
       }
       else {
-        if (y==null)
-          return DefaultDirectionMultiplier;
-        else
-          return BaseComparer.Compare(x.FullName, y.FullName);
+        return y == null
+          ? DefaultDirectionMultiplier
+          : BaseComparer.Compare(x.FullName, y.FullName);
       }
     }
 
     public override bool Equals(Assembly x, Assembly y)
-    {
-      return ReferenceEquals(x, y);
-    }
+      => ReferenceEquals(x, y);
 
     public override int GetHashCode(Assembly obj)
-    {
-      return BaseComparer.GetHashCode(obj.FullName);
-    }
+      => BaseComparer.GetHashCode(obj.FullName);
 
 
     // Constructors
 
     public AssemblyComparer(IComparerProvider provider, ComparisonRules comparisonRules) 
       : base(provider, comparisonRules)
+    {
+    }
+
+    public AssemblyComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
     {
     }
   }

--- a/Orm/Xtensive.Orm/Comparison/Internals/BaseComparerWrapper.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/BaseComparerWrapper.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.22
 
 using System;
+using System.Runtime.Serialization;
 using Xtensive.Core;
 
 namespace Xtensive.Comparison
@@ -14,35 +15,27 @@ namespace Xtensive.Comparison
     where T: TBase
   {
     protected override IAdvancedComparer<T> CreateNew(ComparisonRules rules)
-    {
-      return new BaseComparerWrapper<T, TBase>(Provider, ComparisonRules.Combine(rules));
-    }
+      => new BaseComparerWrapper<T, TBase>(Provider, ComparisonRules.Combine(rules));
 
-    public override int Compare(T x, T y)
-    {
-      return BaseComparer.Compare(x, y);
-    }
+    public override int Compare(T x, T y) => BaseComparer.Compare(x, y);
 
-    public override bool Equals(T x, T y)
-    {
-      return BaseComparer.Equals(x, y);
-    }
+    public override bool Equals(T x, T y) => BaseComparer.Equals(x, y);
 
-    public override int GetHashCode(T obj)
-    {
-      return BaseComparer.GetHashCode(obj);
-    }
+    public override int GetHashCode(T obj) => BaseComparer.GetHashCode(obj);
 
     public override T GetNearestValue(T value, Direction direction)
-    {
-      return (T)BaseComparer.GetNearestValue(value, direction);
-    }
+      => (T) BaseComparer.GetNearestValue(value, direction);
 
 
     // Constructors
 
     public BaseComparerWrapper(IComparerProvider provider, ComparisonRules comparisonRules)
       : base(provider, comparisonRules)
+    {
+    }
+
+    public BaseComparerWrapper(SerializationInfo info, StreamingContext context)
+      : base(info, context)
     {
     }
   }

--- a/Orm/Xtensive.Orm/Comparison/Internals/BooleanComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/BooleanComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 using Xtensive.Core;
 
 
@@ -13,16 +14,15 @@ namespace Xtensive.Comparison
   [Serializable]
   internal sealed class BooleanComparer : ValueTypeComparer<bool>
   {
-    protected override IAdvancedComparer<bool> CreateNew(ComparisonRules rules)
-    {
-      return new BooleanComparer(Provider, ComparisonRules.Combine(rules));
-    }
+    protected override IAdvancedComparer<bool> CreateNew(ComparisonRules rules) => new BooleanComparer(Provider, ComparisonRules.Combine(rules));
 
     public override bool GetNearestValue(bool value, Direction direction)
     {
-      if (direction==Direction.None)
+      if (direction == Direction.None) {
         throw Exceptions.InvalidArgument(direction, "direction");
-      return direction==ComparisonRules.Value.Direction ? true : false;
+      }
+
+      return direction == ComparisonRules.Value.Direction ? true : false;
     }
 
 
@@ -32,6 +32,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<bool>(true, false, true, true, true, true);
+    }
+
+    public BooleanComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/BooleanComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/BooleanComparer.cs
@@ -22,7 +22,7 @@ namespace Xtensive.Comparison
         throw Exceptions.InvalidArgument(direction, "direction");
       }
 
-      return direction == ComparisonRules.Value.Direction ? true : false;
+      return direction == ComparisonRules.Value.Direction;
     }
 
 

--- a/Orm/Xtensive.Orm/Comparison/Internals/ByteComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/ByteComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class ByteComparer : ValueTypeComparer<byte>
   {
     protected override IAdvancedComparer<byte> CreateNew(ComparisonRules rules)
-    {
-      return new ByteComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new ByteComparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -22,7 +21,12 @@ namespace Xtensive.Comparison
     public ByteComparer(IComparerProvider provider, ComparisonRules comparisonRules)
       : base(provider, comparisonRules)
     {
-      ValueRangeInfo = new ValueRangeInfo<byte>(true, Byte.MinValue, true, Byte.MaxValue, true, 1);
+      ValueRangeInfo = new ValueRangeInfo<byte>(true, byte.MinValue, true, byte.MaxValue, true, 1);
+    }
+
+    public ByteComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/CharComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/CharComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class CharComparer : ValueTypeComparer<char>
   {
     protected override IAdvancedComparer<char> CreateNew(ComparisonRules rules)
-    {
-      return new CharComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new CharComparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -22,7 +21,12 @@ namespace Xtensive.Comparison
     public CharComparer(IComparerProvider provider, ComparisonRules comparisonRules)
       : base(provider, comparisonRules)
     {
-      ValueRangeInfo = new ValueRangeInfo<char>(true, Char.MinValue, true, Char.MaxValue, true, '\x0001');
+      ValueRangeInfo = new ValueRangeInfo<char>(true, char.MinValue, true, char.MaxValue, true, '\x0001');
+    }
+
+    public CharComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/DecimalComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/DecimalComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class DecimalComparer : ValueTypeComparer<decimal>
   {
     protected override IAdvancedComparer<decimal> CreateNew(ComparisonRules rules)
-    {
-      return new DecimalComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new DecimalComparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -23,6 +22,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<decimal>(true, decimal.MinValue, true, decimal.MaxValue, false, 0m);
+    }
+
+    public DecimalComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/DoubleComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/DoubleComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class DoubleComparer : ValueTypeComparer<double>
   {
     protected override IAdvancedComparer<double> CreateNew(ComparisonRules rules)
-    {
-      return new DoubleComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new DoubleComparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -23,6 +22,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<double>(true, double.MinValue, true, double.MaxValue, false, 0d);
+    }
+
+    public DoubleComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/EnumComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/EnumComparer.cs
@@ -1,11 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
-// Created by: 
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+// Created by: Alex Yakunin
 // Created:    2008.01.23
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Core;
 
 using Xtensive.Reflection;
@@ -13,49 +15,77 @@ using Xtensive.Reflection;
 namespace Xtensive.Comparison
 {
   [Serializable]
-  internal sealed class EnumComparer<TEnum, TSystem>: WrappingComparer<TEnum, TSystem>,
+  internal sealed class EnumComparer<TEnum, TSystem> : WrappingComparer<TEnum, TSystem>,
     ISystemComparer<TEnum>
     where TEnum: struct
     where TSystem: struct
   {
-    private static readonly Converter<TEnum, TSystem> enumToSystem = DelegateHelper.CreatePrimitiveCastDelegate<TEnum, TSystem>();
-    // private static readonly Converter<TSystem, TEnum> systemToEnum = DelegateHelper.CreatePrimitiveCastDelegate<TSystem, TEnum>();
+    private static readonly Converter<TEnum, TSystem> EnumToSystem = DelegateHelper.CreatePrimitiveCastDelegate<TEnum, TSystem>();
+
     private readonly TEnum[] values;
     private readonly Dictionary<TEnum, int> valueToIndex;
     private readonly int maxIndex;
 
     protected override IAdvancedComparer<TEnum> CreateNew(ComparisonRules rules)
-    {
-      return new EnumComparer<TEnum,TSystem>(Provider, ComparisonRules.Combine(rules));
-    }
+      => new EnumComparer<TEnum, TSystem>(Provider, ComparisonRules.Combine(rules));
 
-    public override int Compare(TEnum x, TEnum y)
-    {
-      return BaseComparer.Compare(enumToSystem(x), enumToSystem(y));
-    }
+    public override int Compare(TEnum x, TEnum y) => BaseComparer.Compare(EnumToSystem(x), EnumToSystem(y));
 
-    public override bool Equals(TEnum x, TEnum y)
-    {
-      return BaseComparer.Equals(enumToSystem(x), enumToSystem(y));
-    }
+    public override bool Equals(TEnum x, TEnum y) => BaseComparer.Equals(EnumToSystem(x), EnumToSystem(y));
 
-    public override int GetHashCode(TEnum obj)
-    {
-      return obj.GetHashCode();
-    }
+    public override int GetHashCode(TEnum obj) => obj.GetHashCode();
 
     public override TEnum GetNearestValue(TEnum value, Direction direction)
     {
-      int index = valueToIndex[value];
-      if (index<0)
+      var index = valueToIndex[value];
+      if (index < 0) {
         throw Exceptions.InvalidArgument(value, "value");
+      }
+
       switch (direction) {
-      case Direction.Positive:
-        return index >= maxIndex ? value : values[index + 1];
-      case Direction.Negative:
-        return index == 0 ? value : values[index - 1];
-      default:        
-        throw Exceptions.InvalidArgument(direction, "direction");
+        case Direction.Positive:
+          return index >= maxIndex ? value : values[index + 1];
+        case Direction.Negative:
+          return index == 0 ? value : values[index - 1];
+        default:
+          throw Exceptions.InvalidArgument(direction, "direction");
+      }
+    }
+
+    private TEnum[] BuildValues(out int valueCount)
+    {
+      var originalValues = Enum.GetValues(typeof(TEnum));
+      valueCount = originalValues.Length;
+      if (valueCount < 1) {
+        valueCount = 1;
+        var values = new TEnum[] { default(TEnum) };
+        valueToIndex.Add(values[0], 0);
+        return values;
+      }
+      else {
+        var allValues = new TEnum[valueCount];
+        for (var i = 0; i < valueCount; i++) {
+          allValues[i] = (TEnum) originalValues.GetValue(i);
+        }
+
+        Array.Sort<TEnum>(allValues, (x, y) => BaseComparer.Compare(EnumToSystem(x), EnumToSystem(y)));
+        for (var i = 0; i < valueCount - 1; i++) {
+          var j = i + 1;
+          if (BaseComparer.Equals(EnumToSystem(allValues[i]), EnumToSystem(allValues[j]))) {
+            valueCount--;
+            Array.Copy(allValues, j, allValues, i, valueCount - i);
+          }
+        }
+        var values = new TEnum[valueCount];
+        Array.Copy(allValues, values, valueCount);
+        var names = Enum.GetNames(typeof(TEnum));
+        for (var i = 0; i < names.Length; i++) {
+          var current = (TEnum) originalValues.GetValue(i);
+          if (!valueToIndex.ContainsKey(current)) {
+            valueToIndex.Add(current, Array.IndexOf(values, current));
+          }
+        }
+        return values;
       }
     }
 
@@ -66,38 +96,23 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       valueToIndex = new Dictionary<TEnum, int>();
-      Array originalValues = Enum.GetValues(typeof (TEnum));
-      int valueCount = originalValues.Length;
-      if (valueCount<1) {
-        valueCount = 1;
-        values = new TEnum[] {default(TEnum)};
-        valueToIndex.Add(values[0], 0);
-      }
-      else {
-        TEnum[] allValues = new TEnum[valueCount];
-        for (int i = 0; i < valueCount; i++)
-          allValues[i] = (TEnum) originalValues.GetValue(i);
-        Array.Sort<TEnum>(allValues, (x, y) => BaseComparer.Compare(enumToSystem(x), enumToSystem(y)));
-        for (int i = 0; i<valueCount-1; i++) {
-          int j = i + 1;
-          if (BaseComparer.Equals(enumToSystem(allValues[i]), enumToSystem(allValues[j]))) {
-            valueCount--;
-            Array.Copy(allValues, j, allValues, i, valueCount-i);
-          }
-        }
-        values = new TEnum[valueCount];
-        Array.Copy(allValues, values, valueCount);
-        string[] names = Enum.GetNames(typeof (TEnum));
-        for (int i = 0; i<names.Length; i++) {
-          TEnum current = (TEnum) originalValues.GetValue(i);
-          if (!valueToIndex.ContainsKey(current))
-            valueToIndex.Add(current, Array.IndexOf(values, current));
-        }
-      }
+      values = BuildValues(out var valueCount);
       maxIndex = valueCount - 1;
       ValueRangeInfo = new ValueRangeInfo<TEnum>(
         true, values[0], 
-        true, values[valueCount - 1], 
+        true, values[valueCount - 1],
+        false, default(TEnum));
+    }
+
+    public EnumComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
+      valueToIndex = new Dictionary<TEnum, int>();
+      values = BuildValues(out var valueCount);
+      maxIndex = valueCount - 1;
+      ValueRangeInfo = new ValueRangeInfo<TEnum>(
+        true, values[0],
+        true, values[valueCount - 1],
         false, default(TEnum));
     }
   }

--- a/Orm/Xtensive.Orm/Comparison/Internals/EnumerableInterfaceComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/EnumerableInterfaceComparer.cs
@@ -1,58 +1,50 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
 // Created:    2008.01.16
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
   [Serializable]
-  internal sealed class EnumerableInterfaceComparer<TEnumerable, T>: WrappingComparer<TEnumerable, T>,
+  internal sealed class EnumerableInterfaceComparer<TEnumerable, T> : WrappingComparer<TEnumerable, T>,
     ISystemComparer<TEnumerable>
     where TEnumerable: class, IEnumerable<T>
   {
     protected override IAdvancedComparer<TEnumerable> CreateNew(ComparisonRules rules)
-    {
-      return new EnumerableInterfaceComparer<TEnumerable,T>(Provider, ComparisonRules.Combine(rules));
-    }
+      => new EnumerableInterfaceComparer<TEnumerable, T>(Provider, ComparisonRules.Combine(rules));
 
     public override int Compare(TEnumerable x, TEnumerable y)
     {
       if (x == null) {
-        if (y == null)
-          return 0;
-        else
-          return -DefaultDirectionMultiplier;
+        return y == null ? 0 : -DefaultDirectionMultiplier;
       }
       else {
-        if (y == null)
+        if (y == null) {
           return DefaultDirectionMultiplier;
+        }
         else {
-          IEnumerator<T> ex = x.GetEnumerator();
-          IEnumerator<T> ey = y.GetEnumerator();
-          int i = 1;
+          var ex = x.GetEnumerator();
+          var ey = y.GetEnumerator();
+          var i = 1;
           while (true) {
-            bool hasX = ex.MoveNext();
-            bool hasY = ey.MoveNext();
+            var hasX = ex.MoveNext();
+            var hasY = ey.MoveNext();
             if (!hasX) {
-              if (!hasY)
-                return 0;
-              else
-                return -i * DefaultDirectionMultiplier;
+              return !hasY ? 0 : -i * DefaultDirectionMultiplier;
             }
             else {
-              if (!hasY)
+              if (!hasY) {
                 return i * DefaultDirectionMultiplier;
+              }
               else {
-                int r = BaseComparer.Compare(ex.Current, ey.Current);
+                var r = BaseComparer.Compare(ex.Current, ey.Current);
                 if (r != 0) {
-                  if (r<0)
-                    return -i;
-                  else
-                    return i;
+                  return r < 0 ? -i : i;
                 }
               }
             }
@@ -65,32 +57,29 @@ namespace Xtensive.Comparison
     public override bool Equals(TEnumerable x, TEnumerable y)
     {
       if (x == null) {
-        if (y == null)
-          return true;
-        else
-          return false;
+        return y == null;
       }
       else {
-        if (y == null)
+        if (y == null) {
           return false;
+        }
         else {
-          IEnumerator<T> ex = x.GetEnumerator();
-          IEnumerator<T> ey = y.GetEnumerator();
+          var ex = x.GetEnumerator();
+          var ey = y.GetEnumerator();
           while (true) {
-            bool hasX = ex.MoveNext();
-            bool hasY = ey.MoveNext();
+            var hasX = ex.MoveNext();
+            var hasY = ey.MoveNext();
             if (!hasX) {
-              if (!hasY)
-                return true;
-              else
-                return false;
+              return !hasY;
             }
             else {
-              if (!hasY)
+              if (!hasY) {
                 return false;
+              }
               else {
-                if (!BaseComparer.Equals(ex.Current, ey.Current))
+                if (!BaseComparer.Equals(ex.Current, ey.Current)) {
                   return false;
+                }
               }
             }
           }
@@ -100,11 +89,14 @@ namespace Xtensive.Comparison
 
     public override int GetHashCode(TEnumerable obj)
     {
-      if (obj == null)
+      if (obj == null) {
         return 0;
-      int hashCode = 0;
-      foreach (T current in obj)
+      }
+
+      var hashCode = 0;
+      foreach (T current in obj) {
         hashCode ^= BaseComparer.GetHashCode(current);
+      }
       return hashCode;
     }
 
@@ -115,6 +107,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<TEnumerable>(true, null, false, null, false, null);
+    }
+
+    public EnumerableInterfaceComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/GuidComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/GuidComparer.cs
@@ -1,10 +1,11 @@
 // Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class GuidComparer: ValueTypeComparer<Guid>
   {
     protected override IAdvancedComparer<Guid> CreateNew(ComparisonRules rules)
-    {
-      return new GuidComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new GuidComparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -26,6 +25,11 @@ namespace Xtensive.Comparison
         true, Guid.Empty,
         true, new Guid(0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
         false, Guid.Empty);
+    }
+
+    public GuidComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/Int16Comparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/Int16Comparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class Int16Comparer : ValueTypeComparer<short>
   {
     protected override IAdvancedComparer<short> CreateNew(ComparisonRules rules)
-    {
-      return new Int16Comparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new Int16Comparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -23,6 +22,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<short>(true, short.MinValue, true, short.MaxValue, true, 1);
+    }
+
+    public Int16Comparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/Int32Comparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/Int32Comparer.cs
@@ -1,20 +1,18 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
   [Serializable]
   internal sealed class Int32Comparer : ValueTypeComparer<int>
   {
-    protected override IAdvancedComparer<int> CreateNew(ComparisonRules rules)
-    {
-      return new Int32Comparer(Provider, ComparisonRules.Combine(rules));
-    }
+    protected override IAdvancedComparer<int> CreateNew(ComparisonRules rules) => new Int32Comparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -23,6 +21,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<int>(true, int.MinValue, true, int.MaxValue, true, 1);
+    }
+
+    public Int32Comparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/Int64Comparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/Int64Comparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class Int64Comparer : ValueTypeComparer<long>
   {
     protected override IAdvancedComparer<long> CreateNew(ComparisonRules rules)
-    {
-      return new Int64Comparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new Int64Comparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -23,6 +22,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<long>(true, long.MinValue, true, long.MaxValue, true, 1);
+    }
+
+    public Int64Comparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/KeyValuePairComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/KeyValuePairComparer.cs
@@ -1,11 +1,12 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.22
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Xtensive.Core;
 
 namespace Xtensive.Comparison
@@ -15,35 +16,25 @@ namespace Xtensive.Comparison
     ISystemComparer<KeyValuePair<T1, T2>>
   {
     protected override IAdvancedComparer<KeyValuePair<T1, T2>> CreateNew(ComparisonRules rules)
-    {
-      return new KeyValuePairComparer<T1, T2>(Provider, ComparisonRules.Combine(rules));
-    }
+      => new KeyValuePairComparer<T1, T2>(Provider, ComparisonRules.Combine(rules));
 
     public override int Compare(KeyValuePair<T1, T2> x, KeyValuePair<T1, T2> y)
     {
-      int result = BaseComparer1.Compare(x.Key, y.Key);
-      if (result != 0)
-        return result;
-      return BaseComparer2.Compare(x.Value, y.Value);
+      var result = BaseComparer1.Compare(x.Key, y.Key);
+      return result != 0 ? result : BaseComparer2.Compare(x.Value, y.Value);
     }
 
     public override bool Equals(KeyValuePair<T1, T2> x, KeyValuePair<T1, T2> y)
-    {
-      if (!BaseComparer1.Equals(x.Key, y.Key))
-        return false;
-      return BaseComparer2.Equals(x.Value, y.Value);
-    }
+      => BaseComparer1.Equals(x.Key, y.Key) && BaseComparer2.Equals(x.Value, y.Value);
 
     public override int GetHashCode(KeyValuePair<T1, T2> obj)
     {
-      int result = BaseComparer1.GetHashCode(obj.Key);
+      var result = BaseComparer1.GetHashCode(obj.Key);
       return result ^ BaseComparer2.GetHashCode(obj.Value);
     }
 
     public override KeyValuePair<T1, T2> GetNearestValue(KeyValuePair<T1, T2> value, Direction direction)
-    {
-      return new KeyValuePair<T1, T2>(value.Key, BaseComparer2.GetNearestValue(value.Value, direction));
-    }
+      => new KeyValuePair<T1, T2>(value.Key, BaseComparer2.GetNearestValue(value.Value, direction));
 
 
     // Constructors
@@ -68,6 +59,11 @@ namespace Xtensive.Comparison
         hasDeltaValue = true;
       }
       ValueRangeInfo = new ValueRangeInfo<KeyValuePair<T1, T2>>(hasMinValue, minValue, hasMaxValue, maxValue, hasDeltaValue, deltaValue);
+    }
+
+    public KeyValuePairComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/NoSystemComparerHandler.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/NoSystemComparerHandler.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.02.10
 
@@ -39,8 +39,8 @@ namespace Xtensive.Comparison
     public override int GetHashCode()
     {
       throw new NotSupportedException(string.Format(
-        Strings.ExTypeXMustImplementY, 
-        typeof(T).GetShortName(), 
+        Strings.ExTypeXMustImplementY,
+        typeof(T).GetShortName(),
         typeof(IEquatable<T>).GetShortName()));
     }
 

--- a/Orm/Xtensive.Orm/Comparison/Internals/ObjectComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/ObjectComparer.cs
@@ -41,7 +41,7 @@ namespace Xtensive.Comparison
         return ReferenceEquals(y, null);
       }
       else {
-        return ReferenceEquals(y, null) ? false : x.Equals(y);
+        return !ReferenceEquals(y, null) && x.Equals(y);
       }
     }
 

--- a/Orm/Xtensive.Orm/Comparison/Internals/ObjectComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/ObjectComparer.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.23
 
@@ -21,49 +21,32 @@ namespace Xtensive.Comparison
     private int nullHashCode;
 
     protected override IAdvancedComparer<T> CreateNew(ComparisonRules rules)
-    {
-      return new ObjectComparer<T>(Provider, ComparisonRules.Combine(rules));
-    }
+      => new ObjectComparer<T>(Provider, ComparisonRules.Combine(rules));
 
     public override int Compare(T x, T y)
     {
       if (ReferenceEquals(x, null)) {
-        if (ReferenceEquals(y, null))
-          return 0;
-        else
-          return -DefaultDirectionMultiplier;
+        return ReferenceEquals(y, null) ? 0 : -DefaultDirectionMultiplier;
       }
       else {
-        if (ReferenceEquals(y, null))
-          return DefaultDirectionMultiplier;
-        else
-          return x.CompareTo(y) * DefaultDirectionMultiplier;
+        return ReferenceEquals(y, null)
+          ? DefaultDirectionMultiplier
+          : x.CompareTo(y) * DefaultDirectionMultiplier;
       }
     }
 
     public override bool Equals(T x, T y)
     {
       if (ReferenceEquals(x, null)) {
-        if (ReferenceEquals(y, null))
-          return true;
-        else
-          return false;
+        return ReferenceEquals(y, null);
       }
       else {
-        if (ReferenceEquals(y, null))
-          return false;
-        else
-          return x.Equals(y);
+        return ReferenceEquals(y, null) ? false : x.Equals(y);
       }
     }
 
     public override int GetHashCode(T obj)
-    {
-      if (ReferenceEquals(obj, null))
-        return nullHashCode;
-      else
-        return obj.GetHashCode();
-    }
+      => ReferenceEquals(obj, null) ? nullHashCode : obj.GetHashCode();
 
     private void Initialize()
     {
@@ -79,6 +62,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       Initialize();
+    }
+
+    public ObjectComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
 
     public override void OnDeserialization(object sender)

--- a/Orm/Xtensive.Orm/Comparison/Internals/PairComparer{T1,T2}.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/PairComparer{T1,T2}.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.22
 
 using System;
+using System.Runtime.Serialization;
 using Xtensive.Core;
 
 namespace Xtensive.Comparison
@@ -19,35 +20,23 @@ namespace Xtensive.Comparison
 
     public override int Compare(Pair<T1, T2> x, Pair<T1, T2> y)
     {
-      int result = BaseComparer1.Compare(x.First, y.First);
-      if (result != 0)
-        return result;
-      return BaseComparer2.Compare(x.Second, y.Second);
+      var result = BaseComparer1.Compare(x.First, y.First);
+      return result != 0 ? result : BaseComparer2.Compare(x.Second, y.Second);
     }
 
     public override bool Equals(Pair<T1, T2> x, Pair<T1, T2> y)
-    {
-      if (!BaseComparer1.Equals(x.First, y.First))
-        return false;
-      return BaseComparer2.Equals(x.Second, y.Second);
-    }
+      => BaseComparer1.Equals(x.First, y.First) && BaseComparer2.Equals(x.Second, y.Second);
 
     public override int GetHashCode(Pair<T1, T2> obj)
     {
-      int result = BaseComparer1.GetHashCode(obj.First);
+      var result = BaseComparer1.GetHashCode(obj.First);
       return result ^ BaseComparer2.GetHashCode(obj.Second);
     }
 
     public override Pair<T1, T2> GetNearestValue(Pair<T1, T2> value, Direction direction)
-    {
-      return new Pair<T1, T2>(value.First, BaseComparer2.GetNearestValue(value.Second, direction));
-    }
+      => new Pair<T1, T2>(value.First, BaseComparer2.GetNearestValue(value.Second, direction));
 
-
-    // Constructors
-
-    public PairComparer(IComparerProvider provider, ComparisonRules comparisonRules)
-      : base(provider, comparisonRules)
+    private void Initialize()
     {
       Pair<T1, T2> minValue, maxValue, deltaValue;
       bool hasMinValue = false, hasMaxValue = false, hasDeltaValue = false;
@@ -66,6 +55,21 @@ namespace Xtensive.Comparison
         hasDeltaValue = true;
       }
       ValueRangeInfo = new ValueRangeInfo<Pair<T1, T2>>(hasMinValue, minValue, hasMaxValue, maxValue, hasDeltaValue, deltaValue);
+    }
+
+
+    // Constructors
+
+    public PairComparer(IComparerProvider provider, ComparisonRules comparisonRules)
+      : base(provider, comparisonRules)
+    {
+      Initialize();
+    }
+
+    public PairComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
+      Initialize();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/PairComparer{T}.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/PairComparer{T}.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.22
 
 using System;
+using System.Runtime.Serialization;
 using Xtensive.Core;
 
 namespace Xtensive.Comparison
@@ -13,41 +14,27 @@ namespace Xtensive.Comparison
   internal sealed class PairComparer<T>: WrappingComparer<Pair<T>, T>
   {
     protected override IAdvancedComparer<Pair<T>> CreateNew(ComparisonRules rules)
-    {
-      return new PairComparer<T>(Provider, ComparisonRules.Combine(rules));
-    }
+      => new PairComparer<T>(Provider, ComparisonRules.Combine(rules));
 
     public override int Compare(Pair<T> x, Pair<T> y)
     {
-      int result = BaseComparer.Compare(x.First, y.First);
-      if (result != 0)
-        return result;
-      return BaseComparer.Compare(x.Second, y.Second);
+      var result = BaseComparer.Compare(x.First, y.First);
+      return result != 0 ? result : BaseComparer.Compare(x.Second, y.Second);
     }
 
     public override bool Equals(Pair<T> x, Pair<T> y)
-    {
-      if (!BaseComparer.Equals(x.First, y.First))
-        return false;
-      return BaseComparer.Equals(x.Second, y.Second);
-    }
+      => BaseComparer.Equals(x.First, y.First) && BaseComparer.Equals(x.Second, y.Second);
 
     public override int GetHashCode(Pair<T> obj)
     {
-      int result = BaseComparer.GetHashCode(obj.First);
+      var result = BaseComparer.GetHashCode(obj.First);
       return result ^ BaseComparer.GetHashCode(obj.Second);
     }
 
     public override Pair<T> GetNearestValue(Pair<T> value, Direction direction)
-    {
-      return new Pair<T>(value.First, BaseComparer.GetNearestValue(value.Second, direction));
-    }
+      => new Pair<T>(value.First, BaseComparer.GetNearestValue(value.Second, direction));
 
-
-    // Constructors
-
-    public PairComparer(IComparerProvider provider, ComparisonRules comparisonRules)
-      : base(provider, comparisonRules)
+    private void Initialize()
     {
       Pair<T> minValue, maxValue, deltaValue;
       bool hasMinValue = false, hasMaxValue = false, hasDeltaValue = false;
@@ -66,6 +53,21 @@ namespace Xtensive.Comparison
         hasDeltaValue = true;
       }
       ValueRangeInfo = new ValueRangeInfo<Pair<T>>(hasMinValue, minValue, hasMaxValue, maxValue, hasDeltaValue, deltaValue);
+    }
+
+
+    // Constructors
+
+    public PairComparer(IComparerProvider provider, ComparisonRules comparisonRules)
+      : base(provider, comparisonRules)
+    {
+      Initialize();
+    }
+
+    public PairComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
+      Initialize();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/SByteComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/SByteComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class SByteComparer : ValueTypeComparer<sbyte>
   {
     protected override IAdvancedComparer<sbyte> CreateNew(ComparisonRules rules)
-    {
-      return new SByteComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new SByteComparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -22,7 +21,12 @@ namespace Xtensive.Comparison
     public SByteComparer(IComparerProvider provider, ComparisonRules comparisonRules)
       : base(provider, comparisonRules)
     {
-      ValueRangeInfo = new ValueRangeInfo<sbyte>(true, SByte.MinValue, true, SByte.MaxValue, true, 1);
+      ValueRangeInfo = new ValueRangeInfo<sbyte>(true, sbyte.MinValue, true, sbyte.MaxValue, true, 1);
+    }
+
+    public SByteComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/SingleComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/SingleComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
 // Created:    2007.11.14
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class SingleComparer : ValueTypeComparer<float>
   {
     protected override IAdvancedComparer<float> CreateNew(ComparisonRules rules)
-    {
-      return new SingleComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new SingleComparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -23,6 +22,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<float>(true, float.MinValue, true, float.MaxValue, false, default(float));
+    }
+
+    public SingleComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/StringComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/StringComparer.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
@@ -16,7 +16,7 @@ namespace Xtensive.Comparison
   internal sealed class StringComparer: AdvancedComparerBase<string>,
     ISystemComparer<string>
   {
-    private static readonly int emptyHash = string.Empty.GetHashCode();
+    private static readonly int EmptyHash = string.Empty.GetHashCode();
     [NonSerialized]
     private Func<string, string, CompareOptions, int> stringCompare;
     [NonSerialized]
@@ -29,68 +29,69 @@ namespace Xtensive.Comparison
 
     public override int Compare(string x, string y)
     {
-      if (ReferenceEquals(x, y))
-        return 0;
-
-      return stringCompare(x, y, CompareOptions.None) * DefaultDirectionMultiplier;
+      return ReferenceEquals(x, y)
+        ? 0
+        : stringCompare(x, y, CompareOptions.None) * DefaultDirectionMultiplier;
     }
 
     public override bool Equals(string x, string y)
     {
-      if (ReferenceEquals(x, y))
+      if (ReferenceEquals(x, y)) {
         return true;
-      if (ReferenceEquals(x, null))
+      }
+      if (ReferenceEquals(x, null) || ReferenceEquals(y, null)) {
         return false;
-      if (ReferenceEquals(y, null))
+      }
+      if (x.Length != y.Length) {
         return false;
-      if (x.Length != y.Length)
-        return false;
-      if (x.GetHashCode() != y.GetHashCode())
-        return false;
-      return stringIsSuffix(x, y, CompareOptions.None);
+      }
+      return x.GetHashCode() != y.GetHashCode()
+        ? false
+        : stringIsSuffix(x, y, CompareOptions.None);
     }
 
     public override int GetHashCode(string obj)
-    {
-      if (ReferenceEquals(obj, null))
-        return emptyHash;
-      return obj.GetHashCode();
-    }
+      => ReferenceEquals(obj, null) ? EmptyHash : obj.GetHashCode();
 
     public override string GetNearestValue(string value, Direction direction)
     {
-      if (direction==Direction.None)
+      if (direction == Direction.None) {
         throw Exceptions.InvalidArgument(direction, "direction");
-     
-      if (direction == Direction.Positive) { 
+      }
+
+      if (direction == Direction.Positive) {
         // Next value
-        if (value == null)
+        if (value == null) {
           return string.Empty;
-        else
-          if (value==string.Empty || value[value.Length - 1] != Char.MaxValue)
-            return value + Char.MinValue;
-          else // Ends with Char.MaxValue
-            if (value.Length == 1)
-              return value;
-            else
-              return value.Substring(0, value.Length - 2) + (char)(value[value.Length - 2] + 1);
+        }
+        else {
+          if (value == string.Empty || value[value.Length - 1] != char.MaxValue) {
+            return value + char.MinValue;
+          }
+          else { // Ends with Char.MaxValue
+            return value.Length == 1
+              ? value
+              : value.Substring(0, value.Length - 2) + (char) (value[value.Length - 2] + 1);
+          }
+        }
       }
       else {
         // Prev value
-        if (String.IsNullOrEmpty(value))
+        if (string.IsNullOrEmpty(value)) {
           return null;
-        else
-          if (value[value.Length - 1] != Char.MinValue)
-            return value.Substring(0, value.Length - 1) + (char)(value[value.Length - 1] - 1) + Char.MaxValue;      
-          else
-            return value.Substring(0, value.Length - 1);
+        }
+        else {
+          return value[value.Length - 1] != char.MinValue
+            ? value.Substring(0, value.Length - 1) + (char) (value[value.Length - 1] - 1) + char.MaxValue
+            : value.Substring(0, value.Length - 1);
+        }
       }
     }
 
     private void Initialize()
     {
       ValueRangeInfo = new ValueRangeInfo<string>(true, null, false, null, false, null);
-      CultureInfo culture = ComparisonRules.Value.Culture;
+      var culture = ComparisonRules.Value.Culture;
       if (culture != null) {
         stringCompare  = culture.CompareInfo.Compare;
         stringIsSuffix = culture.CompareInfo.IsSuffix;
@@ -102,17 +103,21 @@ namespace Xtensive.Comparison
     }
 
     private static int CompareOrdinal(string first, string second, CompareOptions options)
-    {
-      return string.CompareOrdinal(first, second);
-    }
+      => string.CompareOrdinal(first, second);
 
-    
+
     // Constructors
 
     public StringComparer(IComparerProvider provider, ComparisonRules comparisonRules) 
       : base(provider, comparisonRules)
     {
       Initialize();
+    }
+
+    public StringComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
+
     }
 
     public override void OnDeserialization(object sender)

--- a/Orm/Xtensive.Orm/Comparison/Internals/StringComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/StringComparer.cs
@@ -117,7 +117,6 @@ namespace Xtensive.Comparison
     public StringComparer(SerializationInfo info, StreamingContext context)
       : base(info, context)
     {
-
     }
 
     public override void OnDeserialization(object sender)

--- a/Orm/Xtensive.Orm/Comparison/Internals/SystemComparerStruct.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/SystemComparerStruct.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.02.10
 
@@ -19,15 +19,15 @@ namespace Xtensive.Comparison
     public readonly new Predicate<T, T> Equals;
     public readonly new Func<T, int> GetHashCode;
 
-    
+
     // Constructors
-    
+
     private SystemComparerStruct(bool ignore)
     {
-      IComparer<T> comparer = 
+      var comparer = 
         (IComparer<T>)Comparer<T>.Default ?? 
         (IComparer<T>)(object)NoSystemComparerHandler<T>.Instance;
-      IEqualityComparer<T> equalityComparer = 
+      var equalityComparer = 
         (IEqualityComparer<T>)EqualityComparer<T>.Default ?? 
         (IEqualityComparer<T>)(object)NoSystemComparerHandler<T>.Instance;
       Compare = comparer.Compare;

--- a/Orm/Xtensive.Orm/Comparison/Internals/TupleComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/TupleComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.29
 
 using System;
+using System.Runtime.Serialization;
 using Tuple = Xtensive.Tuples.Tuple;
 
 namespace Xtensive.Comparison
@@ -17,19 +18,12 @@ namespace Xtensive.Comparison
     private int nullHashCode;
 
     protected override IAdvancedComparer<Tuple> CreateNew(ComparisonRules rules)
-    {
-      return new TupleComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new TupleComparer(Provider, ComparisonRules.Combine(rules));
 
     public override int Compare(Tuple x, Tuple y)
-    {
-      throw new NotSupportedException();
-    }
+      => throw new NotSupportedException();
 
-    public override bool Equals(Tuple x, Tuple y)
-    {
-      return object.Equals(x, y);
-    }
+    public override bool Equals(Tuple x, Tuple y) => object.Equals(x, y);
 
     public override int GetHashCode(Tuple obj)
     {
@@ -39,9 +33,7 @@ namespace Xtensive.Comparison
     }
 
     private void Initialize()
-    {
-      nullHashCode = SystemComparerStruct<Tuple>.Instance.GetHashCode(null);
-    }
+      => nullHashCode = SystemComparerStruct<Tuple>.Instance.GetHashCode(null);
 
 
     // Constructors
@@ -50,6 +42,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       Initialize();
+    }
+
+    public TupleComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
 
     public override void OnDeserialization(object sender)

--- a/Orm/Xtensive.Orm/Comparison/Internals/TupleDescriptorComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/TupleDescriptorComparer.cs
@@ -1,11 +1,12 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.22
 
 using System;
 using System.Reflection;
+using System.Runtime.Serialization;
 using Xtensive.Collections;
 using Xtensive.Core;
 
@@ -19,29 +20,24 @@ namespace Xtensive.Comparison
     ISystemComparer<TupleDescriptor>
   {
     protected override IAdvancedComparer<TupleDescriptor> CreateNew(ComparisonRules rules)
-    {
-      return new TupleDescriptorComparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new TupleDescriptorComparer(Provider, ComparisonRules.Combine(rules));
 
-    public override int Compare(TupleDescriptor x, TupleDescriptor y)
-    {
-      throw new NotSupportedException();
-    }
+    public override int Compare(TupleDescriptor x, TupleDescriptor y) => throw new NotSupportedException();
 
-    public override bool Equals(TupleDescriptor x, TupleDescriptor y)
-    {
-      return x==y;
-    }
+    public override bool Equals(TupleDescriptor x, TupleDescriptor y) => x == y;
 
     public override int GetHashCode(TupleDescriptor obj)
-    {
-      return AdvancedComparerStruct<TupleDescriptor>.System.GetHashCode(obj);
-    }
+      => AdvancedComparerStruct<TupleDescriptor>.System.GetHashCode(obj);
 
     // Constructors
 
     public TupleDescriptorComparer(IComparerProvider provider, ComparisonRules comparisonRules)
       : base(provider, comparisonRules)
+    {
+    }
+
+    public TupleDescriptorComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
     {
     }
 

--- a/Orm/Xtensive.Orm/Comparison/Internals/UInt16Comparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/UInt16Comparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class UInt16Comparer : ValueTypeComparer<ushort>
   {
     protected override IAdvancedComparer<ushort> CreateNew(ComparisonRules rules)
-    {
-      return new UInt16Comparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new UInt16Comparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -23,6 +22,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<ushort>(true, ushort.MinValue, true, ushort.MaxValue, true, 1);
+    }
+
+    public UInt16Comparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/UInt32Comparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/UInt32Comparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class UInt32Comparer : ValueTypeComparer<uint>
   {
     protected override IAdvancedComparer<uint> CreateNew(ComparisonRules rules)
-    {
-      return new UInt32Comparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new UInt32Comparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -23,6 +22,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<uint>(true, uint.MinValue, true, uint.MaxValue, true, 1);
+    }
+
+    public UInt32Comparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/UInt64Comparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/UInt64Comparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
 // Created:    2007.11.28
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -12,9 +13,7 @@ namespace Xtensive.Comparison
   internal sealed class UInt64Comparer : ValueTypeComparer<ulong>
   {
     protected override IAdvancedComparer<ulong> CreateNew(ComparisonRules rules)
-    {
-      return new UInt64Comparer(Provider, ComparisonRules.Combine(rules));
-    }
+      => new UInt64Comparer(Provider, ComparisonRules.Combine(rules));
 
 
     // Constructors
@@ -23,6 +22,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       ValueRangeInfo = new ValueRangeInfo<ulong>(true, ulong.MinValue, true, ulong.MaxValue, true, 1);
+    }
+
+    public UInt64Comparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/Internals/ValueTypeComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/ValueTypeComparer.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.23
 
@@ -17,44 +17,32 @@ namespace Xtensive.Comparison
     where T: struct, IComparable<T>, IEquatable<T>
   {
     protected override IAdvancedComparer<T> CreateNew(ComparisonRules rules)
-    {
-      return new ValueTypeComparer<T>(Provider, ComparisonRules.Combine(rules));
-    }
+      => new ValueTypeComparer<T>(Provider, ComparisonRules.Combine(rules));
 
     public override int Compare(T x, T y)
-    {
-      return x.CompareTo(y) 
-        * DefaultDirectionMultiplier;
-    }
+      => x.CompareTo(y) * DefaultDirectionMultiplier;
 
-    public override bool Equals(T x, T y)
-    {
-      return x.Equals(y);
-    }
+    public override bool Equals(T x, T y) => x.Equals(y);
 
-    public override int GetHashCode(T obj)
-    {
-      return obj.GetHashCode();
-    }
+    public override int GetHashCode(T obj) => obj.GetHashCode();
 
     private void Initialize()
     {
-      Type valueTypeComparerType = typeof (ValueTypeComparer<T>);
-      Type myType = GetType();
-      Type tType = typeof (T);
-      
-      MethodInfo mCompare = myType.GetMethod("Compare", 
-        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-        null, new Type[] {tType, tType}, null);
-      UsesDefaultCompare = mCompare.DeclaringType==valueTypeComparerType;
-      MethodInfo mEquals = myType.GetMethod("Equals",
-        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-        null, new Type[] {tType, tType}, null);
-      UsesDefaultEquals = mEquals.DeclaringType==valueTypeComparerType;
-      MethodInfo mGetHashCode = myType.GetMethod("GetHashCode", 
-        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-        null, new Type[] {tType}, null);
-      UsesDefaultGetHashCode = mGetHashCode.DeclaringType==valueTypeComparerType;
+      var valueTypeComparerType = typeof(ValueTypeComparer<T>);
+      var myType = GetType();
+      var tType = typeof (T);
+
+      var searchFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+      var mCompare = myType.GetMethod("Compare", searchFlags,
+        null, new Type[] { tType, tType }, null);
+      UsesDefaultCompare = mCompare.DeclaringType == valueTypeComparerType;
+      var mEquals = myType.GetMethod("Equals", searchFlags,
+        null, new Type[] { tType, tType }, null);
+      UsesDefaultEquals = mEquals.DeclaringType == valueTypeComparerType;
+      var mGetHashCode = myType.GetMethod("GetHashCode", searchFlags,
+        null, new Type[] { tType }, null);
+      UsesDefaultGetHashCode = mGetHashCode.DeclaringType == valueTypeComparerType;
     }
 
 
@@ -64,6 +52,11 @@ namespace Xtensive.Comparison
       : base(provider, comparisonRules)
     {
       Initialize();
+    }
+
+    public ValueTypeComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
     }
 
     public override void OnDeserialization(object sender)

--- a/Orm/Xtensive.Orm/Comparison/Internals/ValueTypeComparerBase.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/ValueTypeComparerBase.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.23
 
@@ -27,6 +27,11 @@ namespace Xtensive.Comparison
 
     public ValueTypeComparerBase(IComparerProvider provider, ComparisonRules comparisonRules)
       : base(provider, comparisonRules)
+    {
+    }
+
+    public ValueTypeComparerBase(SerializationInfo info, StreamingContext context)
+      : base(info, context)
     {
     }
   }

--- a/Orm/Xtensive.Orm/Comparison/SystemComparer.cs
+++ b/Orm/Xtensive.Orm/Comparison/SystemComparer.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.02.10
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -22,33 +23,28 @@ namespace Xtensive.Comparison
 
     /// <inheritdoc/>
     protected override IAdvancedComparer<T> CreateNew(ComparisonRules rules)
-    {
-      return new SystemComparer<T>(Provider, ComparisonRules.Combine(rules));
-    }
+      => new SystemComparer<T>(Provider, ComparisonRules.Combine(rules));
 
     /// <inheritdoc/>
     public override int Compare(T x, T y)
-    {
-      return SystemComparerStruct<T>.Instance.Compare(x, y) * DefaultDirectionMultiplier;
-    }
+      => SystemComparerStruct<T>.Instance.Compare(x, y) * DefaultDirectionMultiplier;
 
     /// <inheritdoc/>
-    public override bool Equals(T x, T y)
-    {
-      return SystemComparerStruct<T>.Instance.Equals(x, y);
-    }
+    public override bool Equals(T x, T y) => SystemComparerStruct<T>.Instance.Equals(x, y);
 
     /// <inheritdoc/>
-    public override int GetHashCode(T obj)
-    {
-      return SystemComparerStruct<T>.Instance.GetHashCode(obj);
-    }
+    public override int GetHashCode(T obj) => SystemComparerStruct<T>.Instance.GetHashCode(obj);
 
 
     // Constructors
 
     internal SystemComparer(IComparerProvider provider, ComparisonRules comparisonRules)
       : base(provider, comparisonRules)
+    {
+    }
+
+    public SystemComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
     {
     }
   }

--- a/Orm/Xtensive.Orm/Comparison/SystemComparerProvider.cs
+++ b/Orm/Xtensive.Orm/Comparison/SystemComparerProvider.cs
@@ -1,11 +1,12 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.02.10
 
 using System;
 using System.Diagnostics;
+using System.Runtime.Serialization;
 
 namespace Xtensive.Comparison
 {
@@ -29,16 +30,20 @@ namespace Xtensive.Comparison
     protected override TAssociate CreateAssociate<TKey, TAssociate>(out Type foundFor)
     {
       TAssociate associate = base.CreateAssociate<TKey, TAssociate>(out foundFor);
-      if (associate is ISystemComparer<TKey>)
-        return associate;
-      else
-        return (TAssociate) SystemComparer<TKey>.Instance;
+      return associate is ISystemComparer<TKey>
+        ? associate
+        : (TAssociate) SystemComparer<TKey>.Instance;
     }
 
 
     // Constructors
 
     private SystemComparerProvider()
+    {
+    }
+
+    public SystemComparerProvider(SerializationInfo info, StreamingContext context)
+      : base(info, context)
     {
     }
   }

--- a/Orm/Xtensive.Orm/Comparison/WrappingComparer{T,TBase1,TBase2}.cs
+++ b/Orm/Xtensive.Orm/Comparison/WrappingComparer{T,TBase1,TBase2}.cs
@@ -1,10 +1,12 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.21
 
 using System;
+using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Core;
 
 
@@ -42,6 +44,21 @@ namespace Xtensive.Comparison
       ArgumentValidator.EnsureArgumentNotNull(provider, "provider");
       BaseComparer1 = provider.GetComparer<TBase1>().ApplyRules(comparisonRules[0]);
       BaseComparer2 = provider.GetComparer<TBase2>().ApplyRules(comparisonRules[1]);
+    }
+
+    public WrappingComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
+      BaseComparer1 = (AdvancedComparerStruct<TBase1>) info.GetValue(nameof(BaseComparer1), typeof(AdvancedComparerStruct<TBase1>));
+      BaseComparer2 = (AdvancedComparerStruct<TBase2>) info.GetValue(nameof(BaseComparer2), typeof(AdvancedComparerStruct<TBase2>));
+    }
+
+    [SecurityCritical]
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+      base.GetObjectData(info, context);
+      info.AddValue(nameof(BaseComparer1), BaseComparer1, BaseComparer1.GetType());
+      info.AddValue(nameof(BaseComparer2), BaseComparer2, BaseComparer2.GetType());
     }
   }
 }

--- a/Orm/Xtensive.Orm/Comparison/WrappingComparer{T,TBase}.cs
+++ b/Orm/Xtensive.Orm/Comparison/WrappingComparer{T,TBase}.cs
@@ -1,10 +1,12 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.01.21
 
 using System;
+using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Core;
 
 
@@ -37,6 +39,19 @@ namespace Xtensive.Comparison
     {
       ArgumentValidator.EnsureArgumentNotNull(provider, "provider");
       BaseComparer = provider.GetComparer<TBase>().ApplyRules(comparisonRules);
+    }
+
+    public WrappingComparer(SerializationInfo info, StreamingContext context)
+      : base(info, context)
+    {
+      BaseComparer = (AdvancedComparerStruct<TBase>) info.GetValue(nameof(BaseComparer), typeof(AdvancedComparerStruct<TBase>));
+    }
+
+    [SecurityCritical]
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+      base.GetObjectData(info, context);
+      info.AddValue(nameof(BaseComparer), BaseComparer, BaseComparer.GetType());
     }
   }
 }

--- a/Orm/Xtensive.Orm/Core/AssociateProvider.cs
+++ b/Orm/Xtensive.Orm/Core/AssociateProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Gamzov
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Security;
 using System.Text;
 using System.Threading;
 using Xtensive.Collections;
@@ -25,18 +26,20 @@ namespace Xtensive.Core
   /// </summary>
   [Serializable]
   public abstract class AssociateProvider :
-    IDeserializationCallback
+    IDeserializationCallback,
+    ISerializable
   {
     private static readonly AsyncLocal<SetSlim<TypePair>> inProgressAsync = new AsyncLocal<SetSlim<TypePair>>();
 
     private static SetSlim<TypePair> InProgress
     {
       get {
-        if (inProgressAsync.Value==null)
+        if (inProgressAsync.Value == null) {
           inProgressAsync.Value = new SetSlim<TypePair>();
+        }
         return inProgressAsync.Value;
       }
-      set { inProgressAsync.Value = value; }
+      set => inProgressAsync.Value = value;
     }
 
     [NonSerialized]
@@ -55,19 +58,20 @@ namespace Xtensive.Core
     protected object[] ConstructorParams
     {
       [DebuggerStepThrough]
-      get { return constructorParams; }
+      get => constructorParams;
       [DebuggerStepThrough]
-      set { constructorParams = value; }
+      set => constructorParams = value;
     }
 
     /// <summary>
     /// Gets or sets associate type suffixes.
     /// </summary>
-    protected string[] TypeSuffixes { 
+    protected string[] TypeSuffixes
+    {
       [DebuggerStepThrough]
-      get { return typeSuffixes; }
+      get => typeSuffixes;
       [DebuggerStepThrough]
-      set { typeSuffixes = value; }
+      set => typeSuffixes = value;
     }
 
     /// <summary>
@@ -91,10 +95,12 @@ namespace Xtensive.Core
     {
       lock (_lock) {
         var newHighPriorityLocations = new List<Pair<Assembly, string>>(highPriorityLocations);
-        if (overriding)
+        if (overriding) {
           newHighPriorityLocations.Insert(0, new Pair<Assembly, string>(assembly, nameSpace));
-        else
+        }
+        else {
           newHighPriorityLocations.Add(new Pair<Assembly, string>(assembly, nameSpace));
+        }
         Thread.MemoryBarrier();
         highPriorityLocations = newHighPriorityLocations;
       }
@@ -103,10 +109,7 @@ namespace Xtensive.Core
     /// <summary>
     /// Gets a list of high priority locations.
     /// </summary>
-    protected List<Pair<Assembly, string>> HighPriorityLocations
-    {
-      get { return highPriorityLocations; }
-    }
+    protected List<Pair<Assembly, string>> HighPriorityLocations => highPriorityLocations;
 
     /// <summary>
     /// Gets associate instance for specified parameter and result types.
@@ -120,11 +123,9 @@ namespace Xtensive.Core
     protected TResult GetAssociate<TKey, TAssociate, TResult>()
       where TAssociate : class
     {
-      var key = new TypePair(typeof (TKey), typeof (TResult));
-      return (TResult) cache.GetValue(key, _key => {
-        Type foundFor;
-        return ConvertAssociate<TKey, TAssociate, TResult>(CreateAssociate<TKey, TAssociate>(out foundFor));
-      });
+      var key = new TypePair(typeof(TKey), typeof(TResult));
+      return (TResult) cache.GetValue(key,
+        _key => ConvertAssociate<TKey, TAssociate, TResult>(CreateAssociate<TKey, TAssociate>(out var foundFor)));
     }
 
     /// <summary>
@@ -141,30 +142,22 @@ namespace Xtensive.Core
     protected TResult GetAssociate<TKey1, TKey2, TAssociate, TResult>()
       where TAssociate : class
     {
-      var key = new TypePair(typeof (TKey1), typeof (TResult));
+      var key = new TypePair(typeof(TKey1), typeof(TResult));
       return (TResult) cache.GetValue(key, _key => {
-        Type foundFor;
-        TAssociate associate1 = CreateAssociate<TKey1, TAssociate>(out foundFor);
-        TAssociate associate2 = CreateAssociate<TKey2, TAssociate>(out foundFor);
+        var associate1 = CreateAssociate<TKey1, TAssociate>(out var foundFor);
+        var associate2 = CreateAssociate<TKey2, TAssociate>(out foundFor);
         // Preferring non-null ;)
-        TAssociate associate;
-        if (associate1==null)
-          associate = associate2;
-        else if (associate2==null)
-          associate = associate1;
-        else
-          // Both are non-null; preferring one of two
-          associate = PreferAssociate<TKey1, TKey2, TAssociate>(associate1, associate2);
-        if (associate==null) {
+        var associate = associate1 ?? associate2 ?? PreferAssociate<TKey1, TKey2, TAssociate>(associate1, associate2);
+        if (associate == null) {
           // Try to get complex associate (create it manually)
           associate = CreateCustomAssociate<TKey1, TKey2, TAssociate>();
-          if (associate==null) {
+          if (associate == null) {
             var stringBuilder = new StringBuilder();
-            for (int i = 0; i < TypeSuffixes.Length; i++) {
-              if (i!=0) {
-                stringBuilder.Append(", ");
+            for (var i = 0; i < TypeSuffixes.Length; i++) {
+              if (i != 0) {
+                _ = stringBuilder.Append(", ");
               }
-              stringBuilder.Append(TypeSuffixes[i]);
+              _ = stringBuilder.Append(TypeSuffixes[i]);
             }
             throw new InvalidOperationException(string.Format(
               Strings.ExCantFindAssociate2, stringBuilder,
@@ -189,12 +182,9 @@ namespace Xtensive.Core
     protected virtual TAssociate PreferAssociate<TKey1, TKey2, TAssociate>(TAssociate associate1,
       TAssociate associate2)
     {
-      int locationPosition1 = GetAssociateLocationPosition(associate1);
-      int locationPosition2 = GetAssociateLocationPosition(associate2);
-      if (locationPosition1 <= locationPosition2)
-        return associate1;
-      else
-        return associate2;
+      var locationPosition1 = GetAssociateLocationPosition(associate1);
+      var locationPosition2 = GetAssociateLocationPosition(associate2);
+      return locationPosition1 <= locationPosition2 ? associate1 : associate2;
     }
 
     /// <summary>
@@ -211,9 +201,11 @@ namespace Xtensive.Core
         associate.GetType().Assembly,
         associate.GetType().Namespace);
       var hpl = HighPriorityLocations;
-      for (int i = 0; i < hpl.Count; i++)
-        if (AdvancedComparerStruct<Pair<Assembly, string>>.Default.Equals(hpl[i], entry))
+      for (var i = 0; i < hpl.Count; i++) {
+        if (AdvancedComparerStruct<Pair<Assembly, string>>.Default.Equals(hpl[i], entry)) {
           return i;
+        }
+      }
       return int.MaxValue;
     }
 
@@ -229,19 +221,22 @@ namespace Xtensive.Core
     protected virtual TAssociate CreateAssociate<TKey, TAssociate>(out Type foundFor)
       where TAssociate : class
     {
-      if (InProgress==null)
+      if (InProgress == null) {
         InProgress = new SetSlim<TypePair>();
-      var progressionMark = new TypePair(typeof (TKey), typeof (TAssociate));
-      if (InProgress.Contains(progressionMark))
+      }
+
+      var progressionMark = new TypePair(typeof(TKey), typeof(TAssociate));
+      if (InProgress.Contains(progressionMark)) {
         throw new InvalidOperationException(Strings.ExRecursiveAssociateLookupDetected);
-      InProgress.Add(progressionMark);
+      }
+      _ = InProgress.Add(progressionMark);
       try {
         var associate = TypeHelper.CreateAssociate<TAssociate>(
-          typeof (TKey), out foundFor, TypeSuffixes, constructorParams, highPriorityLocations);
+          typeof(TKey), out foundFor, TypeSuffixes, constructorParams, highPriorityLocations);
         return associate;
       }
       finally {
-        InProgress.Remove(progressionMark);
+        _ = InProgress.Remove(progressionMark);
       }
     }
 
@@ -255,9 +250,7 @@ namespace Xtensive.Core
     /// <returns>Associate instance or <see langword="null"/>.</returns>
     protected virtual TAssociate CreateCustomAssociate<TKey1, TKey2, TAssociate>()
       where TAssociate : class
-    {
-      return null;
-    }
+      => null;
 
     /// <summary>
     /// Converts <paramref name="associate"/> to <typeparamref name="TResult"/> object.
@@ -268,9 +261,7 @@ namespace Xtensive.Core
     /// <param name="associate">Associate to convert to result.</param>
     /// <returns>Conversion result.</returns>
     protected virtual TResult ConvertAssociate<TKey, TAssociate, TResult>(TAssociate associate)
-    {
-      return (TResult) (object) associate;
-    }
+      => (TResult) (object) associate;
 
     /// <summary>
     /// Converts <paramref name="associate"/> to <typeparamref name="TResult"/> object.
@@ -282,9 +273,7 @@ namespace Xtensive.Core
     /// <param name="associate">Associate to convert to result.</param>
     /// <returns>Conversion result.</returns>
     protected virtual TResult ConvertAssociate<TKey1, TKey2, TAssociate, TResult>(TAssociate associate)
-    {
-      return (TResult) (object) associate;
-    }
+      => (TResult) (object) associate;
 
 
     // Constructors
@@ -294,9 +283,26 @@ namespace Xtensive.Core
     /// </summary>
     protected AssociateProvider()
     {
-      constructorParams = new object[] {this};
+      constructorParams = new object[] { this };
       _lock = new object();
       cache = ThreadSafeDictionary<TypePair, object>.Create(_lock);
+    }
+
+    protected AssociateProvider(SerializationInfo info, StreamingContext context)
+    {
+      if (info == null) {
+        throw new ArgumentNullException(nameof(info));
+      }
+
+      var constructorParamsExceptThis = (object[]) info.GetValue(nameof(constructorParams), typeof(object[]));
+      constructorParams = new object[constructorParamsExceptThis.Length + 1];
+      constructorParams[0] = this;
+      Array.Copy(constructorParamsExceptThis, 0, constructorParams, 1, constructorParamsExceptThis.Length);
+
+      typeSuffixes = (string[]) info.GetValue(nameof(typeSuffixes), typeof(string[]));
+
+      var highPriorityLocationsSerializable = (List<Pair<string, string>>) info.GetValue(nameof(highPriorityLocations), typeof(List<Pair<string, string>>));
+      highPriorityLocations = highPriorityLocationsSerializable.SelectToList(ls => new Pair<Assembly, string>(Assembly.Load(ls.First), ls.Second));
     }
 
     /// <summary>
@@ -307,6 +313,26 @@ namespace Xtensive.Core
     {
       _lock = new object();
       cache = ThreadSafeDictionary<TypePair, object>.Create(_lock);
+    }
+
+    /// <inheritdoc/>
+    [SecurityCritical]
+    public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+      object[] constructorParamsExceptThis = null;
+      // need to exclude this form parameters to prevent loop
+      if (constructorParams.Length == 1) {
+        constructorParamsExceptThis = Array.Empty<object>();
+      }
+      else {
+        constructorParamsExceptThis = new object[constructorParams.Length - 1];
+        Array.Copy(constructorParams, 1, constructorParamsExceptThis, 0, constructorParamsExceptThis.Length);
+      }
+      info.AddValue(nameof(constructorParams), constructorParamsExceptThis, constructorParams.GetType());
+      info.AddValue(nameof(typeSuffixes), typeSuffixes, typeSuffixes.GetType());
+
+      var highPriorityLocationsSerializable = highPriorityLocations.SelectToList(l => new Pair<string, string>(l.First.FullName, l.Second));
+      info.AddValue(nameof(highPriorityLocations), highPriorityLocationsSerializable, highPriorityLocationsSerializable.GetType());
     }
   }
 }

--- a/Orm/Xtensive.Orm/Core/AssociateProvider.cs
+++ b/Orm/Xtensive.Orm/Core/AssociateProvider.cs
@@ -147,7 +147,17 @@ namespace Xtensive.Core
         var associate1 = CreateAssociate<TKey1, TAssociate>(out var foundFor);
         var associate2 = CreateAssociate<TKey2, TAssociate>(out foundFor);
         // Preferring non-null ;)
-        var associate = associate1 ?? associate2 ?? PreferAssociate<TKey1, TKey2, TAssociate>(associate1, associate2);
+        TAssociate associate = null;
+        if (associate1 == null) {
+          associate = associate2;
+        }
+        else if (associate2 == null) {
+          associate = associate1;
+        }
+        else {
+          // Both are non-null; preferring one of two
+          associate = PreferAssociate<TKey1, TKey2, TAssociate>(associate1, associate2);
+        }
         if (associate == null) {
           // Try to get complex associate (create it manually)
           associate = CreateCustomAssociate<TKey1, TKey2, TAssociate>();
@@ -161,9 +171,9 @@ namespace Xtensive.Core
             }
             throw new InvalidOperationException(string.Format(
               Strings.ExCantFindAssociate2, stringBuilder,
-              typeof (TAssociate).GetShortName(),
-              typeof (TKey1).GetShortName(),
-              typeof (TKey2).GetShortName()));
+              typeof(TAssociate).GetShortName(),
+              typeof(TKey1).GetShortName(),
+              typeof(TKey2).GetShortName()));
           }
         }
         return ConvertAssociate<TKey1, TKey2, TAssociate, TResult>(associate);

--- a/Orm/Xtensive.Orm/Core/MethodCacheBase.cs
+++ b/Orm/Xtensive.Orm/Core/MethodCacheBase.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2008.02.10
 
@@ -44,7 +44,7 @@ namespace Xtensive.Core
     /// <param name="context"></param>
     protected MethodCacheBase(SerializationInfo info, StreamingContext context)
     {
-      Implementation = (TImplementation)info.GetValue("Implementation", typeof(TImplementation));
+      Implementation = (TImplementation) info.GetValue("Implementation", typeof(TImplementation));
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ namespace Xtensive.Core
     [SecurityCritical]
     public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
     {
-      info.AddValue("Implementation", Implementation);
+      info.AddValue("Implementation", Implementation, Implementation.GetType());
     }
   }
 }

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableBinaryExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableBinaryExpression.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
@@ -8,6 +8,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -33,9 +34,9 @@ namespace Xtensive.Linq.SerializableExpressions
     /// <summary>
     /// <see cref="BinaryExpression.Method"/>
     /// </summary>
-    [NonSerialized]
     public MethodInfo Method;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableConditionalExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableConditionalExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Xtensive.Linq.SerializableExpressions
 {
@@ -29,6 +30,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableExpression IfFalse;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableConstantExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableConstantExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Xtensive.Linq.SerializableExpressions
 {
@@ -21,6 +22,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public object Value;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableElementInit.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableElementInit.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Kryuchkov
 // Created:    2009.05.14
 
@@ -8,6 +8,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -21,13 +22,13 @@ namespace Xtensive.Linq.SerializableExpressions
     /// <summary>
     /// <see cref="ElementInit.AddMethod"/>
     /// </summary>
-    [NonSerialized]
     public MethodInfo AddMethod;
     /// <summary>
     /// <see cref="ElementInit.Arguments"/>
     /// </summary>
     public SerializableExpression[] Arguments;
 
+    [SecurityCritical]
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       info.AddValue("AddMethod", AddMethod.ToSerializableForm());

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -24,9 +25,9 @@ namespace Xtensive.Linq.SerializableExpressions
     /// <summary>
     /// <see cref="Expression.Type"/>.
     /// </summary>
-    [NonSerialized]
     public Type Type;
 
+    [SecurityCritical]
     public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       info.AddValue("NodeType", NodeType.ToString());

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableInvocationExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableInvocationExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.13
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -26,6 +27,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableExpression[] Arguments;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableLambdaExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableLambdaExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -27,6 +28,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableParameterExpression[] Parameters;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableListInitExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableListInitExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.13
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -26,6 +27,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableElementInit[] Initializers;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberAssignment.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberAssignment.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.15
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Xtensive.Linq.SerializableExpressions
 {
@@ -21,6 +22,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableExpression Expression;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberBinding.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberBinding.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.15
 
@@ -8,6 +8,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -25,9 +26,9 @@ namespace Xtensive.Linq.SerializableExpressions
     /// <summary>
     /// <see cref="MemberBinding.Member"/>
     /// </summary>
-    [NonSerialized]
     public MemberInfo Member;
 
+    [SecurityCritical]
     public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       info.AddValue("Member", Member.ToSerializableForm());

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberExpression.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -26,9 +27,9 @@ namespace Xtensive.Linq.SerializableExpressions
     /// <summary>
     /// <see cref="MemberExpression.Member"/>
     /// </summary>
-    [NonSerialized]
     public MemberInfo Member;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberInitExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberInitExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.13
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -26,6 +27,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableMemberBinding[] Bindings;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberListBinding.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberListBinding.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Kryuchkov
 // Created:    2009.05.15
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -22,6 +23,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableElementInit[] Initializers;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberMemberBinding.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMemberMemberBinding.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.15
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -22,6 +23,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableMemberBinding[] Bindings;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMethodCallExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableMethodCallExpression.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
@@ -8,6 +8,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -25,7 +26,6 @@ namespace Xtensive.Linq.SerializableExpressions
     /// <summary>
     /// <see cref="MethodCallExpression.Method"/>
     /// </summary>
-    [NonSerialized]
     public MethodInfo Method;
 
     /// <summary>
@@ -33,6 +33,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableExpression Object;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableNewArrayExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableNewArrayExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.13
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -22,6 +23,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public SerializableExpression[] Expressions;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableNewExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableNewExpression.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -26,14 +27,13 @@ namespace Xtensive.Linq.SerializableExpressions
     /// <summary>
     /// <see cref="NewExpression.Constructor"/>
     /// </summary>
-    [NonSerialized]
     public ConstructorInfo Constructor;
     /// <summary>
     /// <see cref="NewExpression.Members"/>
     /// </summary>
-    [NonSerialized]
     public MemberInfo[] Members;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableParameterExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableParameterExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Xtensive.Linq.SerializableExpressions
 {
@@ -21,6 +22,7 @@ namespace Xtensive.Linq.SerializableExpressions
     /// </summary>
     public string Name;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableTypeBinaryExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableTypeBinaryExpression.cs
@@ -1,12 +1,13 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
 using System;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 using ExpressionFactory = System.Linq.Expressions.Expression;
 
@@ -25,9 +26,9 @@ namespace Xtensive.Linq.SerializableExpressions
     /// <summary>
     /// <see cref="TypeBinaryExpression.TypeOperand"/>
     /// </summary>
-    [NonSerialized]
     public Type TypeOperand;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableUnaryExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/SerializableUnaryExpression.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.05.12
 
@@ -8,6 +8,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Security;
 using Xtensive.Linq.SerializableExpressions.Internals;
 
 namespace Xtensive.Linq.SerializableExpressions
@@ -18,8 +19,6 @@ namespace Xtensive.Linq.SerializableExpressions
   [Serializable]
   public sealed class SerializableUnaryExpression : SerializableExpression
   {
-    //private string methodName;
-
     /// <summary>
     /// <see cref="UnaryExpression.Operand"/>
     /// </summary>
@@ -27,9 +26,9 @@ namespace Xtensive.Linq.SerializableExpressions
     /// <summary>
     /// <see cref="UnaryExpression.Method"/>
     /// </summary>
-    [NonSerialized]
     public MethodInfo Method;
 
+    [SecurityCritical]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
       base.GetObjectData(info, context);


### PR DESCRIPTION
A summary of what's made:
- global setup for internal logging (also updated test adapter).
- The ```ChainedBufferTest``` is now in right namespace.
- Updated MySQL client library package. The 6.10.4 had a bug causing Nested Transaction error out of nowhere.
- A lot of manual serialization implementations for some collections, comparers and comparer-related types.
- ```ISerializable.GetObjectData()``` method implementations in ```SerializableExpressions``` were marked as ```[SecurityCritical]``` like they suppose to be (actually **this is an off-topic change**, I did it for good measure since I'd already been working on serialization :) )
- The ```ThreadingTest``` lost its ```Async``` part (I commented it out) because there is no support for ```BeginInvoke/EndInvoke``` methods this part used.