### PR TITLE
Compatibility with Microsoft.Data.SqlClient 4.x (#52); Update BitFaster.Caching to 1.0.4

### DIFF
--- a/Extensions/TestCommon/TestCommon.csproj
+++ b/Extensions/TestCommon/TestCommon.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Reprocessing/Xtensive.Orm.Reprocessing.csproj
+++ b/Extensions/Xtensive.Orm.Reprocessing/Xtensive.Orm.Reprocessing.csproj
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>$(ExtensionsKeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Readme.txt" />

--- a/Extensions/Xtensive.Orm.Security/Xtensive.Orm.Security.csproj
+++ b/Extensions/Xtensive.Orm.Security/Xtensive.Orm.Security.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)MSBuild\DataObjects.Net.InternalBuild.targets" />
   <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm\Xtensive.Orm.csproj" />

--- a/Extensions/Xtensive.Orm.Tracking/Xtensive.Orm.Tracking.csproj
+++ b/Extensions/Xtensive.Orm.Tracking/Xtensive.Orm.Tracking.csproj
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>$(ExtensionsKeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm\Xtensive.Orm.csproj" />

--- a/Extensions/Xtensive.Orm.Web/Xtensive.Orm.Web.csproj
+++ b/Extensions/Xtensive.Orm.Web/Xtensive.Orm.Web.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm\Xtensive.Orm.csproj" />

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/DriverFactory.cs
@@ -109,6 +109,7 @@ namespace Xtensive.Sql.Drivers.SqlServer
       SqlHelper.ValidateConnectionUrl(url);
 
       var builder = new SqlConnectionStringBuilder();
+      builder.Encrypt = url.Secure;
 
       // host, port, database
       if (url.Port==0) {

--- a/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
+++ b/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="System.CodeDom" Version="4.4.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Spatial" Version="5.8.3" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0.0" />

--- a/Orm/Xtensive.Orm/Caching/FastConcurrentLruCache{TKey, TItem}.cs
+++ b/Orm/Xtensive.Orm/Caching/FastConcurrentLruCache{TKey, TItem}.cs
@@ -53,9 +53,7 @@ namespace Xtensive.Caching
     public override void RemoveKey(TKey key, bool removeCompletely) => realCache.TryRemove(key);
 
     /// <inheritdoc/>
-    public override void Clear() =>
-      //TODO: Change to imp.Clear() after updating BitFaster.Caching package to 1.0.4
-      realCache = new FastConcurrentLru<TKey, TItem>((int) MaxSize);
+    public override void Clear() => realCache.Clear();
 
     /// <inheritdoc/>
     /// <exception cref="NotImplementedException"/>

--- a/Orm/Xtensive.Orm/Orm/UrlInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/UrlInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2020 Xtensive LLC.
+// Copyright (C) 2007-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
@@ -77,7 +77,7 @@ namespace Xtensive.Orm
     ISerializable
   {
     private static readonly Regex Pattern = new Regex(
-          @"^(?'proto'[^:]*)://" +
+          @"^(?'proto'[^:]*[^sS])(?'secure'[sS]?)://" +
           @"((?'username'[^:@]*)" +
           @"(:(?'password'[^@]*))?@)?" +
           @"(?'host'[^:/]*)" +
@@ -88,6 +88,7 @@ namespace Xtensive.Orm
 
     private string url = string.Empty;
     private string protocol = string.Empty;
+    private bool secure = false;
     private string host = string.Empty;
     private int    port;
     private string resource = string.Empty;
@@ -114,6 +115,16 @@ namespace Xtensive.Orm
     {
       [DebuggerStepThrough]
       get { return protocol; }
+    }
+
+    /// <summary>
+    /// Gets the security part of the current <see cref="Url"/>
+    /// Scheme with 's' suffix is secure.
+    /// </summary>
+    public bool Secure
+    {
+      [DebuggerStepThrough]
+      get => secure;
     }
 
     /// <summary>
@@ -237,6 +248,7 @@ namespace Xtensive.Orm
         info.resource = UrlDecode(result.Result("${resource}"));
         info.host = UrlDecode(result.Result("${host}"));
         info.protocol = UrlDecode(result.Result("${proto}"));
+        info.secure = !string.IsNullOrEmpty(result.Result("${secure}"));
         info.port = @port;
         info.parameters = new ReadOnlyDictionary<string, string>(@params);
       }

--- a/Orm/Xtensive.Orm/Xtensive.Orm.csproj
+++ b/Orm/Xtensive.Orm/Xtensive.Orm.csproj
@@ -40,8 +40,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup Label="Packages">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
-    <PackageReference Include="BitFaster.Caching" Version="1.0.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="BitFaster.Caching" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup Label="T4GeneratorsUpdaters">
     <None Update="Arithmetic\Internal\PrimitiveArithmetics.tt">


### PR DESCRIPTION
for compatibility with `Microsoft.Data.SqlClient 4.x`:
* Upgrade System.Configuration.ConfigurationManager to 5.0.0
* Added `UrlInfo.Secure` property parsed from 's' suffix of URL scheme, e.g. `sqlservers://dbServer`
* Set `.Encrypt = urlInfo.Secure` explicitly  because by default it is true in 4.x.

* Update `BitFaster.Chaching` package to use new `cache.Clear()` method
