### PR TITLE
Access to DbConnection

### DIFF
--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/DriverFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2020 Xtensive LLC.
+// Copyright (C) 2011-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Csaba Beer
@@ -152,16 +152,21 @@ namespace Xtensive.Sql.Drivers.Firebird
         }
       }
       else {
-        SqlHelper.NotifyConnectionOpening(handlers, connection);
+        await SqlHelper.NotifyConnectionOpeningAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         try {
-          await connection.OpenAsync();
-          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql))
-            SqlHelper.NotifyConnectionInitializing(handlers, connection, configuration.ConnectionInitializationSql);
-          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken);
-          SqlHelper.NotifyConnectionOpened(handlers, connection);
+          await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql)) {
+            await SqlHelper.NotifyConnectionInitializingAsync(handlers,
+                connection, configuration.ConnectionInitializationSql, false, cancellationToken)
+              .ConfigureAwait(false);
+          }
+
+          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken).ConfigureAwait(false);
+          await SqlHelper.NotifyConnectionOpenedAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) {
-          SqlHelper.NotifyConnectionOpeningFailed(handlers, connection, ex);
+          await SqlHelper.NotifyConnectionOpeningFailedAsync(handlers, connection, ex, false, cancellationToken).ConfigureAwait(false);
           throw;
         }
       }

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/DriverFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2020 Xtensive LLC.
+// Copyright (C) 2011-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Malisa Ncube
@@ -172,16 +172,21 @@ namespace Xtensive.Sql.Drivers.MySql
         }
       }
       else {
-        SqlHelper.NotifyConnectionOpening(handlers, connection);
+        await SqlHelper.NotifyConnectionOpeningAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         try {
-          await connection.OpenAsync();
-          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql))
-            SqlHelper.NotifyConnectionInitializing(handlers, connection, configuration.ConnectionInitializationSql);
-          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken);
-          SqlHelper.NotifyConnectionOpened(handlers, connection);
+          await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql)) {
+            await SqlHelper.NotifyConnectionInitializingAsync(handlers,
+                connection, configuration.ConnectionInitializationSql, false, cancellationToken)
+              .ConfigureAwait(false);
+          }
+
+          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken).ConfigureAwait(false);
+          await SqlHelper.NotifyConnectionOpenedAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) {
-          SqlHelper.NotifyConnectionOpeningFailed(handlers, connection, ex);
+          await SqlHelper.NotifyConnectionOpeningFailedAsync(handlers, connection, ex, false, cancellationToken).ConfigureAwait(false);
           throw;
         }
       }

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/DriverFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -165,16 +165,21 @@ namespace Xtensive.Sql.Drivers.Oracle
         }
       }
       else {
-        SqlHelper.NotifyConnectionOpening(handlers, connection);
+        await SqlHelper.NotifyConnectionOpeningAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         try {
-          await connection.OpenAsync();
-          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql))
-            SqlHelper.NotifyConnectionInitializing(handlers, connection, configuration.ConnectionInitializationSql);
-          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken);
-          SqlHelper.NotifyConnectionOpened(handlers, connection);
+          await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql)) {
+            await SqlHelper.NotifyConnectionInitializingAsync(handlers,
+                connection, configuration.ConnectionInitializationSql, false, cancellationToken)
+              .ConfigureAwait(false);
+          }
+
+          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken).ConfigureAwait(false);
+          await SqlHelper.NotifyConnectionOpenedAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) {
-          SqlHelper.NotifyConnectionOpeningFailed(handlers, connection, ex);
+          await SqlHelper.NotifyConnectionOpeningFailedAsync(handlers, connection, ex, false, cancellationToken).ConfigureAwait(false);
           throw;
         }
       }

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/DriverFactory.cs
@@ -71,8 +71,10 @@ namespace Xtensive.Sql.Drivers.Oracle
     protected override SqlDriver CreateDriver(string connectionString, SqlDriverConfiguration configuration)
     {
       using var connection = new OracleConnection(connectionString);
-      connection.Open();
-      SqlHelper.ExecuteInitializationSql(connection, configuration);
+      if (configuration.ConnectionHandlers.Count > 0)
+        OpenConnectionWithNotifications(connection, configuration, false).GetAwaiter().GetResult();
+      else
+        OpenConnectionFast(connection, configuration, false).GetAwaiter().GetResult();
       var version = string.IsNullOrEmpty(configuration.ForcedServerVersion)
         ? ParseVersion(connection.ServerVersion)
         : new Version(configuration.ForcedServerVersion);
@@ -86,8 +88,10 @@ namespace Xtensive.Sql.Drivers.Oracle
     {
       var connection = new OracleConnection(connectionString);
       await using (connection.ConfigureAwait(false)) {
-        await connection.OpenAsync(token).ConfigureAwait(false);
-        await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, token).ConfigureAwait(false);
+        if (configuration.ConnectionHandlers.Count > 0)
+          await OpenConnectionWithNotifications(connection, configuration, true, token).ConfigureAwait(false);
+        else
+          await OpenConnectionFast(connection, configuration, true, token).ConfigureAwait(false);
         var version = string.IsNullOrEmpty(configuration.ForcedServerVersion)
           ? ParseVersion(connection.ServerVersion)
           : new Version(configuration.ForcedServerVersion);
@@ -124,5 +128,56 @@ namespace Xtensive.Sql.Drivers.Oracle
     protected override Task<DefaultSchemaInfo> ReadDefaultSchemaAsync(
       DbConnection connection, DbTransaction transaction, CancellationToken token) =>
       SqlHelper.ReadDatabaseAndSchemaAsync(DatabaseAndSchemaQuery, connection, transaction, token);
+
+    private async ValueTask OpenConnectionFast(OracleConnection connection,
+      SqlDriverConfiguration configuration,
+      bool isAsync,
+      CancellationToken cancellationToken = default)
+    {
+      if (!isAsync) {
+        connection.Open();
+        SqlHelper.ExecuteInitializationSql(connection, configuration);
+      }
+      else {
+        await connection.OpenAsync().ConfigureAwait(false);
+        await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken).ConfigureAwait(false);
+      }
+    }
+
+    private async ValueTask OpenConnectionWithNotifications(OracleConnection connection,
+      SqlDriverConfiguration configuration,
+      bool isAsync,
+      CancellationToken cancellationToken = default)
+    {
+      var handlers = configuration.ConnectionHandlers;
+      if (!isAsync) {
+        SqlHelper.NotifyConnectionOpening(handlers, connection);
+        try {
+          connection.Open();
+          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql))
+            SqlHelper.NotifyConnectionInitializing(handlers, connection, configuration.ConnectionInitializationSql);
+          SqlHelper.ExecuteInitializationSql(connection, configuration);
+          SqlHelper.NotifyConnectionOpened(handlers, connection);
+        }
+        catch (Exception ex) {
+          SqlHelper.NotifyConnectionOpeningFailed(handlers, connection, ex);
+          throw;
+        }
+      }
+      else {
+        SqlHelper.NotifyConnectionOpening(handlers, connection);
+        try {
+          await connection.OpenAsync();
+          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql))
+            SqlHelper.NotifyConnectionInitializing(handlers, connection, configuration.ConnectionInitializationSql);
+          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken);
+          SqlHelper.NotifyConnectionOpened(handlers, connection);
+        }
+        catch (Exception ex) {
+          SqlHelper.NotifyConnectionOpeningFailed(handlers, connection, ex);
+          throw;
+        }
+      }
+    }
   }
 }

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/DriverFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -160,8 +160,10 @@ namespace Xtensive.Sql.Drivers.PostgreSql
         SqlHelper.NotifyConnectionOpening(handlers, connection);
         try {
           connection.Open();
-          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql))
+          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql)) {
             SqlHelper.NotifyConnectionInitializing(handlers, connection, configuration.ConnectionInitializationSql);
+          }
+
           SqlHelper.ExecuteInitializationSql(connection, configuration);
           SqlHelper.NotifyConnectionOpened(handlers, connection);
         }
@@ -171,16 +173,21 @@ namespace Xtensive.Sql.Drivers.PostgreSql
         }
       }
       else {
-        SqlHelper.NotifyConnectionOpening(handlers, connection);
+        await SqlHelper.NotifyConnectionOpeningAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         try {
-          await connection.OpenAsync();
-          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql))
-            SqlHelper.NotifyConnectionInitializing(handlers, connection, configuration.ConnectionInitializationSql);
-          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken);
-          SqlHelper.NotifyConnectionOpened(handlers, connection);
+          await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql)) {
+            await SqlHelper.NotifyConnectionInitializingAsync(handlers,
+                connection, configuration.ConnectionInitializationSql, false, cancellationToken)
+              .ConfigureAwait(false);
+          }
+
+          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken).ConfigureAwait(false);
+          await SqlHelper.NotifyConnectionOpenedAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) {
-          SqlHelper.NotifyConnectionOpeningFailed(handlers, connection, ex);
+          await SqlHelper.NotifyConnectionOpeningFailedAsync(handlers, connection, ex, false, cancellationToken).ConfigureAwait(false);
           throw;
         }
       }

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/DriverFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2020 Xtensive LLC.
+// Copyright (C) 2011-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Malisa Ncube
@@ -133,8 +133,10 @@ namespace Xtensive.Sql.Drivers.Sqlite
         SqlHelper.NotifyConnectionOpening(handlers, connection);
         try {
           connection.Open();
-          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql))
+          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql)) {
             SqlHelper.NotifyConnectionInitializing(handlers, connection, configuration.ConnectionInitializationSql);
+          }
+
           SqlHelper.ExecuteInitializationSql(connection, configuration);
           SqlHelper.NotifyConnectionOpened(handlers, connection);
         }
@@ -144,16 +146,21 @@ namespace Xtensive.Sql.Drivers.Sqlite
         }
       }
       else {
-        SqlHelper.NotifyConnectionOpening(handlers, connection);
+        await SqlHelper.NotifyConnectionOpeningAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         try {
-          await connection.OpenAsync();
-          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql))
-            SqlHelper.NotifyConnectionInitializing(handlers, connection, configuration.ConnectionInitializationSql);
-          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken);
-          SqlHelper.NotifyConnectionOpened(handlers, connection);
+          await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+          if (!string.IsNullOrEmpty(configuration.ConnectionInitializationSql)) {
+            await SqlHelper.NotifyConnectionInitializingAsync(handlers,
+                connection, configuration.ConnectionInitializationSql, false, cancellationToken)
+              .ConfigureAwait(false);
+          }
+
+          await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken).ConfigureAwait(false);
+          await SqlHelper.NotifyConnectionOpenedAsync(handlers, connection, false, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) {
-          SqlHelper.NotifyConnectionOpeningFailed(handlers, connection, ex);
+          await SqlHelper.NotifyConnectionOpeningFailedAsync(handlers, connection, ex, false, cancellationToken).ConfigureAwait(false);
           throw;
         }
       }

--- a/Orm/Xtensive.Orm.Tests.Sql/DriverFactoryTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/DriverFactoryTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm.Tests.Sql/DriverFactoryTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/DriverFactoryTest.cs
@@ -8,6 +8,44 @@ using Xtensive.Core;
 using Xtensive.Orm;
 using Xtensive.Orm.Building.Builders;
 using Xtensive.Sql;
+using Xtensive.Orm.Tests.Sql.DriverFactoryTestTypes;
+
+namespace Xtensive.Orm.Tests.Sql.DriverFactoryTestTypes
+{
+  public class TestConnectionHandler : IConnectionHandler
+  {
+    public int OpeningCounter = 0;
+    public int OpenedCounter = 0;
+    public int OpeningInitCounter = 0;
+    public int OpeningFailedCounter = 0;
+
+    public void ConnectionOpening(ConnectionEventData eventData)
+    {
+      OpeningCounter++;
+    }
+
+    public void ConnectionOpened(ConnectionEventData eventData)
+    {
+      OpenedCounter++;
+    }
+
+    public void ConnectionInitialization(ConnectionInitEventData eventData)
+    {
+      OpeningInitCounter++;
+    }
+
+    public void ConnectionOpeningFailed(ConnectionErrorEventData eventData)
+    {
+      OpeningFailedCounter++;
+    }
+  }
+
+  public static class StaticCounter
+  {
+    public static int OpeningReached;
+    public static int OpenedReached;
+  }
+}
 
 namespace Xtensive.Orm.Tests.Sql
 {
@@ -95,6 +133,61 @@ namespace Xtensive.Orm.Tests.Sql
       Assert.That(GetCheckConnectionIsAliveFlag(driver), Is.False);
     }
 
+    [Test]
+    public void ConnectionHandlerTest()
+    {
+      var handlerInstance = new TestConnectionHandler();
+      var handlersArray = new[] { handlerInstance };
+      var descriptor = ProviderDescriptor.Get(provider);
+      var factory = (SqlDriverFactory) Activator.CreateInstance(descriptor.DriverFactory);
+
+      Assert.That(handlerInstance.OpeningCounter, Is.EqualTo(0));
+      Assert.That(handlerInstance.OpeningInitCounter, Is.EqualTo(0));
+      Assert.That(handlerInstance.OpenedCounter, Is.EqualTo(0));
+      Assert.That(handlerInstance.OpeningFailedCounter, Is.EqualTo(0));
+
+      var configuration = new SqlDriverConfiguration(handlersArray);
+      _ = factory.GetDriver(new ConnectionInfo(Url), configuration);
+      Assert.That(handlerInstance.OpeningCounter, Is.EqualTo(1));
+      Assert.That(handlerInstance.OpeningInitCounter, Is.EqualTo(0));
+      Assert.That(handlerInstance.OpenedCounter, Is.EqualTo(1));
+      Assert.That(handlerInstance.OpeningFailedCounter, Is.EqualTo(0));
+
+      configuration = new SqlDriverConfiguration(handlersArray) { EnsureConnectionIsAlive = true };
+      _ = factory.GetDriver(new ConnectionInfo(Url), configuration);
+      Assert.That(handlerInstance.OpeningCounter, Is.EqualTo(2));
+      if (provider == WellKnown.Provider.SqlServer)
+        Assert.That(handlerInstance.OpeningInitCounter, Is.EqualTo(1));
+      else
+        Assert.That(handlerInstance.OpeningInitCounter, Is.EqualTo(0));
+      Assert.That(handlerInstance.OpenedCounter, Is.EqualTo(2));
+      Assert.That(handlerInstance.OpeningFailedCounter, Is.EqualTo(0));
+
+      configuration = new SqlDriverConfiguration(handlersArray) { ConnectionInitializationSql = InitQueryPerProvider(provider) };
+      _ = factory.GetDriver(new ConnectionInfo(Url), configuration);
+      Assert.That(handlerInstance.OpeningCounter, Is.EqualTo(3));
+      if (provider == WellKnown.Provider.SqlServer)
+        Assert.That(handlerInstance.OpeningInitCounter, Is.EqualTo(2));
+      else
+        Assert.That(handlerInstance.OpeningInitCounter, Is.EqualTo(1));
+      Assert.That(handlerInstance.OpenedCounter, Is.EqualTo(3));
+      Assert.That(handlerInstance.OpeningFailedCounter, Is.EqualTo(0));
+
+      configuration = new SqlDriverConfiguration(handlersArray) { ConnectionInitializationSql = "dummy string to trigger error" };
+      try {
+        _ = factory.GetDriver(new ConnectionInfo(Url), configuration);
+      }
+      catch {
+        //skip it
+      }
+      Assert.That(handlerInstance.OpeningCounter, Is.EqualTo(4));
+      if (provider == WellKnown.Provider.SqlServer)
+        Assert.That(handlerInstance.OpeningInitCounter, Is.EqualTo(3));
+      else
+        Assert.That(handlerInstance.OpeningInitCounter, Is.EqualTo(2));
+      Assert.That(handlerInstance.OpenedCounter, Is.EqualTo(3));
+      Assert.That(handlerInstance.OpeningFailedCounter, Is.EqualTo(1));
+    }
 
     private static void TestProvider(string providerName, string connectionString, string connectionUrl)
     {
@@ -108,6 +201,19 @@ namespace Xtensive.Orm.Tests.Sql
       var type = typeof (Xtensive.Sql.Drivers.SqlServer.Driver);
       return (bool) type.GetField(fieldName, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
         .GetValue(driver);
+    }
+
+    private static string InitQueryPerProvider(string currentProvider)
+    {
+      switch (currentProvider) {
+        case WellKnown.Provider.Firebird: return "select current_timestamp from RDB$DATABASE;";
+        case WellKnown.Provider.MySql: return "SELECT 0";
+        case WellKnown.Provider.Oracle: return "select current_timestamp from DUAL";
+        case WellKnown.Provider.PostgreSql: return "SELECT 0";
+        case WellKnown.Provider.SqlServer: return "SELECT 0";
+        case WellKnown.Provider.Sqlite: return "SELECT 0";
+        default: throw new ArgumentOutOfRangeException(currentProvider);
+      }
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/ConnectionHandlerTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/ConnectionHandlerTest.cs
@@ -12,10 +12,11 @@ using Xtensive.Core;
 using Xtensive.Orm.Providers;
 using Xtensive.Sql;
 using Xtensive.Orm.Tests.Storage.ConnectionHandlersModel;
+using System.Threading.Tasks;
 
 namespace Xtensive.Orm.Tests.Storage.ConnectionHandlersModel
 {
-  public class MyConnectionHandler : IConnectionHandler
+  public class MyConnectionHandler : ConnectionHandler
   {
     private Guid instanceMarker;
 
@@ -26,13 +27,13 @@ namespace Xtensive.Orm.Tests.Storage.ConnectionHandlersModel
     public int ConnectionOpenedCounter;
     public int ConnectionOpeningFailedCounter;
 
-    public void ConnectionOpening(ConnectionEventData eventData)
+    public override void ConnectionOpening(ConnectionEventData eventData)
     {
       instanceMarker = UniqueInstanceIdentifier;
       ConnectionOpeningCounter++;
     }
 
-    public void ConnectionInitialization(ConnectionInitEventData eventData)
+    public override void ConnectionInitialization(ConnectionInitEventData eventData)
     {
       ConnectionInitializationCounter++;
       if (instanceMarker != UniqueInstanceIdentifier) {
@@ -40,7 +41,7 @@ namespace Xtensive.Orm.Tests.Storage.ConnectionHandlersModel
       }
     }
 
-    public void ConnectionOpened(ConnectionEventData eventData)
+    public override void ConnectionOpened(ConnectionEventData eventData)
     {
       ConnectionOpenedCounter++;
       if (instanceMarker != UniqueInstanceIdentifier) {
@@ -48,7 +49,7 @@ namespace Xtensive.Orm.Tests.Storage.ConnectionHandlersModel
       }
     }
 
-    public void ConnectionOpeningFailed(ConnectionErrorEventData eventData)
+    public override void ConnectionOpeningFailed(ConnectionErrorEventData eventData)
     {
       ConnectionOpeningFailedCounter++;
       if (instanceMarker != UniqueInstanceIdentifier) {
@@ -62,7 +63,7 @@ namespace Xtensive.Orm.Tests.Storage.ConnectionHandlersModel
     }
   }
 
-  public class NoDefaultConstructorHandler : IConnectionHandler
+  public class NoDefaultConstructorHandler : ConnectionHandler
   {
 #pragma warning disable IDE0060 // Remove unused parameter
     public NoDefaultConstructorHandler(int dummyParameter)
@@ -71,7 +72,7 @@ namespace Xtensive.Orm.Tests.Storage.ConnectionHandlersModel
     }
   }
 
-  public class NonPublicDefaultConstructorHandler : IConnectionHandler
+  public class NonPublicDefaultConstructorHandler : ConnectionHandler
   {
     private NonPublicDefaultConstructorHandler()
     {
@@ -80,31 +81,31 @@ namespace Xtensive.Orm.Tests.Storage.ConnectionHandlersModel
 
   #region Performance Test handlers
 
-  public class PerfHandler1 : IConnectionHandler { }
-  public class PerfHandler2 : IConnectionHandler { }
-  public class PerfHandler3 : IConnectionHandler { }
-  public class PerfHandler4 : IConnectionHandler { }
-  public class PerfHandler5 : IConnectionHandler { }
-  public class PerfHandler6 : IConnectionHandler { }
-  public class PerfHandler7 : IConnectionHandler { }
-  public class PerfHandler8 : IConnectionHandler { }
-  public class PerfHandler9 : IConnectionHandler { }
-  public class PerfHandler10 : IConnectionHandler { }
-  public class PerfHandler11 : IConnectionHandler { }
-  public class PerfHandler12 : IConnectionHandler { }
-  public class PerfHandler13 : IConnectionHandler { }
-  public class PerfHandler14 : IConnectionHandler { }
-  public class PerfHandler15 : IConnectionHandler { }
-  public class PerfHandler16 : IConnectionHandler { }
-  public class PerfHandler17 : IConnectionHandler { }
-  public class PerfHandler18 : IConnectionHandler { }
-  public class PerfHandler19 : IConnectionHandler { }
-  public class PerfHandler20 : IConnectionHandler { }
-  public class PerfHandler21 : IConnectionHandler { }
-  public class PerfHandler22 : IConnectionHandler { }
-  public class PerfHandler23 : IConnectionHandler { }
-  public class PerfHandler24 : IConnectionHandler { }
-  public class PerfHandler25 : IConnectionHandler { }
+  public class PerfHandler1 : ConnectionHandler { }
+  public class PerfHandler2 : ConnectionHandler { }
+  public class PerfHandler3 : ConnectionHandler { }
+  public class PerfHandler4 : ConnectionHandler { }
+  public class PerfHandler5 : ConnectionHandler { }
+  public class PerfHandler6 : ConnectionHandler { }
+  public class PerfHandler7 : ConnectionHandler { }
+  public class PerfHandler8 : ConnectionHandler { }
+  public class PerfHandler9 : ConnectionHandler { }
+  public class PerfHandler10 : ConnectionHandler { }
+  public class PerfHandler11 : ConnectionHandler { }
+  public class PerfHandler12 : ConnectionHandler { }
+  public class PerfHandler13 : ConnectionHandler { }
+  public class PerfHandler14 : ConnectionHandler { }
+  public class PerfHandler15 : ConnectionHandler { }
+  public class PerfHandler16 : ConnectionHandler { }
+  public class PerfHandler17 : ConnectionHandler { }
+  public class PerfHandler18 : ConnectionHandler { }
+  public class PerfHandler19 : ConnectionHandler { }
+  public class PerfHandler20 : ConnectionHandler { }
+  public class PerfHandler21 : ConnectionHandler { }
+  public class PerfHandler22 : ConnectionHandler { }
+  public class PerfHandler23 : ConnectionHandler { }
+  public class PerfHandler24 : ConnectionHandler { }
+  public class PerfHandler25 : ConnectionHandler { }
 
   #endregion
 
@@ -157,6 +158,19 @@ namespace Xtensive.Orm.Tests.Storage
     }
 
     [Test]
+    public void NoDefaultConstructorAsyncTest()
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.UpgradeMode = DomainUpgradeMode.Recreate;
+      domainConfig.Types.Register(typeof(DummyEntity));
+      domainConfig.Types.Register(typeof(NoDefaultConstructorHandler));
+
+      Domain domain = null;
+      _ = Assert.ThrowsAsync<NotSupportedException>(async () => domain = await Domain.BuildAsync(domainConfig));
+      domain.DisposeSafely();
+    }
+
+    [Test]
     public void NonPublicDefaultConstructorTest()
     {
       var domainConfig = DomainConfigurationFactory.Create();
@@ -168,6 +182,17 @@ namespace Xtensive.Orm.Tests.Storage
     }
 
     [Test]
+    public async Task NonPublicDefaultConstructorAsyncTest()
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.UpgradeMode = DomainUpgradeMode.Recreate;
+      domainConfig.Types.Register(typeof(DummyEntity));
+      domainConfig.Types.Register(typeof(NonPublicDefaultConstructorHandler));
+
+      await using var domain = await Domain.BuildAsync(domainConfig);
+    }
+
+    [Test]
     public void SessionConnectionHandlersTest()
     {
       var domainConfig = DomainConfigurationFactory.Create();
@@ -175,7 +200,7 @@ namespace Xtensive.Orm.Tests.Storage
       domainConfig.Types.Register(typeof(DummyEntity));
       domainConfig.Types.Register(typeof(MyConnectionHandler));
 
-      Guid? first = null; 
+      Guid? first = null;
       using (var domain = Domain.Build(domainConfig))
       using (var session = domain.OpenSession()) {
         var nativeHandler = (SqlSessionHandler) session.Handler;
@@ -189,6 +214,39 @@ namespace Xtensive.Orm.Tests.Storage
       Guid? second = null;
       using (var domain = Domain.Build(domainConfig))
       using (var session = domain.OpenSession()) {
+        var nativeHandler = (SqlSessionHandler) session.Handler;
+        var extension = nativeHandler.Connection.Extensions.Get<ConnectionHandlersExtension>();
+        var handlerInstance = (MyConnectionHandler) extension.Handlers.First();
+        Assert.That(handlerInstance.ConnectionOpeningCounter, Is.Not.EqualTo(0));
+        Assert.That(handlerInstance.ConnectionOpenedCounter, Is.Not.EqualTo(0));
+        second = handlerInstance.UniqueInstanceIdentifier;
+      }
+
+      Assert.That(first != null && second != null && first != second, Is.True);
+    }
+
+    [Test]
+    public async Task SessionConnectionHandlersAsyncTest()
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.UpgradeMode = DomainUpgradeMode.Recreate;
+      domainConfig.Types.Register(typeof(DummyEntity));
+      domainConfig.Types.Register(typeof(MyConnectionHandler));
+
+      Guid? first = null;
+      await using (var domain = await Domain.BuildAsync(domainConfig))
+      await using (var session = await domain.OpenSessionAsync()) {
+        var nativeHandler = (SqlSessionHandler) session.Handler;
+        var extension = nativeHandler.Connection.Extensions.Get<ConnectionHandlersExtension>();
+        var handlerInstance = (MyConnectionHandler) extension.Handlers.First();
+        Assert.That(handlerInstance.ConnectionOpeningCounter, Is.Not.EqualTo(0));
+        Assert.That(handlerInstance.ConnectionOpenedCounter, Is.Not.EqualTo(0));
+        first = handlerInstance.UniqueInstanceIdentifier;
+      }
+
+      Guid? second = null;
+      await using (var domain = await Domain.BuildAsync(domainConfig))
+      await using (var session = await domain.OpenSessionAsync()) {
         var nativeHandler = (SqlSessionHandler) session.Handler;
         var extension = nativeHandler.Connection.Extensions.Get<ConnectionHandlersExtension>();
         var handlerInstance = (MyConnectionHandler) extension.Handlers.First();
@@ -215,6 +273,35 @@ namespace Xtensive.Orm.Tests.Storage
 
       using (var domain = Domain.Build(domainConfig))
       using (var session = domain.OpenSession()) {
+        var nativeHandler = (SqlSessionHandler) session.Handler;
+        var extensions = nativeHandler.Connection.Extensions;
+        if (includeHandlersCount > 0) {
+          Assert.That(extensions.Count, Is.EqualTo(1));
+          var extension = extensions.Get<ConnectionHandlersExtension>();
+          Assert.That(extension, Is.Not.Null);
+          Assert.That(extension.Handlers.Count, Is.EqualTo(includeHandlersCount));
+        }
+        else {
+          Assert.That(extensions.Count, Is.EqualTo(0));
+        }
+      }
+    }
+
+    [Test]
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    public async Task ConnectionExtensionExistanceAsyncTest(int includeHandlersCount)
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.UpgradeMode = DomainUpgradeMode.Recreate;
+
+      foreach (var handler in GetHandlers(includeHandlersCount)) {
+        domainConfig.Types.Register(handler);
+      }
+
+      await using (var domain = await Domain.BuildAsync(domainConfig))
+      await using (var session = await domain.OpenSessionAsync()) {
         var nativeHandler = (SqlSessionHandler) session.Handler;
         var extensions = nativeHandler.Connection.Extensions;
         if (includeHandlersCount > 0) {

--- a/Orm/Xtensive.Orm.Tests/Storage/ConnectionHandlerTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/ConnectionHandlerTest.cs
@@ -1,0 +1,279 @@
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Xtensive.Core;
+using Xtensive.Orm.Providers;
+using Xtensive.Sql;
+using Xtensive.Orm.Tests.Storage.ConnectionHandlersModel;
+
+namespace Xtensive.Orm.Tests.Storage.ConnectionHandlersModel
+{
+  public class MyConnectionHandler : IConnectionHandler
+  {
+    private Guid instanceMarker;
+
+    public readonly Guid UniqueInstanceIdentifier;
+
+    public int ConnectionOpeningCounter;
+    public int ConnectionInitializationCounter;
+    public int ConnectionOpenedCounter;
+    public int ConnectionOpeningFailedCounter;
+
+    public void ConnectionOpening(ConnectionEventData eventData)
+    {
+      instanceMarker = UniqueInstanceIdentifier;
+      ConnectionOpeningCounter++;
+    }
+
+    public void ConnectionInitialization(ConnectionInitEventData eventData)
+    {
+      ConnectionInitializationCounter++;
+      if (instanceMarker != UniqueInstanceIdentifier) {
+        throw new Exception("Not the same instance");
+      }
+    }
+
+    public void ConnectionOpened(ConnectionEventData eventData)
+    {
+      ConnectionOpenedCounter++;
+      if (instanceMarker != UniqueInstanceIdentifier) {
+        throw new Exception("Not the same instance");
+      }
+    }
+
+    public void ConnectionOpeningFailed(ConnectionErrorEventData eventData)
+    {
+      ConnectionOpeningFailedCounter++;
+      if (instanceMarker != UniqueInstanceIdentifier) {
+        throw new Exception("Not the same instance");
+      }
+    }
+
+    public MyConnectionHandler()
+    {
+      UniqueInstanceIdentifier = Guid.NewGuid();
+    }
+  }
+
+  public class NoDefaultConstructorHandler : IConnectionHandler
+  {
+#pragma warning disable IDE0060 // Remove unused parameter
+    public NoDefaultConstructorHandler(int dummyParameter)
+#pragma warning restore IDE0060 // Remove unused parameter
+    {
+    }
+  }
+
+  public class NonPublicDefaultConstructorHandler : IConnectionHandler
+  {
+    private NonPublicDefaultConstructorHandler()
+    {
+    }
+  }
+
+  #region Performance Test handlers
+
+  public class PerfHandler1 : IConnectionHandler { }
+  public class PerfHandler2 : IConnectionHandler { }
+  public class PerfHandler3 : IConnectionHandler { }
+  public class PerfHandler4 : IConnectionHandler { }
+  public class PerfHandler5 : IConnectionHandler { }
+  public class PerfHandler6 : IConnectionHandler { }
+  public class PerfHandler7 : IConnectionHandler { }
+  public class PerfHandler8 : IConnectionHandler { }
+  public class PerfHandler9 : IConnectionHandler { }
+  public class PerfHandler10 : IConnectionHandler { }
+  public class PerfHandler11 : IConnectionHandler { }
+  public class PerfHandler12 : IConnectionHandler { }
+  public class PerfHandler13 : IConnectionHandler { }
+  public class PerfHandler14 : IConnectionHandler { }
+  public class PerfHandler15 : IConnectionHandler { }
+  public class PerfHandler16 : IConnectionHandler { }
+  public class PerfHandler17 : IConnectionHandler { }
+  public class PerfHandler18 : IConnectionHandler { }
+  public class PerfHandler19 : IConnectionHandler { }
+  public class PerfHandler20 : IConnectionHandler { }
+  public class PerfHandler21 : IConnectionHandler { }
+  public class PerfHandler22 : IConnectionHandler { }
+  public class PerfHandler23 : IConnectionHandler { }
+  public class PerfHandler24 : IConnectionHandler { }
+  public class PerfHandler25 : IConnectionHandler { }
+
+  #endregion
+
+  public static class StaticCounter
+  {
+    public static int OpeningReached;
+    public static int OpenedReached;
+  }
+
+  public class DummyEntity : Entity
+  {
+    [Field, Key]
+    public int Id { get; private set; }
+
+    [Field]
+    public int Value { get; set; }
+
+    public DummyEntity(Session session)
+      : base(session)
+    {
+    }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  public class ConnectionHandlerTest
+  {
+    [Test]
+    public void DomainRegistryTest()
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.Types.Register(typeof(DummyEntity));
+      domainConfig.Types.Register(typeof(MyConnectionHandler));
+
+      Assert.That(domainConfig.Types.ConnectionHandlers.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void NoDefaultConstructorTest()
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.UpgradeMode = DomainUpgradeMode.Recreate;
+      domainConfig.Types.Register(typeof(DummyEntity));
+      domainConfig.Types.Register(typeof(NoDefaultConstructorHandler));
+
+      Domain domain = null;
+      _ = Assert.Throws<NotSupportedException>(() => domain = Domain.Build(domainConfig));
+      domain.DisposeSafely();
+    }
+
+    [Test]
+    public void NonPublicDefaultConstructorTest()
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.UpgradeMode = DomainUpgradeMode.Recreate;
+      domainConfig.Types.Register(typeof(DummyEntity));
+      domainConfig.Types.Register(typeof(NonPublicDefaultConstructorHandler));
+
+      using var domain = Domain.Build(domainConfig);
+    }
+
+    [Test]
+    public void SessionConnectionHandlersTest()
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.UpgradeMode = DomainUpgradeMode.Recreate;
+      domainConfig.Types.Register(typeof(DummyEntity));
+      domainConfig.Types.Register(typeof(MyConnectionHandler));
+
+      Guid? first = null; 
+      using (var domain = Domain.Build(domainConfig))
+      using (var session = domain.OpenSession()) {
+        var nativeHandler = (SqlSessionHandler) session.Handler;
+        var extension = nativeHandler.Connection.Extensions.Get<ConnectionHandlersExtension>();
+        var handlerInstance = (MyConnectionHandler)extension.Handlers.First();
+        Assert.That(handlerInstance.ConnectionOpeningCounter, Is.Not.EqualTo(0));
+        Assert.That(handlerInstance.ConnectionOpenedCounter, Is.Not.EqualTo(0));
+        first = handlerInstance.UniqueInstanceIdentifier;
+      }
+
+      Guid? second = null;
+      using (var domain = Domain.Build(domainConfig))
+      using (var session = domain.OpenSession()) {
+        var nativeHandler = (SqlSessionHandler) session.Handler;
+        var extension = nativeHandler.Connection.Extensions.Get<ConnectionHandlersExtension>();
+        var handlerInstance = (MyConnectionHandler) extension.Handlers.First();
+        Assert.That(handlerInstance.ConnectionOpeningCounter, Is.Not.EqualTo(0));
+        Assert.That(handlerInstance.ConnectionOpenedCounter, Is.Not.EqualTo(0));
+        second = handlerInstance.UniqueInstanceIdentifier;
+      }
+
+      Assert.That(first != null && second != null && first != second, Is.True);
+    }
+
+    [Test]
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    public void ConnectionExtensionExistanceTest(int includeHandlersCount)
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.UpgradeMode = DomainUpgradeMode.Recreate;
+
+      foreach (var handler in GetHandlers(includeHandlersCount)) {
+        domainConfig.Types.Register(handler);
+      }
+
+      using (var domain = Domain.Build(domainConfig))
+      using (var session = domain.OpenSession()) {
+        var nativeHandler = (SqlSessionHandler) session.Handler;
+        var extensions = nativeHandler.Connection.Extensions;
+        if (includeHandlersCount > 0) {
+          Assert.That(extensions.Count, Is.EqualTo(1));
+          var extension = extensions.Get<ConnectionHandlersExtension>();
+          Assert.That(extension, Is.Not.Null);
+          Assert.That(extension.Handlers.Count, Is.EqualTo(includeHandlersCount));
+        }
+        else {
+          Assert.That(extensions.Count, Is.EqualTo(0));
+        }
+      }
+    }
+
+    [Explicit]
+    [TestCase(0)]
+    [TestCase(5)]
+    [TestCase(10)]
+    [TestCase(15)]
+    [TestCase(20)]
+    [TestCase(25)]
+    public void SessionOpeningPerformanceTest(int includeHandlersCount)
+    {
+      var domainConfig = DomainConfigurationFactory.Create();
+      domainConfig.UpgradeMode = DomainUpgradeMode.Recreate;
+
+      foreach (var handler in GetHandlers(includeHandlersCount)) {
+        domainConfig.Types.Register(handler);
+      }
+
+      var watch = new Stopwatch();
+      using (var domain = Domain.Build(domainConfig)) {
+        watch.Start();
+        for (var i = 0; i < 1000000; i++) {
+          domain.OpenSession().Dispose();
+        }
+        watch.Stop();
+      }
+      Console.WriteLine(watch.ElapsedTicks / 1000000);
+    }
+
+    private IEnumerable<Type> GetHandlers(int neededCount)
+    {
+      if (neededCount > 25) {
+        throw new Exception();
+      }
+
+      var all = new Type[] {
+        typeof(PerfHandler1), typeof(PerfHandler2), typeof(PerfHandler3), typeof(PerfHandler4),
+        typeof(PerfHandler5), typeof(PerfHandler6), typeof(PerfHandler7), typeof(PerfHandler8),
+        typeof(PerfHandler9), typeof(PerfHandler10), typeof(PerfHandler11), typeof(PerfHandler12),
+        typeof(PerfHandler13), typeof(PerfHandler14), typeof(PerfHandler15), typeof(PerfHandler16),
+        typeof(PerfHandler17), typeof(PerfHandler18), typeof(PerfHandler19), typeof(PerfHandler20),
+        typeof(PerfHandler21), typeof(PerfHandler22), typeof(PerfHandler23), typeof(PerfHandler24),
+        typeof(PerfHandler25)
+      };
+      for (var i = 0; i < neededCount; i++) {
+        yield return all[i];
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainTypeRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainTypeRegistry.cs
@@ -25,7 +25,11 @@ namespace Xtensive.Orm.Configuration
     private readonly static Type iModuleType = typeof(IModule);
     private readonly static Type iUpgradeHandlerType = typeof(IUpgradeHandler);
     private readonly static Type keyGeneratorType = typeof(KeyGenerator);
-    private static readonly Type ifulltextCatalogNameBuilder = typeof(IFullTextCatalogNameBuilder);
+    private readonly static Type ifulltextCatalogNameBuilder = typeof(IFullTextCatalogNameBuilder);
+    private readonly static Type iConnectionHandlerType = typeof(IConnectionHandler);
+
+    private Type[] connectionHandlers;
+
 
     /// <summary>
     /// Gets all the registered persistent types.
@@ -68,6 +72,27 @@ namespace Xtensive.Orm.Configuration
     /// </summary>
     public IEnumerable<Type> FullTextCatalogResolvers => this.Where(IsFullTextCatalogNameBuilder);
 
+    /// <summary>
+    /// Gets all the registered <see cref="IConnectionHandler"/> implementations.
+    /// </summary>
+    public IEnumerable<Type> ConnectionHandlers
+    {
+      get {
+        // a lot of access to this property. better to have items cached;
+        if (IsLocked) {
+          if(connectionHandlers == null) {
+            var container = new List<Type>(10);// not so many handlers expected
+            foreach (var type in this.Where(IsConnectionHandler))
+              container.Add(type);
+            connectionHandlers = container.Count == 0 ? Array.Empty<Type>() : container.ToArray();
+          }
+          return connectionHandlers;
+        }
+        // if instacne is not locked then there is a chance of new handlers appeared
+        return this.Where(IsConnectionHandler);
+      }
+    }
+
     #region IsXxx method group
 
     /// <summary>
@@ -85,7 +110,8 @@ namespace Xtensive.Orm.Configuration
       IsUpgradeHandler(type) ||
       IsKeyGenerator(type) ||
       IsCompilerContainer(type) ||
-      IsFullTextCatalogNameBuilder(type);
+      IsFullTextCatalogNameBuilder(type) ||
+      IsConnectionHandler(type);
 
     /// <summary>
     /// Determines whether a <paramref name="type"/>
@@ -199,6 +225,21 @@ namespace Xtensive.Orm.Configuration
       }
 
       return ifulltextCatalogNameBuilder.IsAssignableFrom(type) && ifulltextCatalogNameBuilder != type;
+    }
+
+    /// <summary>
+    /// Determines whether the <paramref name="type"/> is
+    /// a connection handler.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>Check result.</returns>
+    public static bool IsConnectionHandler(Type type)
+    {
+      if (type.IsAbstract) {
+        return false;
+      }
+
+      return iConnectionHandlerType.IsAssignableFrom(type) && iConnectionHandlerType != type;
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainTypeRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainTypeRegistry.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2020 Xtensive LLC.
+// Copyright (C) 2010-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin

--- a/Orm/Xtensive.Orm/Orm/ConnectionErrorEventData.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionErrorEventData.cs
@@ -1,4 +1,8 @@
-﻿using System;
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
 using System.Data.Common;
 using Xtensive.Core;
 

--- a/Orm/Xtensive.Orm/Orm/ConnectionErrorEventData.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionErrorEventData.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Data.Common;
+using Xtensive.Core;
+
+namespace Xtensive.Orm
+{
+  /// <summary>
+  /// Extended <see cref="ConnectionEventData"/> with error happend during connection opening, restoration or initialization.
+  /// </summary>
+  public class ConnectionErrorEventData : ConnectionEventData
+  {
+    /// <summary>
+    /// The exception appeared.
+    /// </summary>
+    public Exception Exception { get; }
+
+    public ConnectionErrorEventData(Exception exception, DbConnection connection, bool reconnect = false)
+      : base(connection, reconnect)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(exception, nameof(exception));
+      Exception = exception;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/ConnectionEventData.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionEventData.cs
@@ -1,0 +1,28 @@
+﻿using System.Data.Common;
+using Xtensive.Core;
+
+namespace Xtensive.Orm
+{
+  /// <summary>
+  /// Contains general data for <see cref="IConnectionHandler"/> methods.
+  /// </summary>
+  public class ConnectionEventData
+  {
+    /// <summary>
+    /// The connection for which event triggered.
+    /// </summary>
+    public DbConnection Connection { get; }
+
+    /// <summary>
+    /// Indicates whether event happened during an attempt to restore connection.
+    /// </summary>
+    public bool Reconnect { get; }
+
+    public ConnectionEventData(DbConnection connection, bool reconnect = false)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(connection, nameof(connection));
+      Connection = connection;
+      Reconnect = reconnect;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/ConnectionEventData.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionEventData.cs
@@ -1,4 +1,8 @@
-﻿using System.Data.Common;
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Data.Common;
 using Xtensive.Core;
 
 namespace Xtensive.Orm

--- a/Orm/Xtensive.Orm/Orm/ConnectionInitEventData.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionInitEventData.cs
@@ -1,4 +1,8 @@
-﻿using System.Data.Common;
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Data.Common;
 using Xtensive.Core;
 
 namespace Xtensive.Orm

--- a/Orm/Xtensive.Orm/Orm/ConnectionInitEventData.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionInitEventData.cs
@@ -1,0 +1,23 @@
+﻿using System.Data.Common;
+using Xtensive.Core;
+
+namespace Xtensive.Orm
+{
+  /// <summary>
+  /// Extended <see cref="ConnectionEventData"/> with connection initialization script
+  /// </summary>
+  public class ConnectionInitEventData : ConnectionEventData
+  {
+    /// <summary>
+    /// Gets the script which will be used for connection initializatin
+    /// </summary>
+    public string InitializationScript { get; }
+
+    public ConnectionInitEventData(string initializationScript, DbConnection connection, bool reconnect = false)
+      : base(connection, reconnect)
+    {
+      ArgumentValidator.EnsureArgumentNotNullOrEmpty(initializationScript, nameof(initializationScript));
+      InitializationScript = initializationScript;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Interfaces/ConnectionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Interfaces/ConnectionHandler.cs
@@ -1,0 +1,63 @@
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xtensive.Orm
+{
+  /// <summary>
+  /// Base type for connection handlers to be inherited from.
+  /// </summary>
+  public abstract class ConnectionHandler : IConnectionHandler
+  {
+    /// <inheritdoc/>
+    public virtual void ConnectionOpening(ConnectionEventData eventData)
+    {
+    }
+
+    /// <inheritdoc/>
+    public virtual Task ConnectionOpeningAsync(ConnectionEventData eventData, CancellationToken cancellationToken)
+    {
+      ConnectionOpening(eventData);
+      return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public virtual void ConnectionInitialization(ConnectionInitEventData eventData)
+    {
+    }
+
+    /// <inheritdoc/>
+    public virtual Task ConnectionInitializationAsync(ConnectionInitEventData eventData, CancellationToken cancellationToken)
+    {
+      ConnectionInitialization(eventData);
+      return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public virtual void ConnectionOpened(ConnectionEventData eventData)
+    {
+    }
+
+    /// <inheritdoc/>
+    public virtual Task ConnectionOpenedAsync(ConnectionEventData eventData, CancellationToken cancellationToken)
+    {
+      ConnectionOpened(eventData);
+      return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public virtual void ConnectionOpeningFailed(ConnectionErrorEventData eventData)
+    {
+    }
+
+    /// <inheritdoc/>
+    public virtual Task ConnectionOpeningFailedAsync(ConnectionErrorEventData eventData, CancellationToken cancellationToken)
+    {
+      ConnectionOpeningFailed(eventData);
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Interfaces/IConnectionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Interfaces/IConnectionHandler.cs
@@ -1,0 +1,33 @@
+namespace Xtensive.Orm
+{
+  /// <summary>
+  /// Offers event-like methods to access native database connection on different stages
+  /// </summary>
+  public interface IConnectionHandler
+  {
+    /// <summary>
+    /// Executes before connection opening.
+    /// </summary>
+    /// <param name="eventData">Information connected with this event.</param>
+    void ConnectionOpening(ConnectionEventData eventData) { }
+
+    /// <summary>
+    /// Executes when connection is already opened but initialization script
+    /// hasn't been executed yet.
+    /// </summary>
+    /// <param name="eventData">Information connected with this event.</param>
+    void ConnectionInitialization(ConnectionInitEventData eventData) { }
+
+    /// <summary>
+    /// Executes when connection is successfully opened and initialized
+    /// </summary>
+    /// <param name="eventData">Information connected with this event</param>
+    void ConnectionOpened(ConnectionEventData eventData) { }
+
+    /// <summary>
+    /// Executes if an error appeared on either connection opening or connection initialization.
+    /// </summary>
+    /// <param name="eventData">Information connected with this event</param>
+    void ConnectionOpeningFailed(ConnectionErrorEventData eventData) { }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Interfaces/IConnectionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Interfaces/IConnectionHandler.cs
@@ -1,7 +1,14 @@
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Xtensive.Orm
 {
   /// <summary>
-  /// Offers event-like methods to access native database connection on different stages
+  /// Offers event-like methods to access native database connection on different stages.
   /// </summary>
   public interface IConnectionHandler
   {
@@ -9,25 +16,58 @@ namespace Xtensive.Orm
     /// Executes before connection opening.
     /// </summary>
     /// <param name="eventData">Information connected with this event.</param>
-    void ConnectionOpening(ConnectionEventData eventData) { }
+    void ConnectionOpening(ConnectionEventData eventData);
+
+    /// <summary>
+    /// Executes before connection opening.
+    /// </summary>
+    /// <param name="eventData">Information connected with this event.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Task performing operation.</returns>
+    Task ConnectionOpeningAsync(ConnectionEventData eventData, CancellationToken cancellationToken);
 
     /// <summary>
     /// Executes when connection is already opened but initialization script
     /// hasn't been executed yet.
     /// </summary>
     /// <param name="eventData">Information connected with this event.</param>
-    void ConnectionInitialization(ConnectionInitEventData eventData) { }
+    void ConnectionInitialization(ConnectionInitEventData eventData);
 
     /// <summary>
-    /// Executes when connection is successfully opened and initialized
+    /// Executes when connection is already opened but initialization script
+    /// hasn't been executed yet.
     /// </summary>
-    /// <param name="eventData">Information connected with this event</param>
-    void ConnectionOpened(ConnectionEventData eventData) { }
+    /// <param name="eventData">Information connected with this event.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Task performing operation.</returns>
+    Task ConnectionInitializationAsync(ConnectionInitEventData eventData, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes when connection is successfully opened and initialized.
+    /// </summary>
+    /// <param name="eventData">Information connected with this event.</param>
+    void ConnectionOpened(ConnectionEventData eventData);
+
+    /// <summary>
+    /// Executes when connection is successfully opened and initialized.
+    /// </summary>
+    /// <param name="eventData">Information connected with this event.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Task performing operation.</returns>
+    Task ConnectionOpenedAsync(ConnectionEventData eventData, CancellationToken cancellationToken);
 
     /// <summary>
     /// Executes if an error appeared on either connection opening or connection initialization.
     /// </summary>
-    /// <param name="eventData">Information connected with this event</param>
-    void ConnectionOpeningFailed(ConnectionErrorEventData eventData) { }
+    /// <param name="eventData">Information connected with this event.</param>
+    void ConnectionOpeningFailed(ConnectionErrorEventData eventData);
+
+    /// <summary>
+    /// Executes if an error appeared on either connection opening or connection initialization.
+    /// </summary>
+    /// <param name="eventData">Information connected with this event.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Task performing operation.</returns>
+    Task ConnectionOpeningFailedAsync(ConnectionErrorEventData eventData, CancellationToken cancellationToken);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -14,7 +14,7 @@ using Xtensive.Sql;
 
 namespace Xtensive.Orm.Providers
 {
-  partial class StorageDriver
+  public partial class StorageDriver
   {
     private sealed class InitializationSqlExtension
     {
@@ -50,6 +50,10 @@ namespace Xtensive.Orm.Providers
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
       }
+      if (handlerFactoriesCache != null) {
+        connection.Extensions.Set(
+          new ConnectionHandlersExtension(CreateHandlersForConnection(configuration.Types.ConnectionHandlers)));
+      }
 
       var sessionConfiguration = GetConfiguration(session);
       connection.CommandTimeout = sessionConfiguration.DefaultCommandTimeout;
@@ -76,7 +80,7 @@ namespace Xtensive.Orm.Providers
       var script = extension?.Script;
       try {
         if (!string.IsNullOrEmpty(script)) {
-          connection.OpenAndInitialize(extension.Script);
+          connection.OpenAndInitialize(script);
         }
         else {
           connection.Open();
@@ -100,8 +104,9 @@ namespace Xtensive.Orm.Providers
       var extension = connection.Extensions.Get<InitializationSqlExtension>();
 
       try {
-        if (!string.IsNullOrEmpty(extension?.Script)) {
-          await connection.OpenAndInitializeAsync(extension.Script, cancellationToken).ConfigureAwait(false);
+        var script = extension?.Script;
+        if (!string.IsNullOrEmpty(script)) {
+          await connection.OpenAndInitializeAsync(script, cancellationToken).ConfigureAwait(false);
         }
         else {
           await connection.OpenAsync(cancellationToken).ConfigureAwait(false);

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -178,10 +178,15 @@ namespace Xtensive.Orm.Providers
     {
       var instances = new List<IConnectionHandler>();
       factories = new ConcurrentDictionary<Type, Func<IConnectionHandler>>();
-      foreach (var item in connectionHandlerTypes) {
-        var handlerFactory = (Func<IConnectionHandler>) FactoryCreatorMethod.MakeGenericMethod(item).Invoke(null, null);
+      foreach (var type in connectionHandlerTypes) {
+        var ctor = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, Type.EmptyTypes, null);
+        if (ctor == null) {
+          throw new NotSupportedException(string.Format(Strings.ExConnectionHandlerXHasNoParameterlessConstructor, type));
+        }
+
+        var handlerFactory = (Func<IConnectionHandler>) FactoryCreatorMethod.MakeGenericMethod(type).Invoke(null, null);
         instances.Add(handlerFactory());
-        factories[item] = handlerFactory;
+        factories[type] = handlerFactory;
       }
       if (factories.Count == 0)
         factories = null;

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm/Sql/ConnectionHandlersExtension.cs
+++ b/Orm/Xtensive.Orm/Sql/ConnectionHandlersExtension.cs
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Collections.Generic;
+using Xtensive.Orm;
+
+namespace Xtensive.Sql
+{
+  /// <summary>
+  /// Wrapper to pass handlers to connection.
+  /// </summary>
+  public sealed class ConnectionHandlersExtension
+  {
+    /// <summary>
+    /// Collection of <see cref="IConnectionHandler"/> instances.
+    /// </summary>
+    public IReadOnlyCollection<IConnectionHandler> Handlers { get; }
+
+    internal ConnectionHandlersExtension(IReadOnlyCollection<IConnectionHandler> handlers)
+    {
+      Handlers = handlers;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Sql/SqlConnection.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm/Sql/SqlDriver.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriver.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm/Sql/SqlDriver.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriver.cs
@@ -46,6 +46,11 @@ namespace Xtensive.Sql
     public SqlTranslator Translator { get; private set; }
 
     /// <summary>
+    /// Gets <see cref="IConnectionHandler"/>s collection.
+    /// </summary>
+    public IReadOnlyCollection<IConnectionHandler> ConnectionHandlers { get; private set; }
+
+    /// <summary>
     /// Gets connection string for the specified <see cref="ConnectionInfo"/>.
     /// </summary>
     /// <param name="connectionInfo"><see cref="ConnectionInfo"/> to convert.</param>
@@ -297,6 +302,8 @@ namespace Xtensive.Sql
     {
       var result = DoCreateConnection();
       result.ConnectionInfo = originConnectionInfo;
+      if (ConnectionHandlers.Count != 0)
+        result.Extensions.Set(new ConnectionHandlersExtension(ConnectionHandlers));
       return result;
     }
 
@@ -309,6 +316,8 @@ namespace Xtensive.Sql
     {
       var result = DoCreateConnection();
       result.ConnectionInfo = connectionInfo;
+      if (ConnectionHandlers.Count != 0)
+        result.Extensions.Set(new ConnectionHandlersExtension(ConnectionHandlers));
       return result;
     }
 
@@ -373,10 +382,14 @@ namespace Xtensive.Sql
 
     #region Private / internal methods
 
-    internal void Initialize(SqlDriverFactory creator, ConnectionInfo creatorConnectionInfo)
+    internal void Initialize(SqlDriverFactory creator, ConnectionInfo creatorConnectionInfo) =>
+      Initialize(creator, creatorConnectionInfo, Array.Empty<IConnectionHandler>());
+
+    internal void Initialize(SqlDriverFactory creator, ConnectionInfo creatorConnectionInfo, IReadOnlyCollection<IConnectionHandler> connectionHandlers)
     {
       origin = creator;
       originConnectionInfo = creatorConnectionInfo;
+      ConnectionHandlers = connectionHandlers;
 
       var serverInfoProvider = CreateServerInfoProvider();
       ServerInfo = ServerInfo.Build(serverInfoProvider);

--- a/Orm/Xtensive.Orm/Sql/SqlDriverConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriverConfiguration.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.12.27
 
@@ -43,7 +43,7 @@ namespace Xtensive.Sql
     public SqlDriverConfiguration Clone()
     {
       // no deep cloning
-      var interceptors = (ConnectionHandlers.Count == 0)
+      var handlers = (ConnectionHandlers.Count == 0)
         ? Array.Empty<IConnectionHandler>()
         : ConnectionHandlers.ToArray(ConnectionHandlers.Count);
 
@@ -51,7 +51,7 @@ namespace Xtensive.Sql
         ForcedServerVersion = ForcedServerVersion,
         ConnectionInitializationSql = ConnectionInitializationSql,
         EnsureConnectionIsAlive = EnsureConnectionIsAlive,
-        ConnectionHandlers = interceptors
+        ConnectionHandlers = handlers
       };
     }
 
@@ -63,9 +63,9 @@ namespace Xtensive.Sql
       ConnectionHandlers = Array.Empty<IConnectionHandler>();
     }
 
-    public SqlDriverConfiguration(IReadOnlyCollection<IConnectionHandler> connectionInterceptors)
+    public SqlDriverConfiguration(IReadOnlyCollection<IConnectionHandler> connectionHandlers)
     {
-      ConnectionHandlers = connectionInterceptors;
+      ConnectionHandlers = connectionHandlers;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/SqlDriverConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriverConfiguration.cs
@@ -1,8 +1,13 @@
-﻿// Copyright (C) 2003-2012 Xtensive LLC.
+// Copyright (C) 2003-2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
 // Created:    2012.12.27
+
+using System;
+using System.Collections.Generic;
+using Xtensive.Core;
+using Xtensive.Orm;
 
 namespace Xtensive.Sql
 {
@@ -27,15 +32,26 @@ namespace Xtensive.Sql
     public bool EnsureConnectionIsAlive { get; set; }
 
     /// <summary>
+    /// Gets connection handlers that should be notified about connection events.
+    /// </summary>
+    public IReadOnlyCollection<IConnectionHandler> ConnectionHandlers { get; private set; }
+
+    /// <summary>
     /// Clones this instance.
     /// </summary>
     /// <returns>Clone of this instance.</returns>
     public SqlDriverConfiguration Clone()
     {
+      // no deep cloning
+      var interceptors = (ConnectionHandlers.Count == 0)
+        ? Array.Empty<IConnectionHandler>()
+        : ConnectionHandlers.ToArray(ConnectionHandlers.Count);
+
       return new SqlDriverConfiguration {
         ForcedServerVersion = ForcedServerVersion,
         ConnectionInitializationSql = ConnectionInitializationSql,
-        EnsureConnectionIsAlive = EnsureConnectionIsAlive
+        EnsureConnectionIsAlive = EnsureConnectionIsAlive,
+        ConnectionHandlers = interceptors
       };
     }
 
@@ -44,6 +60,12 @@ namespace Xtensive.Sql
     /// </summary>
     public SqlDriverConfiguration()
     {
+      ConnectionHandlers = Array.Empty<IConnectionHandler>();
+    }
+
+    public SqlDriverConfiguration(IReadOnlyCollection<IConnectionHandler> connectionInterceptors)
+    {
+      ConnectionHandlers = connectionInterceptors;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/SqlHelper.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlHelper.cs
@@ -490,5 +490,67 @@ namespace Xtensive.Sql
     {
       return NotSupported(feature.ToString());
     }
+
+    /// <summary>
+    /// Notifies all the <paramref name="connectionHandlers"/> that
+    /// <paramref name="connection"/> is about to be opened.
+    /// </summary>
+    /// <param name="connectionHandlers">The handlers that should be notified.</param>
+    /// <param name="connection">The connection that is opening.</param>
+    /// <param name="reconnect"><see langword="true"/> if event happened on attemp to restore connection, otherwise <see langword="false"/>.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void NotifyConnectionOpening(
+      IEnumerable<IConnectionHandler> connectionHandlers, DbConnection connection, bool reconnect = false)
+    {
+      foreach (var handler in connectionHandlers)
+        handler.ConnectionOpening(new ConnectionEventData(connection, reconnect));
+    }
+
+    /// <summary>
+    /// Notifies all the <paramref name="connectionHandlers"/> that
+    /// opened connection is about to be initialized with <paramref name="initializationScript"/>.
+    /// </summary>
+    /// <param name="connectionHandlers">The handlers that should be notified.</param>
+    /// <param name="connection">Opened but not initialized connection</param>
+    /// <param name="initializationScript">The script that will run to initialize connection</param>
+    /// <param name="reconnect"><see langword="true"/> if event happened on attemp to restore connection, otherwise <see langword="false"/>.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void NotifyConnectionInitializing(
+      IEnumerable<IConnectionHandler> connectionHandlers, DbConnection connection, string initializationScript, bool reconnect = false)
+    {
+      foreach (var handler in connectionHandlers)
+        handler.ConnectionInitialization(new ConnectionInitEventData(initializationScript, connection, reconnect));
+    }
+
+    /// <summary>
+    /// Notifies all the <paramref name="connectionHandlers"/> about
+    /// successful connection opening.
+    /// </summary>
+    /// <param name="connectionHandlers">The handlers that should be notified.</param>
+    /// <param name="connection">The connection that is completely opened and initialized.</param>
+    /// <param name="reconnect"><see langword="true"/> if event happened on attemp to restore connection, otherwise <see langword="false"/>.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void NotifyConnectionOpened(
+      IEnumerable<IConnectionHandler> connectionHandlers, DbConnection connection, bool reconnect = false)
+    {
+      foreach (var handler in connectionHandlers)
+        handler.ConnectionOpened(new ConnectionEventData(connection, reconnect));
+    }
+
+    /// <summary>
+    /// Notifies all the <paramref name="connectionHandlers"/> about
+    /// connection opening failure.
+    /// </summary>
+    /// <param name="connectionHandlers">The handlers that should be notified.</param>
+    /// <param name="connection">Connection that failed to be opened or properly initialized.</param>
+    /// <param name="exception">The exception which appeared.</param>
+    /// <param name="reconnect"><see langword="true"/> if event happened on attemp to restore connection, otherwise <see langword="false"/>.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void NotifyConnectionOpeningFailed(
+      IEnumerable<IConnectionHandler> connectionHandlers, DbConnection connection, Exception exception, bool reconnect = false)
+    {
+      foreach (var handler in connectionHandlers)
+        handler.ConnectionOpeningFailed(new ConnectionErrorEventData(exception, connection, reconnect));
+    }
   }
 }

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -1525,6 +1525,15 @@ namespace Xtensive {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Connection handler &apos;{0}&apos; has no parameterless constructor..
+        /// </summary>
+        internal static string ExConnectionHandlerXHasNoParameterlessConstructor {
+            get {
+                return ResourceManager.GetString("ExConnectionHandlerXHasNoParameterlessConstructor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ConnectionInfo is missing. If you are using configuration file you should specify either &apos;connectionUrl&apos; element or &apos;connectionString&apos; and &apos;provider&apos; elements.
         /// </summary>
         internal static string ExConnectionInfoIsMissing {

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -3470,4 +3470,7 @@ Error: {1}</value>
   <data name="ExCantModifyActiveOrDisposedScope" xml:space="preserve">
     <value>Can't modify Active or Disposed scope.</value>
   </data>
+  <data name="ExConnectionHandlerXHasNoParameterlessConstructor" xml:space="preserve">
+    <value>Connection handler '{0}' has no parameterless constructor.</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR adds an ability to execute certain code on connection opening. It adds ```IConnectionHandler``` and its default abstract implementation with following access points
- ```ConnectionOpening```/```ConnectionOpeningAsync``` - when ```DbConnection``` is created but not opened;
- ```ConnectionInitialization```/```ConnectionInitializationAsync``` - when ```DbConnection``` is already opened but connection initialization script is not executed, raises when initialization script exists;
- ```ConnectionOpened```/```ConnectionOpenedAsync``` - when ```DbConnection``` is successfully opened and initialized
- ```ConnectionOpeningFailed```/```ConnectionOpeningFailedAsync``` - when ```DbConnection``` opening or initialization went wrong.

This API allows to fill in connection's ```AccessToken``` like it was required by Denis in #143