### PR TITLE
Fix bad results on VS pre-build run

### DIFF
--- a/MSBuild/DataObjects.Net.targets
+++ b/MSBuild/DataObjects.Net.targets
@@ -21,7 +21,7 @@
         Inputs="@(IntermediateAssembly -> '%(FullPath)')"
         Outputs="@(IntermediateAssembly -> '%(FullPath).weaver-stamp')"
         DependsOnTargets="ResolveAssemblyReferences;_CopyFilesMarkedCopyLocal;$(XtensiveOrmBuildDependsOn)"
-        Condition="'$(XtensiveOrmSkipProcessing)'!='true'">
+        Condition="'$(XtensiveOrmSkipProcessing)'!='true' AND '$(DesignTimeBuild)' != 'true'">
   <Error Condition="!Exists('$(XtensiveOrmWeaver)')"
          Text="Weaver is not found at '$(XtensiveOrmWeaver)'" />
   <Message Importance="low" Text="Using weaver at '$(XtensiveOrmWeaver)'" />


### PR DESCRIPTION
Design-time build runs through very limited targets and does not provide any libraries so we can skip weaving. VS runs normal build at some point anyway so it should not hurt anybody but improve VS responsiveness and user experience.