### PR TITLE
Fix critical bug with attribute reordering by destructive Array.Reverse() on memoized array

### DIFF
--- a/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
@@ -83,7 +83,7 @@ namespace Xtensive.IoC
         return Array.Empty<ServiceRegistration>();
 
       var attributes = type.GetAttributes<ServiceAttribute>(AttributeSearchOptions.InheritNone);
-      var registrations = new List<ServiceRegistration>(attributes.Length);
+      var registrations = new List<ServiceRegistration>(attributes.Count);
       foreach (var sa in attributes) {
         if (!defaultOnly || sa.Default) {
           registrations.Add(new ServiceRegistration(sa.Type, sa.Name.IsNullOrEmpty() ? null : sa.Name, type, sa.Singleton));

--- a/Orm/Xtensive.Orm/Linq/ExpressionWriter.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
@@ -294,12 +294,12 @@ namespace Xtensive.Linq
       name = name.Replace('+', '.');
 
       if (name.IndexOf("__DisplayClass", StringComparison.Ordinal) > 0 &&
-        type.GetAttributes<CompilerGeneratedAttribute>(AttributeSearchOptions.InheritNone).Length > 0) {
+        type.GetAttributes<CompilerGeneratedAttribute>(AttributeSearchOptions.InheritNone).Count > 0) {
         return "@";
       }
 
       if (name.IndexOf("__AnonymousType", StringComparison.Ordinal) > 0 &&
-        type.GetAttributes<CompilerGeneratedAttribute>(AttributeSearchOptions.InheritNone).Length > 0) {
+        type.GetAttributes<CompilerGeneratedAttribute>(AttributeSearchOptions.InheritNone).Count > 0) {
         return string.Format("@<{0}>",
           (from pi in type.GetProperties() select pi.Name).ToCommaDelimitedString());
       }
@@ -340,7 +340,7 @@ namespace Xtensive.Linq
     {
       var type = c.Type;
       if (type.Name.IndexOf("__DisplayClass", StringComparison.Ordinal) > 0 &&
-        type.GetAttributes<CompilerGeneratedAttribute>(AttributeSearchOptions.InheritNone).Length > 0) {
+        type.GetAttributes<CompilerGeneratedAttribute>(AttributeSearchOptions.InheritNone).Count > 0) {
         // A constant of display class type
         Write("@");
       }
@@ -556,7 +556,7 @@ namespace Xtensive.Linq
       }
       else {
         // Static method
-        if (mc.Method.GetAttributes<ExtensionAttribute>(AttributeSearchOptions.InheritNone).Length > 0) {
+        if (mc.Method.GetAttributes<ExtensionAttribute>(AttributeSearchOptions.InheritNone).Count > 0) {
           // A special case: extension method
           Visit(mc.Arguments[0]);
           arguments = new System.Collections.ObjectModel.ReadOnlyCollection<Expression>(mc.Arguments.Skip(1).ToList());

--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -36,7 +36,7 @@ namespace Xtensive.Reflection
     /// <param name="options">Attribute search options.</param>
     /// <returns>An array of attributes of specified type.</returns>
     ///
-    public static TAttribute[] GetAttributes<TAttribute>(this MemberInfo member, AttributeSearchOptions options = AttributeSearchOptions.InheritNone)
+    public static IReadOnlyList<TAttribute> GetAttributes<TAttribute>(this MemberInfo member, AttributeSearchOptions options = AttributeSearchOptions.InheritNone)
         where TAttribute : Attribute =>
       AttributeDictionary<TAttribute>.Dictionary.GetOrAdd(
         new PerAttributeKey(member, options),
@@ -59,7 +59,7 @@ namespace Xtensive.Reflection
       where TAttribute : Attribute
     {
       var attributes = member.GetAttributes<TAttribute>(options);
-      return attributes.Length switch {
+      return attributes.Count switch {
         0 => null,
         1 => attributes[0],
         _ => throw new InvalidOperationException(string.Format(Strings.ExMultipleAttributesOfTypeXAreNotAllowedHere,
@@ -68,7 +68,7 @@ namespace Xtensive.Reflection
       };
     }
 
-    private static Attribute[] GetAttributes(MemberInfo member, Type attributeType, AttributeSearchOptions options) =>
+    private static IReadOnlyList<Attribute> GetAttributes(MemberInfo member, Type attributeType, AttributeSearchOptions options) =>
       attributesByMemberInfoAndSearchOptions.GetOrAdd(
         new AttributesKey(member, attributeType, options),
         t => ExtractAttributes(t).ToArray()


### PR DESCRIPTION
Replace modifying `Array.Reverse()` of memoized array by iterating in reversed order.

Breaking changes of `AttributeHelper` interface:
return `IReadOnlyList` instead of arrays to prevent potential modifications of memoized array instances.