### PR TITLE
Fixes prefetch graph building issue

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ExpressionMapBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ExpressionMapBuilder.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.02.24
 
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         // All lambdas will be associated with single parent.
         call = (MethodCallExpression) source;
         ValidateMethodCall(call);
-        source = call.Arguments[0];
+        source = call.Arguments[0].StripCasts();
         var lambda = call.Arguments[1].StripQuotes();
         subprefetches.Add(lambda);
       }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchQueryEnumerable.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchQueryEnumerable.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2020 Xtensive LLC.
+// Copyright (C) 2010-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
@@ -124,13 +124,6 @@ namespace Xtensive.Orm.Internals.Prefetch
 
       return container;
     }
-
-    //private void Initialize()
-    //{
-    //  unknownTypeQueue = new Queue<Key>();
-    //  prefetchQueue = new Queue<Pair<IEnumerable<Key>, IHasNestedNodes>>();
-    //  fieldDescriptorCache = new Dictionary<Pair<IHasNestedNodes, TypeInfo>, IList<PrefetchFieldDescriptor>>();
-    //}
 
     public PrefetchQueryEnumerable(Session session, IEnumerable<TItem> source,
       SinglyLinkedList<KeyExtractorNode<TItem>> nodes)

--- a/Orm/Xtensive.Orm/Orm/PrefetchExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/PrefetchExtensions.cs
@@ -93,6 +93,21 @@ namespace Xtensive.Orm
     }
 
     /// <summary>
+    /// Registers fields specified by <paramref name="expression"/> for prefetch.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the element of the source sequence.</typeparam>
+    /// <typeparam name="TFieldValue">The type of the field's value to be prefetched.</typeparam>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="expression">The expression specifying a field to be prefetched.</param>
+    /// <returns>An <see cref="IEnumerable{TElement}"/> of source items.</returns>
+    public static PrefetchQuery<TElement> Prefetch<TElement, TFieldValue>(
+      this PrefetchQuery<TElement> source,
+      Expression<Func<TElement, TFieldValue>> expression)
+    {
+      return source.RegisterPath(expression);
+    }
+
+    /// <summary>
     /// Creates <see cref="PrefetchQuery{T}"/> for the specified <paramref name="source"/> and
     /// registers the prefetch of the field specified by <paramref name="expression"/>.
     /// </summary>


### PR DESCRIPTION
Due to new return type of ```Preferch``` extension methods in some cases expression to traverse is a bit different.

An example of prefetch expression in previous versions
```
// DO 6.0 expression
a => a.Bbbbs
      .Prefetch(b => b.Reference4)
      .Prefetch(b => b.Reference5)
      .Prefetch(b => b.Reference6)
      .Prefetch(b => b.SomeObject)
```
and  new expression
```
// DO 7.0 expression
a => Convert(
       Convert(
         Convert(
                  a.Bbbbs.Prefetch(b => b.Reference4),
                  IEnumerable`1
                ).Prefetch(b => b.Reference5),
         IEnumerable`1
       ).Prefetch(b => b.Reference6),
       IEnumerable`1
    ).Prefetch(b => b.SomeObject)
```

These type casts weren't handled correctly so result prefetch graph was wrong which led to some nodes not being fetched as they supposed to.

The PR adds separate ```Prefetch``` extension method for ```PrefetchQuery<T>``` and handles such casts correctly for good measure. ```IssueJira0778_PrefetchStackOverflow``` test shows the problem, we didn't find it earlier because the test is time-consuming and marked as ```Explicit```.