### PR TITLE
Improves compilation of DateTimeOffset parts extraction for MS SQL Server

### DIFF
--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Compiler.cs
@@ -149,11 +149,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
         + SqlDml.Extract(SqlDateTimeOffsetPart.Millisecond, dateTimeOffset) * NanosecondsPerMillisecond;
 
     private static SqlExpression DateTimeOffsetToLocalDateTime(SqlExpression dateTimeOffset) =>
-      SqlDml.Cast(
-        SqlDml.DateTimePlusInterval(
-          Switchoffset(dateTimeOffset, UtcTimeZone),
-          SqlDml.DateTimeMinusDateTime(SqlDml.Native("getdate()"), SqlDml.Native("getutcdate()"))),
-        SqlType.DateTime);
+      SqlDml.Cast(DateTimeOffsetToLocalTime(dateTimeOffset), SqlType.DateTime);
 
     private static SqlUserFunctionCall ToDateTimeOffset(SqlExpression dateTime, SqlExpression offsetInMinutes) =>
       SqlDml.FunctionCall("TODATETIMEOFFSET", dateTime, offsetInMinutes);

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Compiler.cs
@@ -130,19 +130,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
 
     #region Static helpers
 
-    private static SqlExpression DateTimeOffsetTruncate(SqlExpression dateTimeOffset)
-    {
-      return SqlDml.Cast(
-        DateAddMillisecond(
-          DateAddSecond(
-            DateAddMinute(
-              DateAddHour(dateTimeOffset,
-                -SqlDml.Extract(SqlDateTimeOffsetPart.Hour, dateTimeOffset)),
-              -SqlDml.Extract(SqlDateTimeOffsetPart.Minute, dateTimeOffset)),
-            -SqlDml.Extract(SqlDateTimeOffsetPart.Second, dateTimeOffset)),
-          -SqlDml.Extract(SqlDateTimeOffsetPart.Millisecond, dateTimeOffset)),
-        SqlType.DateTime);
-    }
+    private static SqlExpression DateTimeOffsetTruncate(SqlExpression dateTimeOffset) =>
+      SqlDml.Cast(
+        SqlDml.Cast(dateTimeOffset, new SqlValueType(SqlDateTypeName)),
+        new SqlValueType(SqlDateTime2TypeName));
 
     private static SqlExpression DateTimeOffsetTruncateOffset(SqlExpression dateTimeOffset)
     {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Compiler.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.07.07
 
@@ -11,20 +11,20 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
 {
   internal class Compiler : v09.Compiler
   {
-    protected static SqlUserFunctionCall DateAddNanosecond(SqlExpression date, SqlExpression nanoseconds)
-    {
-      return SqlDml.FunctionCall("DATEADD", SqlDml.Native("NS"), nanoseconds, date);
-    }
+    protected const string UtcTimeZone = "+00:00";
+    protected const string SqlDateTypeName = "date";
+    protected const string SqlDateTime2TypeName = "datetime2";
 
-    protected static SqlUserFunctionCall DateDiffNanosecond(SqlExpression date1, SqlExpression date2)
-    {
-      return SqlDml.FunctionCall("DATEDIFF", SqlDml.Native("NS"), date1, date2);
-    }
+    protected static SqlUserFunctionCall DateAddNanosecond(SqlExpression date, SqlExpression nanoseconds) =>
+      SqlDml.FunctionCall("DATEADD", SqlDml.Native("NS"), nanoseconds, date);
 
-    protected override SqlExpression DateTimeTruncate(SqlExpression date)
-    {
-      return SqlDml.Cast(SqlDml.Cast(date, new SqlValueType("Date")), new SqlValueType("DateTime2"));
-    }
+    protected static SqlUserFunctionCall DateDiffNanosecond(SqlExpression date1, SqlExpression date2) =>
+      SqlDml.FunctionCall("DATEDIFF", SqlDml.Native("NS"), date1, date2);
+
+    protected override SqlExpression DateTimeTruncate(SqlExpression date) =>
+      SqlDml.Cast(
+        SqlDml.Cast(date, new SqlValueType(SqlDateTypeName)),
+        new SqlValueType(SqlDateTime2TypeName));
 
     protected override SqlExpression  DateTimeSubtractDateTime(SqlExpression date1, SqlExpression date2)
     {
@@ -52,32 +52,31 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
 
     public override void Visit(SqlExtract node)
     {
-      if (node.DateTimeOffsetPart==SqlDateTimeOffsetPart.DayOfWeek) {
-        Visit((DatePartWeekDay(node.Operand) + DateFirst + 6) % 7);
-        return;
-      }
       switch (node.DateTimeOffsetPart) {
-      case SqlDateTimeOffsetPart.TimeZoneHour:
-        Visit(DateTimeOffsetTimeZoneInMinutes(node.Operand) / 60);
-        return;
-      case SqlDateTimeOffsetPart.TimeZoneMinute:
-        Visit(DateTimeOffsetTimeZoneInMinutes(node.Operand) % 60);
-        return;
-      case SqlDateTimeOffsetPart.Date:
-        DateTimeOffsetTruncate(node.Operand).AcceptVisitor(this);
-        return;
-      case SqlDateTimeOffsetPart.DateTime:
-        DateTimeOffsetTruncateOffset(node.Operand).AcceptVisitor(this);
-        return;
-      case SqlDateTimeOffsetPart.LocalDateTime:
-        DateTimeOffsetToLocalDateTime(node.Operand).AcceptVisitor(this);
-        return;
-      case SqlDateTimeOffsetPart.UtcDateTime:
-        SqlDml.Cast(Switchoffset(node.Operand, "+00:00"), SqlType.DateTime).AcceptVisitor(this);
-        return;
-      case SqlDateTimeOffsetPart.Offset:
-        DateTimeOffsetPartOffset(node.Operand).AcceptVisitor(this);
-        return;
+        case SqlDateTimeOffsetPart.DayOfWeek:
+          Visit((DatePartWeekDay(node.Operand) + DateFirst + 6) % 7);
+          return;
+        case SqlDateTimeOffsetPart.TimeZoneHour:
+          Visit(DateTimeOffsetTimeZoneInMinutes(node.Operand) / 60);
+          return;
+        case SqlDateTimeOffsetPart.TimeZoneMinute:
+          Visit(DateTimeOffsetTimeZoneInMinutes(node.Operand) % 60);
+          return;
+        case SqlDateTimeOffsetPart.Date:
+          DateTimeOffsetTruncate(node.Operand).AcceptVisitor(this);
+          return;
+        case SqlDateTimeOffsetPart.DateTime:
+          DateTimeOffsetTruncateOffset(node.Operand).AcceptVisitor(this);
+          return;
+        case SqlDateTimeOffsetPart.LocalDateTime:
+          DateTimeOffsetToLocalDateTime(node.Operand).AcceptVisitor(this);
+          return;
+        case SqlDateTimeOffsetPart.UtcDateTime:
+          SqlDml.Cast(Switchoffset(node.Operand, UtcTimeZone), SqlType.DateTime).AcceptVisitor(this);
+          return;
+        case SqlDateTimeOffsetPart.Offset:
+          DateTimeOffsetPartOffset(node.Operand).AcceptVisitor(this);
+          return;
       }
       base.Visit(node);
     }
@@ -86,27 +85,27 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
     public override void Visit(SqlFunctionCall node)
     {
       switch (node.FunctionType) {
-      case SqlFunctionType.DateTimeOffsetAddMonths:
-        Visit(DateAddMonth(node.Arguments[0], node.Arguments[1]));
-        return;
-      case SqlFunctionType.DateTimeOffsetAddYears:
-        Visit(DateAddYear(node.Arguments[0], node.Arguments[1]));
-        return;
-      case SqlFunctionType.DateTimeOffsetTimeOfDay:
-        DateTimeOffsetTimeOfDay(node.Arguments[0]).AcceptVisitor(this);
-        return;
-      case SqlFunctionType.DateTimeOffsetConstruct:
-        Visit(ToDateTimeOffset(node.Arguments[0], node.Arguments[1]));
-        return;
-      case SqlFunctionType.DateTimeOffsetToLocalTime:
-        DateTimeOffsetToLocalTime(node.Arguments[0]).AcceptVisitor(this);
-        return;
-      case SqlFunctionType.DateTimeOffsetToUtcTime:
-        DateTimeOffsetToUtcTime(node.Arguments[0]).AcceptVisitor(this);
-        return;
-      case SqlFunctionType.DateTimeToDateTimeOffset:
-        DateTimeToDateTimeOffset(node.Arguments[0]).AcceptVisitor(this);
-        return;
+        case SqlFunctionType.DateTimeOffsetAddMonths:
+          Visit(DateAddMonth(node.Arguments[0], node.Arguments[1]));
+          return;
+        case SqlFunctionType.DateTimeOffsetAddYears:
+          Visit(DateAddYear(node.Arguments[0], node.Arguments[1]));
+          return;
+        case SqlFunctionType.DateTimeOffsetTimeOfDay:
+          DateTimeOffsetTimeOfDay(node.Arguments[0]).AcceptVisitor(this);
+          return;
+        case SqlFunctionType.DateTimeOffsetConstruct:
+          Visit(ToDateTimeOffset(node.Arguments[0], node.Arguments[1]));
+          return;
+        case SqlFunctionType.DateTimeOffsetToLocalTime:
+          DateTimeOffsetToLocalTime(node.Arguments[0]).AcceptVisitor(this);
+          return;
+        case SqlFunctionType.DateTimeOffsetToUtcTime:
+          DateTimeOffsetToUtcTime(node.Arguments[0]).AcceptVisitor(this);
+          return;
+        case SqlFunctionType.DateTimeToDateTimeOffset:
+          DateTimeToDateTimeOffset(node.Arguments[0]).AcceptVisitor(this);
+          return;
       }
 
       base.Visit(node);
@@ -115,15 +114,15 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
     public override void Visit(SqlBinary node)
     {
       switch (node.NodeType) {
-      case SqlNodeType.DateTimeOffsetPlusInterval:
-        DateTimeAddInterval(node.Left, node.Right).AcceptVisitor(this);
-        return;
-      case SqlNodeType.DateTimeOffsetMinusDateTimeOffset:
-        DateTimeOffsetSubtractDateTimeOffset(node.Left, node.Right).AcceptVisitor(this);
-        return;
-      case SqlNodeType.DateTimeOffsetMinusInterval:
-        DateTimeAddInterval(node.Left, -node.Right).AcceptVisitor(this);
-        return;
+        case SqlNodeType.DateTimeOffsetPlusInterval:
+          DateTimeAddInterval(node.Left, node.Right).AcceptVisitor(this);
+          return;
+        case SqlNodeType.DateTimeOffsetMinusDateTimeOffset:
+          DateTimeOffsetSubtractDateTimeOffset(node.Left, node.Right).AcceptVisitor(this);
+          return;
+        case SqlNodeType.DateTimeOffsetMinusInterval:
+          DateTimeAddInterval(node.Left, -node.Right).AcceptVisitor(this);
+          return;
       }
       base.Visit(node);
     }
@@ -135,64 +134,48 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
         SqlDml.Cast(dateTimeOffset, new SqlValueType(SqlDateTypeName)),
         new SqlValueType(SqlDateTime2TypeName));
 
-    private static SqlExpression DateTimeOffsetTruncateOffset(SqlExpression dateTimeOffset)
-    {
-      return SqlDml.Cast(dateTimeOffset, SqlType.DateTime);
-    }
+    private static SqlExpression DateTimeOffsetTruncateOffset(SqlExpression dateTimeOffset) =>
+      SqlDml.Cast(dateTimeOffset, SqlType.DateTime);
 
-    private static SqlExpression DateTimeOffsetPartOffset(SqlExpression dateTimeOffset)
-    {
-      return SqlDml.DateTimeOffsetMinusDateTimeOffset(
+    private static SqlExpression DateTimeOffsetPartOffset(SqlExpression dateTimeOffset) =>
+      SqlDml.DateTimeOffsetMinusDateTimeOffset(
         DateTimeOffsetTruncateOffset(dateTimeOffset),
-        Switchoffset(dateTimeOffset, "+00:00"));
-    }
+        Switchoffset(dateTimeOffset, UtcTimeZone));
 
-    private static SqlExpression DateTimeOffsetTimeOfDay(SqlExpression dateTimeOffset)
-    {
-      return SqlDml.Extract(SqlDateTimeOffsetPart.Hour, dateTimeOffset) * (60 * 60 * NanosecondsPerSecond)
+    private static SqlExpression DateTimeOffsetTimeOfDay(SqlExpression dateTimeOffset) =>
+      SqlDml.Extract(SqlDateTimeOffsetPart.Hour, dateTimeOffset) * (60 * 60 * NanosecondsPerSecond)
         + SqlDml.Extract(SqlDateTimeOffsetPart.Minute, dateTimeOffset) * (60 * NanosecondsPerSecond)
         + SqlDml.Extract(SqlDateTimeOffsetPart.Second, dateTimeOffset) * NanosecondsPerSecond
         + SqlDml.Extract(SqlDateTimeOffsetPart.Millisecond, dateTimeOffset) * NanosecondsPerMillisecond;
-    }
 
-    private static SqlExpression DateTimeOffsetToLocalDateTime(SqlExpression dateTimeOffset)
-    {
-      return SqlDml.Cast(
+    private static SqlExpression DateTimeOffsetToLocalDateTime(SqlExpression dateTimeOffset) =>
+      SqlDml.Cast(
         SqlDml.DateTimePlusInterval(
-          Switchoffset(dateTimeOffset, "+00:00"),
+          Switchoffset(dateTimeOffset, UtcTimeZone),
           SqlDml.DateTimeMinusDateTime(SqlDml.Native("getdate()"), SqlDml.Native("getutcdate()"))),
         SqlType.DateTime);
-    }
 
-    private static SqlUserFunctionCall ToDateTimeOffset(SqlExpression dateTime, SqlExpression offsetInMinutes)
-    {
-      return SqlDml.FunctionCall("TODATETIMEOFFSET", dateTime, offsetInMinutes);
-    }
+    private static SqlUserFunctionCall ToDateTimeOffset(SqlExpression dateTime, SqlExpression offsetInMinutes) =>
+      SqlDml.FunctionCall("TODATETIMEOFFSET", dateTime, offsetInMinutes);
 
-    private static SqlExpression Switchoffset(SqlExpression dateTimeOffset, SqlExpression offset)
-    {
-      return SqlDml.FunctionCall("SWITCHOFFSET", dateTimeOffset, offset);
-    }
+    private static SqlExpression Switchoffset(SqlExpression dateTimeOffset, SqlExpression offset) =>
+      SqlDml.FunctionCall("SWITCHOFFSET", dateTimeOffset, offset);
 
-    private static SqlUserFunctionCall DateTimeOffsetTimeZoneInMinutes(SqlExpression date)
-    {
-      return SqlDml.FunctionCall("DATEPART", SqlDml.Native("TZoffset"), date);
-    }
+    private static SqlUserFunctionCall DateTimeOffsetTimeZoneInMinutes(SqlExpression date) =>
+      SqlDml.FunctionCall("DATEPART", SqlDml.Native("TZoffset"), date);
 
-    private static SqlExpression DateTimeOffsetToLocalTime(SqlExpression dateTimeOffset)
-    {
-      return Switchoffset(dateTimeOffset, DateTimeOffsetTimeZoneInMinutes(SqlDml.Native("SYSDATETIMEOFFSET()")));
-    }
+    private static SqlExpression DateTimeOffsetToLocalTime(SqlExpression dateTimeOffset) =>
+      Switchoffset(dateTimeOffset, DateTimeOffsetTimeZoneInMinutes(SqlDml.Native("SYSDATETIMEOFFSET()")));
 
-    private static SqlExpression DateTimeOffsetToUtcTime(SqlExpression dateTimeOffset)
-    {
-      return Switchoffset(dateTimeOffset, "+00:00");
-    }
+    private static SqlExpression DateTimeOffsetToUtcTime(SqlExpression dateTimeOffset) =>
+      Switchoffset(dateTimeOffset, UtcTimeZone);
 
-    private static SqlExpression DateTimeToDateTimeOffset(SqlExpression dateTime)
-    {
-      return SqlDml.FunctionCall("TODATETIMEOFFSET", dateTime, SqlDml.FunctionCall("DATEPART", SqlDml.Native("TZoffset"), SqlDml.Native("SYSDATETIMEOFFSET()")));
-    }
+    private static SqlExpression DateTimeToDateTimeOffset(SqlExpression dateTime) =>
+      SqlDml.FunctionCall("TODATETIMEOFFSET",
+        dateTime,
+        SqlDml.FunctionCall("DATEPART",
+          SqlDml.Native("TZoffset"),
+          SqlDml.Native("SYSDATETIMEOFFSET()")));
 
     #endregion
 

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Compiler.cs
@@ -143,10 +143,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
         Switchoffset(dateTimeOffset, UtcTimeZone));
 
     private static SqlExpression DateTimeOffsetTimeOfDay(SqlExpression dateTimeOffset) =>
-      SqlDml.Extract(SqlDateTimeOffsetPart.Hour, dateTimeOffset) * (60 * 60 * NanosecondsPerSecond)
-        + SqlDml.Extract(SqlDateTimeOffsetPart.Minute, dateTimeOffset) * (60 * NanosecondsPerSecond)
-        + SqlDml.Extract(SqlDateTimeOffsetPart.Second, dateTimeOffset) * NanosecondsPerSecond
-        + SqlDml.Extract(SqlDateTimeOffsetPart.Millisecond, dateTimeOffset) * NanosecondsPerMillisecond;
+      DateDiffMillisecond(
+        SqlDml.Native("'00:00:00.0000000'"),
+        SqlDml.Cast(dateTimeOffset, new SqlValueType("time")))
+      * NanosecondsPerMillisecond;
 
     private static SqlExpression DateTimeOffsetToLocalDateTime(SqlExpression dateTimeOffset) =>
       SqlDml.Cast(DateTimeOffsetToLocalTime(dateTimeOffset), SqlType.DateTime);

--- a/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/DateTime/PartsExtractionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/DateTime/PartsExtractionTest.cs
@@ -129,9 +129,9 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.DateTimes
     {
       Require.ProviderIs(StorageProvider.SqlServer);
       ExecuteInsideSession(() => {
-        var testDateTimeOffset = DateTimeOffset.Parse(testValueString);
-        _ = new SingleDateTimeOffsetEntity() { MillisecondDateTimeOffset = testDateTimeOffset };
-        RunTest<SingleDateTimeOffsetEntity>(c => c.MillisecondDateTimeOffset.Date == testDateTimeOffset.Date);
+        var testDateTime = DateTime.Parse(testValueString);
+        _ = new SingleDateTimeEntity() { MillisecondDateTime = testDateTime };
+        RunTest<SingleDateTimeEntity>(c => c.MillisecondDateTime.Date == testDateTime.Date);
       });
     }
 

--- a/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/DateTime/PartsExtractionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/DateTime/PartsExtractionTest.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (C) 2016 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2016-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Groznov
 // Created:    2016.08.01
 
+using System;
 using NUnit.Framework;
 using Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.Model;
 
@@ -115,6 +116,22 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.DateTimes
         RunWrongTest<SingleDateTimeEntity>(c => c.DateTime.Date==WrongDateTime.Date);
         RunWrongTest<SingleDateTimeEntity>(c => c.MillisecondDateTime.Date==WrongMillisecondDateTime.Date);
         RunWrongTest<SingleDateTimeEntity>(c => c.NullableDateTime.Value.Date==WrongDateTime.Date);
+      });
+    }
+
+    [Test]
+    [TestCase("2018-10-30 12:15:32.123")]
+    [TestCase("2018-10-30 12:15:32.1234")]
+    [TestCase("2018-10-30 12:15:32.12345")]
+    [TestCase("2018-10-30 12:15:32.123456")]
+    [TestCase("2018-10-30 12:15:32.1234567")]
+    public void ExtractDateFromMicrosecondsTest(string testValueString)
+    {
+      Require.ProviderIs(StorageProvider.SqlServer);
+      ExecuteInsideSession(() => {
+        var testDateTimeOffset = DateTimeOffset.Parse(testValueString);
+        _ = new SingleDateTimeOffsetEntity() { MillisecondDateTimeOffset = testDateTimeOffset };
+        RunTest<SingleDateTimeOffsetEntity>(c => c.MillisecondDateTimeOffset.Date == testDateTimeOffset.Date);
       });
     }
 

--- a/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/DateTimeOffset/PartsExtractionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/DateTimeOffset/PartsExtractionTest.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (C) 2016 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2016-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Groznov
 // Created:    2016.08.01
 
+using System;
 using NUnit.Framework;
 using Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.Model;
 
@@ -145,6 +146,22 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.DateTimeOffsets
         RunWrongTest<SingleDateTimeOffsetEntity>(c => c.DateTimeOffset.Date==wrongDateTimeOffset.Date);
         RunWrongTest<SingleDateTimeOffsetEntity>(c => c.MillisecondDateTimeOffset.Date==wrongMillisecondDateTimeOffset.Date);
         RunWrongTest<SingleDateTimeOffsetEntity>(c => c.NullableDateTimeOffset.Value.Date==wrongDateTimeOffset.Date);
+      });
+    }
+
+    [Test]
+    [TestCase("2018-10-30 12:15:32.123 +05:10")]
+    [TestCase("2018-10-30 12:15:32.1234 +05:10")]
+    [TestCase("2018-10-30 12:15:32.12345 +05:10")]
+    [TestCase("2018-10-30 12:15:32.123456 +05:10")]
+    [TestCase("2018-10-30 12:15:32.1234567 +05:10")]
+    public void ExtractDateFromMicrosecondsTest(string testValueString)
+    {
+      Require.ProviderIs(StorageProvider.SqlServer);
+      ExecuteInsideSession(() => {
+        var testDateTimeOffset =  DateTimeOffset.Parse(testValueString);
+        _ = new SingleDateTimeOffsetEntity() { MillisecondDateTimeOffset = testDateTimeOffset };
+        RunTest<SingleDateTimeOffsetEntity>(c => c.MillisecondDateTimeOffset.Date == testDateTimeOffset.Date);
       });
     }
 


### PR DESCRIPTION
Closes #133

Also improves translation for ```DateTimeOffset.LocalDateTime``` and ```DateTimeOffset.TimeOfDay```

```DateTimeOffset.LocalDateTime```. For query like
```
  _ = session.Query.All<TestEntity>()
    .Where(e=>e.DateTimeOffset.LocalDateTime==localDateTimeOffset.LocalDateTime)
    .Count();
```
old translation produced a query like
```
SELECT COUNT_BIG(*) AS [c01umn] 
FROM [dbo].[TestEntity] [a]
WHERE 
  (
     CAST(
       DATEADD(NS,
               ((((((CAST(DATEDIFF(DAY, getutcdate(), getdate())  AS decimal(18,0)) * CAST(86400000000000 as BIGINT))
                     +
                     (CAST(DATEDIFF(MS,
                                    DATEADD(DAY,
                                            DATEDIFF(DAY, getutcdate(), getdate()), getutcdate()), getdate())  AS decimal(18,0))
                      * CAST(1000000 as BIGINT))
                   ) +
                     DATEDIFF(NS,
                              DATEADD(MS,
                                      DATEDIFF(MS,
                                               DATEADD(DAY, DATEDIFF(DAY, getutcdate(), getdate()), getutcdate()),
                                               getdate()),
                                      DATEADD(DAY, DATEDIFF(DAY, getutcdate(), getdate()), getutcdate())), getdate())
                  ) / CAST(1000000000 as BIGINT)) % CAST(86400000000000 as BIGINT)) / CAST(1000000000 as BIGINT)),
                    DATEADD( MS,
                            (((((CAST(DATEDIFF(DAY, getutcdate(), getdate())  AS decimal(18,0)) * CAST(86400000000000 as BIGINT))
                                +
                                (CAST(DATEDIFF(MS,
                                                DATEADD(DAY,
                                                        DATEDIFF(DAY, getutcdate(), getdate()),
                                                        getutcdate()),
                                                getdate())  AS decimal(18,0)) * CAST(1000000 as BIGINT)))
                                +
                                DATEDIFF(NS,
                                        DATEADD(MS,
                                                DATEDIFF(MS,
                                                        DATEADD(DAY,
                                                                DATEDIFF(DAY,getutcdate(), getdate()),
                                                                getutcdate()),
                                                        getdate()),
                                                DATEADD(DAY, DATEDIFF(DAY, getutcdate(), getdate()), getutcdate())),
                                        getdate())
                              ) / CAST(1000000 as BIGINT)) % CAST(86400000 as BIGINT)),
                            DATEADD(DAY,
                                    ((((CAST(DATEDIFF(DAY, getutcdate(), getdate())  AS decimal(18,0))
                                        *
                                        CAST(86400000000000 as BIGINT))
                                      +
                                      (CAST(DATEDIFF(MS,
                                                    DATEADD(DAY,
                                                            DATEDIFF(DAY, getutcdate(), getdate()),
                                                            getutcdate()),
                                                    getdate())  AS decimal(18,0))
                                            *
                                            CAST(1000000 as BIGINT)))
                                    + DATEDIFF(NS,
                                                DATEADD(MS,
                                                        DATEDIFF(MS,
                                                                 DATEADD(DAY, DATEDIFF(DAY, getutcdate(), getdate()), getutcdate()),
                                                                 getdate()),
                                                        DATEADD(DAY,
                                                                DATEDIFF(DAY, getutcdate(), getdate()),
                                                                getutcdate())),
                                                        getdate())
                                    ) / CAST(86400000000000 as BIGINT)),
                                    SWITCHOFFSET([a].[DateTimeOffset], N''+00:00'')))
                  )  AS datetime2) = @p0_0);
```
Now it is 
```
SELECT COUNT_BIG(*) AS [c01umn]
FROM [dbo].[TestEntity] [a]
WHERE (CAST(SWITCHOFFSET([a].[DateTimeOffset], DATEPART(TZoffset, SYSDATETIMEOFFSET()))  AS datetime2) = @p0_0);
```
New query is more than 3 times less CPU consuming (530 vs 1900 in SQL profiler) and more than 2 times faster ( query duration 150 vs 380 in SQL Profiler ) on my PC.

```DateTimeOffset.TimeOfDay```. For query like 
```
  _ = session.Query.All<TestEntity>()
    .Where(e=>e.DateTimeOffset.TimeOfDay==localDateTimeOffset.TimeOfDay)
    .Count();
```
Old tranlslation produced something like
```
SELECT COUNT_BIG(*) AS [c01umn] 
FROM [dbo].[TestEntity] [a]
WHERE (((((DATEPART(HOUR , [a].[DateTimeOffset]) * CAST(3600000000000 as BIGINT))
          + (DATEPART(MINUTE , [a].[DateTimeOffset]) * CAST(60000000000 as BIGINT)))
        + (DATEPART(SECOND , [a].[DateTimeOffset]) * CAST(1000000000 as BIGINT)))
      + (DATEPART(MILLISECOND , [a].[DateTimeOffset]) * CAST(1000000 as BIGINT))) = @p0_0);
```
Now it is
```
SELECT COUNT_BIG(*) AS [c01umn] 
FROM [dbo].[TestEntity] [a]
WHERE ((DATEDIFF(MS, ''00:00:00.0000000'', CAST([a].[DateTimeOffset]  AS time))
       * CAST(1000000 as BIGINT)) = @p0_0);
```

New query is around 2 times less CPU consuming (970 vs 2150 in SQL Profiler) and around 2 times faster (query duration 220 vs 440 in SQL Profiler) on my PC.

**My PC : Intel Core i5 8400, 32GB memory, Database is on Sata SSD Samsung 850 EVO**, all measurements were done on the table with 5 000 000 rows
