### PR TITLE
BooleanExpressionConverter: use Value = 1 instead of Value <> 0

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/BooleanExpressionConverter.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/BooleanExpressionConverter.cs
@@ -35,17 +35,17 @@ namespace Xtensive.Orm.Providers
         }
       }
 
-      return SqlDml.NotEquals(expression, 0);
+      return SqlDml.Equals(expression, 1);
     }
 
     public SqlExpression BooleanToInt(SqlExpression expression)
     {
       // optimization: omitting BooleanToInt(IntToBoolean(x)) sequences
-      if (expression.NodeType==SqlNodeType.NotEquals) {
+      if (expression.NodeType==SqlNodeType.Equals) {
         var binary = (SqlBinary) expression;
         var left = binary.Left;
         var right = binary.Right as SqlLiteral<int>;
-        if (!ReferenceEquals(right, null) && right.Value==0)
+        if (!ReferenceEquals(right, null) && right.Value==1)
           return left;
       }
 


### PR DESCRIPTION
Value <> 0 does not utilize index over Value, but Value = 1 does

This change would require rebuilding filtered indices with boolean columns in filter expression.