### PR TITLE
Optimizations: allocations in RecordSetHeader.Join(); use IReadOnlyList instead of ReadOnlyList to save allocations

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2021 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2008.08.01
 
@@ -28,12 +28,12 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets the indexes of key columns.
     /// </summary>
-    public ReadOnlyList<int> Keys { get; private set; }
+    public IReadOnlyList<int> Keys { get; private set; }
 
     /// <summary>
     /// Gets the indexes of all columns.
     /// </summary>
-    public ReadOnlyList<int> Columns { get; private set; }
+    public IReadOnlyList<int> Columns { get; private set; }
 
 
     // Constructors
@@ -55,11 +55,11 @@ namespace Xtensive.Orm.Model
     /// <param name="type">The type.</param>
     /// <param name="keys">The keys.</param>
     /// <param name="columns">The columns.</param>
-    public ColumnGroup(TypeInfoRef type, IList<int> keys, IList<int> columns)
+    public ColumnGroup(TypeInfoRef type, IReadOnlyList<int> keys, IReadOnlyList<int> columns)
     {
       TypeInfoRef = type;
-      Keys = new ReadOnlyList<int>(keys);
-      Columns = new ReadOnlyList<int>(columns);
+      Keys = keys;
+      Columns = columns;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2009-2010 Xtensive LLC.
-// This code is distributed under MIT license terms.
-// See the License.txt file in the project root for more information.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// All rights reserved.
+// For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
 // Created:    2009.11.13
 
@@ -15,7 +15,7 @@ using IndexInfo = Xtensive.Orm.Model.IndexInfo;
 
 namespace Xtensive.Orm.Providers
 {
-  partial class SqlCompiler 
+  partial class SqlCompiler
   {
     protected override SqlProvider VisitFreeText(FreeTextProvider provider)
     {
@@ -65,18 +65,22 @@ namespace Xtensive.Orm.Providers
         atRootPolicy = true;
       }
 
-      SqlSelect query;
+      var indexColumns = index.Columns;
+      var tableRef = SqlDml.TableRef(table);
+      var query = SqlDml.Select(tableRef);
+      var queryColumns = query.Columns;
+      queryColumns.Capacity = queryColumns.Count + indexColumns.Count;
       if (!atRootPolicy) {
-        var tableRef = SqlDml.TableRef(table);
-        query = SqlDml.Select(tableRef);
-        query.Columns.AddRange(index.Columns.Select(c => tableRef[c.Name]));
+        foreach (var c in indexColumns) {
+          queryColumns.Add(tableRef[c.Name]);
+        }
       }
       else {
         var root = index.ReflectedType.GetRoot().AffectedIndexes.First(i => i.IsPrimary);
         var lookup = root.Columns.ToDictionary(c => c.Field, c => c.Name);
-        var tableRef = SqlDml.TableRef(table);
-        query = SqlDml.Select(tableRef);
-        query.Columns.AddRange(index.Columns.Select(c => tableRef[lookup[c.Field]]));
+        foreach (var c in indexColumns) {
+          queryColumns.Add(tableRef[lookup[c.Field]]);
+        }
       }
       return query;
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2007.09.24
 
@@ -37,12 +37,6 @@ namespace Xtensive.Orm.Rse
       }
     }
 
-    private void BuildNameIndex()
-    {
-      for (var index = 0; index < Count; index++) 
-        nameIndex.Add(this[index].Name, index);
-    }
-
     /// <summary>
     /// Joins this collection with specified the column collection.
     /// </summary>
@@ -59,7 +53,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="alias">The alias to add.</param>
     /// <returns>Aliased collection of columns.</returns>
     public ColumnCollection Alias(string alias)
-    {      
+    {
       ArgumentValidator.EnsureArgumentNotNullOrEmpty(alias, "alias");
       return new ColumnCollection(this.Select(column => column.Clone(alias + "." + column.Name)));
     }
@@ -71,10 +65,8 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     /// <param name="collection">Collection of items to add.</param>
     public ColumnCollection(IEnumerable<Column> collection)
-      : base(collection.ToList())
+      : this(collection.ToList())
     {
-      nameIndex = new Dictionary<string, int>(Count);
-      BuildNameIndex();
     }
 
     /// <summary>
@@ -85,7 +77,8 @@ namespace Xtensive.Orm.Rse
       : base(collection)
     {
       nameIndex = new Dictionary<string, int>(Count);
-      BuildNameIndex();
+      for (var index = 0; index < Count; index++)
+        nameIndex.Add(this[index].Name, index);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -77,8 +77,9 @@ namespace Xtensive.Orm.Rse
       : base(collection)
     {
       nameIndex = new Dictionary<string, int>(Count);
-      for (var index = 0; index < Count; index++)
+      for (var index = 0; index < Count; index++) {
         nameIndex.Add(this[index].Name, index);
+      }
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2021 Xtensive LLC.
+// Copyright (C) 2007-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2021 Xtensive LLC.
+// Copyright (C) 2007-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2007.09.13
 
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Rse
     public DirectionCollection<int> Order { get; private set; }
 
     /// <summary>
-    /// Gets the tuple descriptor describing 
+    /// Gets the tuple descriptor describing
     /// a set of <see cref="Order"/> columns.
     /// </summary>
     public TupleDescriptor OrderTupleDescriptor {
@@ -111,10 +111,10 @@ namespace Xtensive.Orm.Rse
       var newTupleDescriptor = TupleDescriptor.Create(newFieldTypes);
 
       return new RecordSetHeader(
-        newTupleDescriptor, 
-        newColumns, 
-        ColumnGroups, 
-        OrderTupleDescriptor, 
+        newTupleDescriptor,
+        newColumns,
+        ColumnGroups,
+        OrderTupleDescriptor,
         Order);
     }
 
@@ -126,29 +126,37 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader Join(RecordSetHeader joined)
     {
       var columnCount = Columns.Count;
-      var newColumns = new List<Column>(Columns);
-      newColumns.AddRange(
-        from c in joined.Columns 
-        select c.Clone(columnCount + c.Index));
+      var newColumns = new List<Column>(columnCount + joined.Columns.Count);
+      newColumns.AddRange(Columns);
+      foreach (var c in joined.Columns) {
+        newColumns.Add(c.Clone(columnCount + c.Index));
+      }
 
       var newFieldTypes = new Type[newColumns.Count];
       for (var i = 0; i < newColumns.Count; i++)
         newFieldTypes[i] = newColumns[i].Type;
       var newTupleDescriptor = TupleDescriptor.Create(newFieldTypes);
 
-      var groups = new List<ColumnGroup>(ColumnGroups);
-      groups.AddRange(
-        joined.ColumnGroups
-          .Select(g => new ColumnGroup(
-            g.TypeInfoRef,
-            g.Keys.Select(i => columnCount + i),
-            g.Columns.Select(i => columnCount + i))));
-      
+      var columnGroupCount = ColumnGroups.Count;
+      var groups = new List<ColumnGroup>(columnGroupCount + joined.ColumnGroups.Count);
+      groups.AddRange(ColumnGroups);
+      foreach (var g in joined.ColumnGroups) {
+        var keys = new List<int>(g.Keys.Count);
+        foreach (var i in g.Keys) {
+          keys.Add(columnCount + i);
+        }
+        var columns = new List<int>(g.Columns.Count);
+        foreach (var i in g.Columns) {
+          columns.Add(columnCount + i);
+        }
+        groups.Add(new ColumnGroup(g.TypeInfoRef, keys, columns));
+      }
+
       return new RecordSetHeader(
-        newTupleDescriptor, 
-        newColumns, 
+        newTupleDescriptor,
+        newColumns,
         groups,
-        OrderTupleDescriptor, 
+        OrderTupleDescriptor,
         Order);
     }
 
@@ -171,7 +179,7 @@ namespace Xtensive.Orm.Rse
       var resultOrder = new DirectionCollection<int>(
         Order
           .Select(o => new KeyValuePair<int, Direction>(columnsMap[o.Key], o.Value))
-          .TakeWhile(o => o.Key >= 0));      
+          .TakeWhile(o => o.Key >= 0));
 
       var resultColumns = columns.Select((oldIndex, newIndex) => Columns[oldIndex].Clone(newIndex));
 
@@ -179,17 +187,17 @@ namespace Xtensive.Orm.Rse
         .Where(g => g.Keys.All(k => columnsMap[k]>=0))
         .Select(g => new ColumnGroup(
             g.TypeInfoRef,
-            g.Keys.Select(k => columnsMap[k]), 
+            g.Keys.Select(k => columnsMap[k]),
             g.Columns
               .Select(c => columnsMap[c])
               .Where(c => c >= 0)));
 
       return new RecordSetHeader(
-        resultTupleDescriptor, 
-        resultColumns, 
-        resultGroups, 
-        null, 
-        resultOrder);      
+        resultTupleDescriptor,
+        resultColumns,
+        resultGroups,
+        null,
+        resultOrder);
     }
 
     /// <summary>
@@ -242,24 +250,24 @@ namespace Xtensive.Orm.Rse
         .Select(columnInfo => columnInfo.Key.ValueType)
         .ToArray(indexInfoKeyColumns.Count);
       var keyDescriptor = TupleDescriptor.Create(keyFieldTypes);
-      
+
       var resultColumns = indexInfoColumns.Select((c,i) => (Column) new MappedColumn(c,i,c.ValueType));
       var resultGroups = new[]{indexInfo.Group};
 
       return new RecordSetHeader(
-        resultTupleDescriptor, 
-        resultColumns, 
-        resultGroups, 
-        keyDescriptor, 
+        resultTupleDescriptor,
+        resultColumns,
+        resultGroups,
+        keyDescriptor,
         order);
     }
 
     /// <inheritdoc/>
     public override string ToString()
     {
-      return Columns.Select(c => c.ToString()).ToCommaDelimitedString();      
+      return Columns.Select(c => c.ToString()).ToCommaDelimitedString();
     }
-   
+
 
     // Constructors
 
@@ -267,9 +275,9 @@ namespace Xtensive.Orm.Rse
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="tupleDescriptor">Descriptor of the result item.</param>
-    /// <param name="columns">Result columns.</param>    
+    /// <param name="columns">Result columns.</param>
     public RecordSetHeader(
-      TupleDescriptor tupleDescriptor, 
+      TupleDescriptor tupleDescriptor,
       IEnumerable<Column> columns)
       : this(tupleDescriptor, columns, null, null, null)
     {
@@ -279,11 +287,11 @@ namespace Xtensive.Orm.Rse
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="tupleDescriptor">Descriptor of the result item.</param>
-    /// <param name="columns">Result columns.</param>    
+    /// <param name="columns">Result columns.</param>
     /// <param name="columnGroups">Column groups.</param>
     public RecordSetHeader(
-      TupleDescriptor tupleDescriptor, 
-      IEnumerable<Column> columns, 
+      TupleDescriptor tupleDescriptor,
+      IEnumerable<Column> columns,
       IEnumerable<ColumnGroup> columnGroups)
       : this(tupleDescriptor, columns, columnGroups, null, null)
     {
@@ -293,14 +301,14 @@ namespace Xtensive.Orm.Rse
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="tupleDescriptor">Descriptor of the result item.</param>
-    /// <param name="columns">Result columns.</param>    
+    /// <param name="columns">Result columns.</param>
     /// <param name="orderKeyDescriptor">Descriptor of ordered columns.</param>
     /// <param name="order">Result sort order.</param>
     public RecordSetHeader(
-      TupleDescriptor tupleDescriptor, 
-      IEnumerable<Column> columns, 
+      TupleDescriptor tupleDescriptor,
+      IEnumerable<Column> columns,
       TupleDescriptor orderKeyDescriptor,
-      DirectionCollection<int> order)      
+      DirectionCollection<int> order)
       : this(tupleDescriptor, columns, null, orderKeyDescriptor, order)
     {
     }
@@ -309,25 +317,25 @@ namespace Xtensive.Orm.Rse
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="tupleDescriptor">Descriptor of the result item.</param>
-    /// <param name="columns">Result columns.</param>    
+    /// <param name="columns">Result columns.</param>
     /// <param name="columnGroups">Column groups.</param>
     /// <param name="orderKeyDescriptor">Descriptor of ordered columns.</param>
     /// <param name="order">Result sort order.</param>
     /// <exception cref="ArgumentOutOfRangeException"><c>columns.Count</c> is out of range.</exception>
     public RecordSetHeader(
-      TupleDescriptor tupleDescriptor, 
-      IEnumerable<Column> columns, 
+      TupleDescriptor tupleDescriptor,
+      IEnumerable<Column> columns,
       IEnumerable<ColumnGroup> columnGroups,
       TupleDescriptor orderKeyDescriptor,
-      DirectionCollection<int> order)      
+      DirectionCollection<int> order)
     {
       ArgumentValidator.EnsureArgumentNotNull(tupleDescriptor, "tupleDescriptor");
       ArgumentValidator.EnsureArgumentNotNull(columns, "columns");
 
       TupleDescriptor = tupleDescriptor;
       // Unsafe perf. optimization: if you pass a list, it should be immutable!
-      Columns = columns is List<Column> columnList 
-        ? new ColumnCollection(columnList) 
+      Columns = columns is List<Column> columnList
+        ? new ColumnCollection(columnList)
         : new ColumnCollection(columns);
       if (tupleDescriptor.Count!=Columns.Count)
         throw new ArgumentOutOfRangeException("columns.Count");
@@ -336,7 +344,7 @@ namespace Xtensive.Orm.Rse
         ? ColumnGroupCollection.Empty
         // Unsafe perf. optimization: if you pass a list, it should be immutable!
         : (columnGroups is List<ColumnGroup> columnGroupList
-          ? new ColumnGroupCollection(columnGroupList) 
+          ? new ColumnGroupCollection(columnGroupList)
           : new ColumnGroupCollection(columnGroups));
 
       orderTupleDescriptor = orderKeyDescriptor ?? TupleDescriptor.Empty;

--- a/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
@@ -24,6 +24,11 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public int Count => columnList.Count;
 
+    public int Capacity {
+      get => columnList.Capacity;
+      set => columnList.Capacity = value;
+    }
+
     /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>>
     bool ICollection<SqlColumn>.IsReadOnly => false;
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
@@ -24,6 +24,9 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public int Count => columnList.Count;
 
+    /// <summary>
+    /// Gets or sets capacity of the collection.
+    /// </summary>
     public int Capacity {
       get => columnList.Capacity;
       set => columnList.Capacity = value;

--- a/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information
 
 using System;
 using System.Collections;


### PR DESCRIPTION
Profiling shows significant heap allocations in these places, which are suboptimal.

* Optimizations: allocate List<> with known capacity; use IReadOnlyList instead of ReadOnlyList
* Optimize hot paths: replace LINQ by foreach
* `ReadOnlyList` wrapper is unnecessary, because since .NET 45 `List<>` implements `IReadOnlyList`