### PR TITLE
Reprocessing extension without session activations inside

### DIFF
--- a/ChangeLog/6.0.6_dev.txt
+++ b/ChangeLog/6.0.6_dev.txt
@@ -1,0 +1,1 @@
+[main] Fixed possible cases of broken serialization due to comparers

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/Other.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/Other.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Reprocessing.Tests
     public void NestedSessionReuse()
     {
       Domain.Execute(session1 =>
-        Domain.WithExternalSession(session1)
+        Domain.WithSession(session1)
           .Execute(session2 => Assert.That(session1, Is.SameAs(session2))));
     }
 
@@ -82,7 +82,7 @@ namespace Xtensive.Orm.Reprocessing.Tests
         var bar = session.Query.All<Bar>().FirstOrDefault();
         bar = new Bar(session);
         session.SaveChanges();
-        Domain.WithExternalSession(session).Execute(session1 => {
+        Domain.WithSession(session).Execute(session1 => {
           bar = session1.Query.All<Bar>().FirstOrDefault();
           bar = new Bar(session1);
         });

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/Reprocessing.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/Reprocessing.cs
@@ -119,7 +119,7 @@ namespace Xtensive.Orm.Reprocessing.Tests
         Action<bool, IsolationLevel?, TransactionOpenMode?> action)
       {
         domain.WithStrategy(strategy)
-          .WithExternalSession(session)
+          .WithSession(session)
           .WithIsolationLevel(isolationLevel.GetValueOrDefault(IsolationLevel.RepeatableRead))
           .WithTransactionOpenMode(transactionOpenMode.GetValueOrDefault(TransactionOpenMode.New))
           .Execute(

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/Reprocessing.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/Reprocessing.cs
@@ -30,25 +30,25 @@ namespace Xtensive.Orm.Reprocessing.Tests
       {
         domain.WithStrategy(ExecuteActionStrategy.HandleUniqueConstraintViolation).WithIsolationLevel(isolationLevel.GetValueOrDefault(IsolationLevel.RepeatableRead)).WithTransactionOpenMode(transactionOpenMode.GetValueOrDefault(TransactionOpenMode.New)).Execute(
           session => {
-            Interlocked.Increment(ref Count);
-            new Bar2(session, DateTime.Now, Guid.NewGuid()) {Name = Guid.NewGuid().ToString()};
+            _ = Interlocked.Increment(ref Count);
+            _ = new Bar2(session, DateTime.Now, Guid.NewGuid()) { Name = Guid.NewGuid().ToString() };
             if (first) {
-              session.Query.All<Foo>().Lock(LockMode.Exclusive, LockBehavior.Wait).ToArray();
-              if (wait1!=null) {
-                wait1.Set();
-                wait2.WaitOne();
+              _ = session.Query.All<Foo>().Lock(LockMode.Exclusive, LockBehavior.Wait).ToArray();
+              if (wait1 != null) {
+                _ = wait1.Set();
+                _ = wait2.WaitOne();
                 wait1 = null;
               }
-              session.Query.All<Bar>().Lock(LockMode.Exclusive, LockBehavior.Wait).ToArray();
+              _ = session.Query.All<Bar>().Lock(LockMode.Exclusive, LockBehavior.Wait).ToArray();
             }
             else {
-              session.Query.All<Bar>().Lock(LockMode.Exclusive, LockBehavior.Wait).ToArray();
-              if (wait2!=null) {
-                wait2.Set();
-                wait1.WaitOne();
+              _ = session.Query.All<Bar>().Lock(LockMode.Exclusive, LockBehavior.Wait).ToArray();
+              if (wait2 != null) {
+                _ = wait2.Set();
+                _ = wait1.WaitOne();
                 wait2 = null;
               }
-              session.Query.All<Foo>().Lock(LockMode.Exclusive, LockBehavior.Wait).ToArray();
+              _ = session.Query.All<Foo>().Lock(LockMode.Exclusive, LockBehavior.Wait).ToArray();
             }
           });
       }
@@ -57,28 +57,28 @@ namespace Xtensive.Orm.Reprocessing.Tests
         bool first,
         IsolationLevel? isolationLevel,
         TransactionOpenMode? transactionOpenMode,
-        Action<bool, IsolationLevel?, TransactionOpenMode?> action)
+        Action<Session, bool, IsolationLevel?, TransactionOpenMode?> action)
       {
-        using (Session session = domain.OpenSession())
-        using (Xtensive.Orm.TransactionScope tran = isolationLevel==null ? null : session.OpenTransaction())
-        using (session.Activate()) {
-          if (tran!=null) {
+        using (var session = domain.OpenSession())
+        using (var tran = isolationLevel == null ? null : session.OpenTransaction()) {
+          if (tran != null) {
             session.EnsureTransactionIsStarted();
-            new Bar2(session, DateTime.Now, Guid.NewGuid()) {Name = Guid.NewGuid().ToString()};
+            _ = new Bar2(session, DateTime.Now, Guid.NewGuid()) { Name = Guid.NewGuid().ToString() };
           }
           if (first) {
-            if (wait1!=null && wait2!=null) {
-              wait1.Set();
-              wait2.WaitOne();
+            if (wait1 != null && wait2 != null) {
+              _ = wait1.Set();
+              _ = wait2.WaitOne();
             }
           }
-          else if (wait1!=null && wait2!=null) {
-            wait2.Set();
-            wait1.WaitOne();
+          else if (wait1 != null && wait2 != null) {
+            _ = wait2.Set();
+            _ = wait1.WaitOne();
           }
-          action(first, isolationLevel, transactionOpenMode);
-          if (tran!=null)
+          action(session, first, isolationLevel, transactionOpenMode);
+          if (tran != null) {
             tran.Complete();
+          }
         }
       }
 
@@ -89,22 +89,55 @@ namespace Xtensive.Orm.Reprocessing.Tests
         IExecuteActionStrategy strategy,
         Action<bool, IsolationLevel?, TransactionOpenMode?> action)
       {
-        domain.WithStrategy(strategy).WithIsolationLevel(isolationLevel.GetValueOrDefault(IsolationLevel.RepeatableRead)).WithTransactionOpenMode(transactionOpenMode.GetValueOrDefault(TransactionOpenMode.New)).Execute(
-          session => {
-            session.EnsureTransactionIsStarted();
-            new Bar2(session, DateTime.Now, Guid.NewGuid()) {Name = Guid.NewGuid().ToString()};
-            if (first) {
-              if (wait1!=null && wait2!=null) {
-                wait1.Set();
-                wait2.WaitOne();
+        domain.WithStrategy(strategy)
+          .WithIsolationLevel(isolationLevel.GetValueOrDefault(IsolationLevel.RepeatableRead))
+          .WithTransactionOpenMode(transactionOpenMode.GetValueOrDefault(TransactionOpenMode.New))
+          .Execute(
+            session => {
+              session.EnsureTransactionIsStarted();
+              _ = new Bar2(session, DateTime.Now, Guid.NewGuid()) { Name = Guid.NewGuid().ToString() };
+              if (first) {
+                if (wait1 != null && wait2 != null) {
+                  _ = wait1.Set();
+                  _ = wait2.WaitOne();
+                }
               }
-            }
-            else if (wait1!=null && wait2!=null) {
-              wait2.Set();
-              wait1.WaitOne();
-            }
-            action(first, isolationLevel, transactionOpenMode);
-          });
+              else if (wait1 != null && wait2 != null) {
+                _ = wait2.Set();
+                _ = wait1.WaitOne();
+              }
+              action(first, isolationLevel, transactionOpenMode);
+            });
+      }
+
+      public void Parent(
+        Session session,
+        bool first,
+        IsolationLevel? isolationLevel,
+        TransactionOpenMode? transactionOpenMode,
+        IExecuteActionStrategy strategy,
+        Action<bool, IsolationLevel?, TransactionOpenMode?> action)
+      {
+        domain.WithStrategy(strategy)
+          .WithExternalSession(session)
+          .WithIsolationLevel(isolationLevel.GetValueOrDefault(IsolationLevel.RepeatableRead))
+          .WithTransactionOpenMode(transactionOpenMode.GetValueOrDefault(TransactionOpenMode.New))
+          .Execute(
+            session => {
+              session.EnsureTransactionIsStarted();
+              _ = new Bar2(session, DateTime.Now, Guid.NewGuid()) { Name = Guid.NewGuid().ToString() };
+              if (first) {
+                if (wait1 != null && wait2 != null) {
+                  _ = wait1.Set();
+                  _ = wait2.WaitOne();
+                }
+              }
+              else if (wait1 != null && wait2 != null) {
+                _ = wait2.Set();
+                _ = wait1.WaitOne();
+              }
+              action(first, isolationLevel, transactionOpenMode);
+            });
       }
 
       public void Run(
@@ -117,8 +150,8 @@ namespace Xtensive.Orm.Reprocessing.Tests
             session.Remove(session.Query.All<Foo>());
             session.Remove(session.Query.All<Bar>());
             session.Remove(session.Query.All<Bar2>());
-            new Bar(session);
-            new Foo(session);
+            _ = new Bar(session);
+            _ = new Foo(session);
           });
         Parallel.Invoke(
           () => action(true, isolationLevel, transactionOpenMode),
@@ -130,24 +163,24 @@ namespace Xtensive.Orm.Reprocessing.Tests
       {
         domain.WithStrategy(ExecuteActionStrategy.HandleUniqueConstraintViolation).WithIsolationLevel(isolationLevel.GetValueOrDefault(IsolationLevel.RepeatableRead)).WithTransactionOpenMode(transactionOpenMode.GetValueOrDefault(TransactionOpenMode.New)).Execute(
           session => {
-            Interlocked.Increment(ref Count);
+            _ = Interlocked.Increment(ref Count);
             session.EnsureTransactionIsStarted();
-            new Bar2(session, DateTime.Now, Guid.NewGuid()) {Name = Guid.NewGuid().ToString()};
-            string name = "test";
-            if (!session.Query.All<Foo>().Any(a => a.Name==name)) {
+            _ = new Bar2(session, DateTime.Now, Guid.NewGuid()) { Name = Guid.NewGuid().ToString() };
+            var name = "test";
+            if (!session.Query.All<Foo>().Any(a => a.Name == name)) {
               if (first) {
-                if (wait1!=null && wait2!=null) {
-                  wait1.Set();
-                  wait2.WaitOne();
+                if (wait1 != null && wait2 != null) {
+                  _ = wait1.Set();
+                  _ = wait2.WaitOne();
                   wait1 = null;
                 }
               }
-              else if (wait2!=null && wait2!=null) {
-                wait2.Set();
-                wait1.WaitOne();
+              else if (wait2 != null && wait2 != null) {
+                _ = wait2.Set();
+                _ = wait1.WaitOne();
                 wait2 = null;
               }
-              new Foo(session) {Name = name};
+              _ = new Foo(session) { Name = name };
             }
             session.SaveChanges();
           });
@@ -158,26 +191,26 @@ namespace Xtensive.Orm.Reprocessing.Tests
       {
         domain.WithStrategy(ExecuteActionStrategy.HandleUniqueConstraintViolation).WithIsolationLevel(isolationLevel.GetValueOrDefault(IsolationLevel.RepeatableRead)).WithTransactionOpenMode(transactionOpenMode.GetValueOrDefault(TransactionOpenMode.New)).Execute(
           session => {
-            Interlocked.Increment(ref Count);
+            _ = Interlocked.Increment(ref Count);
             session.EnsureTransactionIsStarted();
-            new Bar2(session, DateTime.Now, Guid.NewGuid()) {Name = Guid.NewGuid().ToString()};
-            int id = 10;
+            _ = new Bar2(session, DateTime.Now, Guid.NewGuid()) { Name = Guid.NewGuid().ToString() };
+            var id = 10;
             if (session.Query.SingleOrDefault<Foo>(id)==null) {
-              AutoResetEvent w1 = wait1;
-              AutoResetEvent w2 = wait2;
+              var w1 = wait1;
+              var w2 = wait2;
               if (first) {
                 if (w1!=null && w2!=null) {
-                  w1.Set();
-                  w2.WaitOne();
+                  _ = w1.Set();
+                  _ = w2.WaitOne();
                   wait1 = null;
                 }
               }
               else if (w1!=null && w2!=null) {
-                w2.Set();
-                w1.WaitOne();
+                _ = w2.Set();
+                _ = w1.WaitOne();
                 wait2 = null;
               }
-              new Foo(session, id) {Name = Guid.NewGuid().ToString()};
+              _ = new Foo(session, id) { Name = Guid.NewGuid().ToString() };
             }
             session.SaveChanges();
           });
@@ -269,8 +302,9 @@ namespace Xtensive.Orm.Reprocessing.Tests
             b,
             null,
             open,
-            (b1, level1, open1) =>
+            (s, b1, level1, open1) =>
               context.Parent(
+                s,
                 b1,
                 IsolationLevel.Snapshot,
                 open1,
@@ -281,30 +315,24 @@ namespace Xtensive.Orm.Reprocessing.Tests
 
       //ExternalWithTransaction nested snapshot UniqueConstraint
       context = new Context(Domain);
-      var ex =
-        Assert.Throws<AggregateException>(
-          () =>
-            context.Run(
-              IsolationLevel.Snapshot,
-              null,
-              (b, level, open) =>
-                context.External(
-                  b,
-                  level,
-                  open,
-                  (b1, level1, open1) =>
-                    context.Parent(
-                      b1,
-                      level1,
-                      open1,
-                      ExecuteActionStrategy.HandleUniqueConstraintViolation,
-                      context.UniqueConstraintViolation))));
-      Assert.That(
-        ex.InnerExceptions.Single(),
-        Is.TypeOf<InvalidOperationException>().Or.TypeOf<StorageException>().With.Property("InnerException").TypeOf
-          <InvalidOperationException>());
-      Assert.That(context.Count, Is.EqualTo(2));
-      Assert.That(Bar2Count(), Is.EqualTo(3));
+      context.Run(
+        IsolationLevel.Snapshot,
+        null,
+        (b, level, open) =>
+          context.External(
+            b,
+            level,
+            open,
+            (s, b1, level1, open1) =>
+              context.Parent(
+                s,
+                b1,
+                level1,
+                open1,
+                ExecuteActionStrategy.HandleUniqueConstraintViolation,
+                context.UniqueConstraintViolation)));
+      Assert.That(context.Count, Is.EqualTo(3));
+      Assert.That(Bar2Count(), Is.EqualTo(6));
 
       //nested UniqueConstraint with auto transaction
       context = new Context(Domain);
@@ -335,18 +363,19 @@ namespace Xtensive.Orm.Reprocessing.Tests
     [Test]
     public void UniqueConstraintViolationExceptionUnique()
     {
-      int i = 0;
-      bool b = false;
-      ExecuteActionStrategy.HandleUniqueConstraintViolation.Error += (sender, args) => b = true;
+      var i = 0;
+      var errorNotified = false;
+      ExecuteActionStrategy.HandleUniqueConstraintViolation.Error += (sender, args) => errorNotified = true;
       Domain.WithStrategy(ExecuteActionStrategy.HandleUniqueConstraintViolation).Execute(
         session => {
-          new Foo(session) {Name = "test"};
+          _ = new Foo(session) { Name = "test" };
           i++;
-          if (i < 5)
-            new Foo(session) {Name = "test"};
+          if (i < 5) {
+            _ = new Foo(session) { Name = "test" };
+          }
         });
       Assert.That(i, Is.EqualTo(5));
-      Assert.That(b, Is.True);
+      Assert.That(errorNotified, Is.True);
     }
   }
 }

--- a/Extensions/Xtensive.Orm.Reprocessing/DomainExtensions.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/DomainExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Transactions;
 using Xtensive.Orm.Reprocessing.Configuration;
 
@@ -131,6 +131,18 @@ namespace Xtensive.Orm.Reprocessing
       return new ExecuteConfiguration(domain).WithTransactionOpenMode(transactionOpenMode);
     }
 
+    /// <summary>
+    /// Starts <see cref="IExecuteConfiguration"/> flow
+    /// and provides <see cref="Session"/> to use.
+    /// </summary>
+    /// <param name="domain">The domain.</param>
+    /// <param name="session">The external session to use.</param>
+    /// <returns>Created <see cref="IExecuteConfiguration"/>.</returns>
+    public static IExecuteConfiguration WithExternalSession(this Domain domain, Session session)
+    {
+      return new ExecuteConfiguration(domain).WithExternalSession(session);
+    }
+
     #region Non-public methods
 
     internal static void ExecuteInternal(
@@ -140,13 +152,33 @@ namespace Xtensive.Orm.Reprocessing
       IExecuteActionStrategy strategy,
       Action<Session> action)
     {
-      ExecuteInternal<object>(
+      _ = ExecuteInternal<object>(
         domain,
         isolationLevel,
         transactionOpenMode,
         strategy,
-        a => {
-          action(a);
+        sessionInstance => {
+          action(sessionInstance);
+          return null;
+        });
+    }
+
+    internal static void ExecuteInternal(
+      this Domain domain,
+      Session session,
+      IsolationLevel isolationLevel,
+      TransactionOpenMode? transactionOpenMode,
+      IExecuteActionStrategy strategy,
+      Action<Session> action)
+    {
+      _ = ExecuteInternal<object>(
+        domain,
+        session,
+        isolationLevel,
+        transactionOpenMode,
+        strategy,
+        sessionInstance => {
+          action(sessionInstance);
           return null;
         });
     }
@@ -158,12 +190,35 @@ namespace Xtensive.Orm.Reprocessing
       IExecuteActionStrategy strategy,
       Func<Session, T> func)
     {
-      ReprocessingConfiguration config = domain.GetReprocessingConfiguration();
-      if (strategy==null)
+      var config = domain.GetReprocessingConfiguration();
+      if (strategy == null) {
         strategy = ExecuteActionStrategy.GetSingleton(config.DefaultExecuteStrategy);
-      if (transactionOpenMode==null)
+      }
+      if (transactionOpenMode == null) {
         transactionOpenMode = config.DefaultTransactionOpenMode;
+      }
       return strategy.Execute(new ExecutionContext<T>(domain, isolationLevel, transactionOpenMode.Value, func));
+    }
+
+    internal static T ExecuteInternal<T>(
+      this Domain domain,
+      Session session,
+      IsolationLevel isolationLevel,
+      TransactionOpenMode? transactionOpenMode,
+      IExecuteActionStrategy strategy,
+      Func<Session, T> func)
+    {
+      var config = domain.GetReprocessingConfiguration();
+      if (strategy == null) {
+        strategy = ExecuteActionStrategy.GetSingleton(config.DefaultExecuteStrategy);
+      }
+      if (transactionOpenMode == null) {
+        transactionOpenMode = config.DefaultTransactionOpenMode;
+      }
+      if (session.IsDisposed) {
+        throw new ObjectDisposedException(nameof(session));
+      }
+      return strategy.Execute(new ExecutionContext<T>(domain, session, isolationLevel, transactionOpenMode.Value, func));
     }
 
     #endregion

--- a/Extensions/Xtensive.Orm.Reprocessing/DomainExtensions.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/DomainExtensions.cs
@@ -138,9 +138,9 @@ namespace Xtensive.Orm.Reprocessing
     /// <param name="domain">The domain.</param>
     /// <param name="session">The external session to use.</param>
     /// <returns>Created <see cref="IExecuteConfiguration"/>.</returns>
-    public static IExecuteConfiguration WithExternalSession(this Domain domain, Session session)
+    public static IExecuteConfiguration WithSession(this Domain domain, Session session)
     {
-      return new ExecuteConfiguration(domain).WithExternalSession(session);
+      return new ExecuteConfiguration(domain).WithSession(session);
     }
 
     #region Non-public methods

--- a/Extensions/Xtensive.Orm.Reprocessing/ExecuteActionStrategy.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/ExecuteActionStrategy.cs
@@ -1,8 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Transactions;
 using Xtensive.Core;
-using Xtensive.Orm.Configuration;
 using SystemTransaction = System.Transactions.Transaction;
 
 namespace Xtensive.Orm.Reprocessing
@@ -56,21 +55,23 @@ namespace Xtensive.Orm.Reprocessing
         try {
           T result;
           var disposeSession = false;
-          //SessionScope sessionScope = null;
           try {
             try {
               var isolationLevel = context.IsolationLevel;
               var currentTransaction = SystemTransaction.Current;
-              if (isolationLevel == IsolationLevel.Unspecified && currentTransaction != null)
+              if (isolationLevel == IsolationLevel.Unspecified && currentTransaction != null) {
                 isolationLevel = currentTransaction.IsolationLevel;
+              }
+
               session = context.ExternalSession;
               if (session == null) {
                 session = context.Domain.OpenSession();
                 disposeSession = true;
-                //sessionScope = session.Activate();
               }
-              if (currentTransaction != null && session.Transaction != null)
+              if (currentTransaction != null && session.Transaction != null) {
                 session.EnsureTransactionIsStarted();
+              }
+
               tran = (currentTransaction != null && currentTransaction.TransactionInformation.DistributedIdentifier != Guid.Empty) ||
                      (session.Transaction != null && session.Transaction.IsDisconnected)
                        ? session.OpenTransaction(isolationLevel)
@@ -85,7 +86,7 @@ namespace Xtensive.Orm.Reprocessing
               }
               catch (StorageException e) {
                 if (e.InnerException == null || !(e.InnerException is InvalidOperationException) ||
-                    e.InnerException.Source != "System.Data") {
+                    !e.InnerException.Source.Equals("System.Data", StringComparison.Ordinal)) {
                   throw;
                 }
 

--- a/Extensions/Xtensive.Orm.Reprocessing/ExecutionContext.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/ExecutionContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Transactions;
 
 namespace Xtensive.Orm.Reprocessing
@@ -13,6 +13,11 @@ namespace Xtensive.Orm.Reprocessing
     /// Gets the domain of this task.
     /// </summary>
     public Domain Domain { get; private set; }
+
+    /// <summary>
+    /// Gets the session passed from outside to be used.
+    /// </summary>
+    public Session ExternalSession { get; private set; }
 
     /// <summary>
     /// Gets the <see cref="System.Transactions.IsolationLevel"/> of this task.
@@ -37,9 +42,31 @@ namespace Xtensive.Orm.Reprocessing
     /// <param name="transactionOpenMode">The transaction open mode.</param>
     /// <param name="function">The task.</param>
     public ExecutionContext(
-      Domain domain, IsolationLevel isolationLevel, TransactionOpenMode transactionOpenMode, Func<Session, T> function)
+      Domain domain,
+      IsolationLevel isolationLevel,
+      TransactionOpenMode transactionOpenMode,
+      Func<Session, T> function)
+      : this(domain, null, isolationLevel, transactionOpenMode, function)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutionContext{T}"/> class.
+    /// </summary>
+    /// <param name="domain">The domain.</param>
+    /// <param name="session">The external session to be used by exection.</param>
+    /// <param name="isolationLevel">The isolation level.</param>
+    /// <param name="transactionOpenMode">The transaction open mode.</param>
+    /// <param name="function">The task.</param>
+    public ExecutionContext(
+      Domain domain,
+      Session session,
+      IsolationLevel isolationLevel,
+      TransactionOpenMode transactionOpenMode,
+      Func<Session, T> function)
     {
       Domain = domain;
+      ExternalSession = session;
       IsolationLevel = isolationLevel;
       TransactionOpenMode = transactionOpenMode;
       Function = function;

--- a/Extensions/Xtensive.Orm.Reprocessing/IExecuteConfiguration.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/IExecuteConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Transactions;
 
 namespace Xtensive.Orm.Reprocessing
@@ -28,6 +28,13 @@ namespace Xtensive.Orm.Reprocessing
     /// <param name="transactionOpenMode">Transction open mode to use.</param>
     /// <returns>This instance.</returns>
     IExecuteConfiguration WithTransactionOpenMode(TransactionOpenMode transactionOpenMode);
+
+    /// <summary>
+    /// Specifies external <see cref="Session"/> to use for this configuration.
+    /// </summary>
+    /// <param name="session">Session to use.</param>
+    /// <returns>This instance.</returns>
+    IExecuteConfiguration WithExternalSession(Session session);
 
     /// <summary>
     /// Executes specified reprocessable <paramref name="action"/>.

--- a/Extensions/Xtensive.Orm.Reprocessing/IExecuteConfiguration.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/IExecuteConfiguration.cs
@@ -34,7 +34,7 @@ namespace Xtensive.Orm.Reprocessing
     /// </summary>
     /// <param name="session">Session to use.</param>
     /// <returns>This instance.</returns>
-    IExecuteConfiguration WithExternalSession(Session session);
+    IExecuteConfiguration WithSession(Session session);
 
     /// <summary>
     /// Executes specified reprocessable <paramref name="action"/>.

--- a/Extensions/Xtensive.Orm.Reprocessing/Internals/ExecuteConfiguration.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/Internals/ExecuteConfiguration.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Reprocessing
       return this;
     }
 
-    public IExecuteConfiguration WithExternalSession(Session session)
+    public IExecuteConfiguration WithSession(Session session)
     {
       ExternalSession = session;
       return this;

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2020 Xtensive LLC.
+// Copyright (C) 2007-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -115,6 +115,14 @@ namespace Xtensive.Orm
         return Configuration.Supports(SessionOptions.NonTransactionalEntityStates) &&
           !Configuration.Supports(SessionOptions.AutoSaveChanges);
       }
+    }
+
+    /// <summary>
+    /// Indicates whether instance is disposed.
+    /// </summary>
+    public bool IsDisposed
+    {
+      get => isDisposed;
     }
 
     /// <summary>


### PR DESCRIPTION
Resolves #126 

**Breaking changes**.

Makes reprocessing not use ```SessionScope``` inside (it does not get session out of it and does not open any activation scopes). To compensate that I provided a way to pass a ```Session``` instance from outside by using ```DomainExtensions.WithExternalSession(this Domain, Session)``` extension or ```IExecutionConfiguration.WithExternalSession(this Domain, Session)```
