### PR TITLE
Improves filtering by enum

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
@@ -1,0 +1,313 @@
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Xtensive.Core;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Tests.Linq.WhereByEnumTestModel;
+
+namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
+{
+  public enum ByteEnum : byte
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Max = byte.MaxValue
+  }
+
+  public enum SByteEnum : sbyte
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Max = sbyte.MaxValue
+  }
+
+  public enum ShortEnum : short
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Max = short.MaxValue
+  }
+
+  public enum UShortEnum : ushort
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Max = ushort.MaxValue
+  }
+
+  public enum IntEnum : int
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Max = int.MaxValue
+  }
+
+  public enum UIntEnum : uint
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Max = uint.MaxValue
+  }
+
+  public enum LongEnum : long
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Max = long.MaxValue
+  }
+
+  public enum ULongEnum : ulong
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Max = ulong.MaxValue
+  }
+
+  [HierarchyRoot]
+  [Index(nameof(EnumContainer.ByteEnumField))]
+  [Index(nameof(EnumContainer.SByteEnumField))]
+  [Index(nameof(EnumContainer.ShortEnumField))]
+  [Index(nameof(EnumContainer.UShortEnumField))]
+  [Index(nameof(EnumContainer.IntEnumField))]
+  [Index(nameof(EnumContainer.UIntEnumField))]
+  [Index(nameof(EnumContainer.LongEnumField))]
+  [Index(nameof(EnumContainer.ULongEnumField))]
+  public class EnumContainer : Entity
+  {
+    public const string Zero = "Zero";
+    public const string One = "One";
+    public const string Two = "Two";
+    public const string Three = "Three";
+    public const string Four = "Four";
+    public const string Max = "Max";
+
+    [Field, Key]
+    public int Id { get; private set; }
+
+    [Field]
+    public ByteEnum ByteEnumField { get; set; }
+
+    [Field]
+    public SByteEnum SByteEnumField { get; set; }
+
+    [Field]
+    public ShortEnum ShortEnumField { get; set; }
+
+    [Field]
+    public UShortEnum UShortEnumField { get; set; }
+
+    [Field]
+    public IntEnum IntEnumField { get; set; }
+
+    [Field]
+    public UIntEnum UIntEnumField { get; set; }
+
+    [Field]
+    public LongEnum LongEnumField { get; set; }
+
+    [Field]
+    public ULongEnum ULongEnumField { get; set; }
+
+    public EnumContainer(Session session, string enumValue)
+      : base(session)
+    {
+      ByteEnumField = (ByteEnum) Enum.Parse(typeof(ByteEnum), enumValue);
+      SByteEnumField = (SByteEnum) Enum.Parse(typeof(SByteEnum), enumValue);
+      ShortEnumField = (ShortEnum) Enum.Parse(typeof(ShortEnum), enumValue);
+      UShortEnumField = (UShortEnum) Enum.Parse(typeof(UShortEnum), enumValue);
+      IntEnumField = (IntEnum) Enum.Parse(typeof(IntEnum), enumValue);
+      UIntEnumField = (UIntEnum) Enum.Parse(typeof(UIntEnum), enumValue);
+      LongEnumField = (LongEnum) Enum.Parse(typeof(LongEnum), enumValue);
+      ULongEnumField = (ULongEnum) Enum.Parse(typeof(ULongEnum), enumValue);
+    }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Linq
+{
+  public class WhereByEnumTest : AutoBuildTest
+  {
+    private Session SharedSession;
+
+    public override void TestFixtureSetUp()
+    {
+      base.TestFixtureSetUp();
+      CreateSessionAndTransaction();
+      SharedSession = Session.Current;
+    }
+
+    public override void TestFixtureTearDown()
+    {
+      SharedSession = null;
+      base.TestFixtureTearDown();
+    }
+
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var config = base.BuildConfiguration();
+      config.Types.Register(typeof(EnumContainer));
+      config.UpgradeMode = DomainUpgradeMode.Recreate;
+      return config;
+    }
+
+    protected override void PopulateData()
+    {
+      using (var session = Domain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        _ = new EnumContainer(session, EnumContainer.Zero);
+        _ = new EnumContainer(session, EnumContainer.One);
+        _ = new EnumContainer(session, EnumContainer.Two);
+        _ = new EnumContainer(session, EnumContainer.Three);
+        _ = new EnumContainer(session, EnumContainer.Four);
+        _ = new EnumContainer(session, EnumContainer.Max);
+        tx.Complete();
+      }
+    }
+
+    [Test]
+    public void ByteTest()
+    {
+      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Zero).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.One).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Two).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Three).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Four).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Max).ToArray(1);
+      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+    }
+
+    [Test]
+    public void SByteTest()
+    {
+      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Zero).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.One).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Two).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Three).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Four).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Max).ToArray(1);
+      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+    }
+
+    [Test]
+    public void ShortTest()
+    {
+      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Zero).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.One).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Two).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Three).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Four).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max).ToArray(1);
+      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+    }
+
+    [Test]
+    public void UShortTest()
+    {
+      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Zero).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.One).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Two).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Three).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Four).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max).ToArray(1);
+
+      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+    }
+
+    [Test]
+    public void IntTest()
+    {
+      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Zero).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.One).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Two).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Three).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Four).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Max).ToArray(1);
+
+      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+    }
+
+    [Test]
+    public void UIntTest()
+    {
+      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Zero).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.One).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Two).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Three).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Four).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Max).ToArray(1);
+
+      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+    }
+
+    [Test]
+    public void LongTest()
+    {
+      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Zero).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.One).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Two).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Three).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Four).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Max).ToArray(1);
+
+      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+    }
+
+    [Test]
+    public void ULontTest()
+    {
+      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Zero).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.One).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Two).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Three).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Four).ToArray(1);
+      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Max).ToArray(1);
+
+      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+    }
+
+    private static void PrintCommandToConsole(object sender, DbCommandEventArgs args) => Console.WriteLine(args.Command.CommandText);
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
@@ -166,7 +166,6 @@ namespace Xtensive.Orm.Tests.Linq
   public class WhereByEnumTest : AutoBuildTest
   {
     private Session sharedSession;
-
     private string castSign;
 
     public override void TestFixtureSetUp()
@@ -210,20 +209,30 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
       
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Zero);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField != ByteEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField > ByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField >= ByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField < ByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField <= ByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -231,20 +240,30 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Zero);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField != ByteEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField > ByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField >= ByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField < ByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField <= ByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -257,20 +276,30 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Zero);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField != SByteEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField > SByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField >= SByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField < SByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField <= SByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -278,20 +307,30 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Zero);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField != SByteEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField > SByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField >= SByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField < SByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField <= SByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -325,20 +364,30 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField == ShortEnum.Zero);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField != ShortEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField == ShortEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField > ShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField >= ShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField < ShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField <= ShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -351,20 +400,30 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Zero);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField != UShortEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField > UShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField >= UShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField < UShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField <= UShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -372,20 +431,30 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField == UShortEnum.Zero);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField != UShortEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField == UShortEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField > UShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField == UShortEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField >= UShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField < UShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField <= UShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -398,20 +467,30 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Zero);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField != IntEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField > IntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField >= IntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField < IntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField <= IntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -419,20 +498,30 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Zero);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField != IntEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField > IntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField >= IntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField < IntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField <= IntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -445,20 +534,30 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Zero);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField != UIntEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField > UIntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField >= UIntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField < UIntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField <= UIntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -466,20 +565,30 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Zero);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField != UIntEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField > UIntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField >= UIntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField < UIntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField <= UIntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -496,20 +605,30 @@ namespace Xtensive.Orm.Tests.Linq
         ? castSign.Length
         : 0;
 
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Zero);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField != LongEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField > LongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField >= LongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField < LongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField <= LongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -517,20 +636,30 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Zero);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField != LongEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField > LongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField >= LongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField < LongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField <= LongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -543,20 +672,30 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Zero);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField != ULongEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField > ULongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField >= ULongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField < ULongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField <= ULongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
@@ -564,20 +703,30 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Zero);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField != ULongEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.One);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField > ULongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Two);
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField >= ULongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
+      Assert.That(query.Count(), Is.EqualTo(3));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField < ULongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(2));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField <= ULongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(3));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);

--- a/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
@@ -19,8 +19,6 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
     Zero = 0,
     One = 1,
     Two = 2,
-    Three = 3,
-    Four = 4,
     Max = byte.MaxValue
   }
 
@@ -29,8 +27,6 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
     Zero = 0,
     One = 1,
     Two = 2,
-    Three = 3,
-    Four = 4,
     Max = sbyte.MaxValue
   }
 
@@ -39,8 +35,6 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
     Zero = 0,
     One = 1,
     Two = 2,
-    Three = 3,
-    Four = 4,
     Max = short.MaxValue
   }
 
@@ -49,8 +43,6 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
     Zero = 0,
     One = 1,
     Two = 2,
-    Three = 3,
-    Four = 4,
     Max = ushort.MaxValue
   }
 
@@ -59,8 +51,6 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
     Zero = 0,
     One = 1,
     Two = 2,
-    Three = 3,
-    Four = 4,
     Max = int.MaxValue
   }
 
@@ -69,8 +59,6 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
     Zero = 0,
     One = 1,
     Two = 2,
-    Three = 3,
-    Four = 4,
     Max = uint.MaxValue
   }
 
@@ -79,8 +67,6 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
     Zero = 0,
     One = 1,
     Two = 2,
-    Three = 3,
-    Four = 4,
     Max = long.MaxValue
   }
 
@@ -89,27 +75,15 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
     Zero = 0,
     One = 1,
     Two = 2,
-    Three = 3,
-    Four = 4,
     Max = ulong.MaxValue
   }
 
   [HierarchyRoot]
-  [Index(nameof(EnumContainer.ByteEnumField))]
-  [Index(nameof(EnumContainer.SByteEnumField))]
-  [Index(nameof(EnumContainer.ShortEnumField))]
-  [Index(nameof(EnumContainer.UShortEnumField))]
-  [Index(nameof(EnumContainer.IntEnumField))]
-  [Index(nameof(EnumContainer.UIntEnumField))]
-  [Index(nameof(EnumContainer.LongEnumField))]
-  [Index(nameof(EnumContainer.ULongEnumField))]
   public class EnumContainer : Entity
   {
     public const string Zero = "Zero";
     public const string One = "One";
     public const string Two = "Two";
-    public const string Three = "Three";
-    public const string Four = "Four";
     public const string Max = "Max";
 
     [Field, Key]
@@ -226,8 +200,6 @@ namespace Xtensive.Orm.Tests.Linq
         _ = new EnumContainer(session, EnumContainer.Zero);
         _ = new EnumContainer(session, EnumContainer.One);
         _ = new EnumContainer(session, EnumContainer.Two);
-        _ = new EnumContainer(session, EnumContainer.Three);
-        _ = new EnumContainer(session, EnumContainer.Four);
         _ = new EnumContainer(session, EnumContainer.Max);
         tx.Complete();
       }
@@ -253,16 +225,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Four);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
@@ -280,16 +242,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Two);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Four);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -320,16 +272,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Four);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
@@ -347,16 +289,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Two);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Four);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -387,16 +319,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Four);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
@@ -414,16 +336,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Two);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Four);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -454,16 +366,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Four);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
@@ -481,16 +383,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField == UShortEnum.Two);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField == UShortEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Four);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -521,16 +413,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Four);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
@@ -548,16 +430,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Two);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Four);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -588,16 +460,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Four);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
@@ -615,16 +477,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Two);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Four);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -659,16 +511,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Four);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
@@ -686,16 +528,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Two);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Four);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -726,16 +558,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Four);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
@@ -753,16 +575,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(query.Count(), Is.EqualTo(1));
 
       query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Two);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Three);
-      queryString = queryFormatter.ToSqlString(query);
-      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
-      Assert.That(query.Count(), Is.EqualTo(1));
-
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Four);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));

--- a/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
@@ -9,6 +9,7 @@ using System.Text;
 using NUnit.Framework;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Services;
 using Xtensive.Orm.Tests.Linq.WhereByEnumTestModel;
 
 namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
@@ -138,6 +139,30 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
     [Field]
     public ULongEnum ULongEnumField { get; set; }
 
+    [Field]
+    public ByteEnum? NByteEnumField { get; set; }
+
+    [Field]
+    public SByteEnum? NSByteEnumField { get; set; }
+
+    [Field]
+    public ShortEnum? NShortEnumField { get; set; }
+
+    [Field]
+    public UShortEnum? NUShortEnumField { get; set; }
+
+    [Field]
+    public IntEnum? NIntEnumField { get; set; }
+
+    [Field]
+    public UIntEnum? NUIntEnumField { get; set; }
+
+    [Field]
+    public LongEnum? NLongEnumField { get; set; }
+
+    [Field]
+    public ULongEnum? NULongEnumField { get; set; }
+
     public EnumContainer(Session session, string enumValue)
       : base(session)
     {
@@ -149,6 +174,15 @@ namespace Xtensive.Orm.Tests.Linq.WhereByEnumTestModel
       UIntEnumField = (UIntEnum) Enum.Parse(typeof(UIntEnum), enumValue);
       LongEnumField = (LongEnum) Enum.Parse(typeof(LongEnum), enumValue);
       ULongEnumField = (ULongEnum) Enum.Parse(typeof(ULongEnum), enumValue);
+
+      NByteEnumField = (ByteEnum) Enum.Parse(typeof(ByteEnum), enumValue);
+      NSByteEnumField = (SByteEnum) Enum.Parse(typeof(SByteEnum), enumValue);
+      NShortEnumField = (ShortEnum) Enum.Parse(typeof(ShortEnum), enumValue);
+      NUShortEnumField = (UShortEnum) Enum.Parse(typeof(UShortEnum), enumValue);
+      NIntEnumField = (IntEnum) Enum.Parse(typeof(IntEnum), enumValue);
+      NUIntEnumField = (UIntEnum) Enum.Parse(typeof(UIntEnum), enumValue);
+      NLongEnumField = (LongEnum) Enum.Parse(typeof(LongEnum), enumValue);
+      NULongEnumField = (ULongEnum) Enum.Parse(typeof(ULongEnum), enumValue);
     }
   }
 }
@@ -157,18 +191,23 @@ namespace Xtensive.Orm.Tests.Linq
 {
   public class WhereByEnumTest : AutoBuildTest
   {
-    private Session SharedSession;
+    private Session sharedSession;
+
+    private string castSign;
 
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
       CreateSessionAndTransaction();
-      SharedSession = Session.Current;
+      sharedSession = Session.Current;
+      castSign = StorageProviderInfo.Instance.CheckProviderIs(StorageProvider.PostgreSql)
+        ? "::"
+        : "CAST";
     }
 
     public override void TestFixtureTearDown()
     {
-      SharedSession = null;
+      sharedSession = null;
       base.TestFixtureTearDown();
     }
 
@@ -197,117 +236,541 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void ByteTest()
     {
-      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Zero).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.One).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Two).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Three).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Four).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Max).ToArray(1);
-      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
+      
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Zero);
+      var queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Zero);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
     }
 
     [Test]
     public void SByteTest()
     {
-      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Zero).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.One).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Two).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Three).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Four).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Max).ToArray(1);
-      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
+
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Zero);
+      var queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Zero);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
     }
 
     [Test]
     public void ShortTest()
     {
-      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Zero).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.One).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Two).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Three).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Four).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max).ToArray(1);
-      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
+
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Zero);
+      var queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField == ShortEnum.Zero);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField == ShortEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
     }
 
     [Test]
     public void UShortTest()
     {
-      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Zero).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.One).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Two).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Three).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Four).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max).ToArray(1);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Zero);
+      var queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
 
-      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField == UShortEnum.Zero);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField == UShortEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField == UShortEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField == UShortEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
     }
 
     [Test]
     public void IntTest()
     {
-      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Zero).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.One).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Two).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Three).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Four).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Max).ToArray(1);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Zero);
+      var queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
 
-      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Zero);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
     }
 
     [Test]
     public void UIntTest()
     {
-      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Zero).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.One).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Two).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Three).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Four).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Max).ToArray(1);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Zero);
+      var queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
 
-      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Zero);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
     }
 
     [Test]
     public void LongTest()
     {
-      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Zero).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.One).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Two).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Three).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Four).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Max).ToArray(1);
+      var substractValue = StorageProviderInfo.Instance.CheckProviderIs(StorageProvider.SqlServer)
+        ? castSign.Length
+        : 0;
 
-      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Zero);
+      var queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Zero);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
+      Assert.That(query.Count(), Is.EqualTo(1));
     }
 
     [Test]
-    public void ULontTest()
+    public void ULongTest()
     {
-      SharedSession.Events.DbCommandExecuting += PrintCommandToConsole;
+      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
 
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Zero).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.One).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Two).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Three).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Four).ToArray(1);
-      _ = SharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Max).ToArray(1);
+      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Zero);
+      var queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
 
-      SharedSession.Events.DbCommandExecuting -= PrintCommandToConsole;
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Zero);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.One);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Two);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Three);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Four);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
+
+      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Max);
+      queryString = queryFormatter.ToSqlString(query);
+      Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
+      Assert.That(query.Count(), Is.EqualTo(1));
     }
-
-    private static void PrintCommandToConsole(object sender, DbCommandEventArgs args) => Console.WriteLine(args.Command.CommandText);
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/PartialIndexTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/PartialIndexTest.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2011 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2011-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2011.10.06
 
@@ -49,73 +49,61 @@ namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
     string TestField { get; set; }
   }
 
-  [HierarchyRoot, Index("TestField", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(TestField), Filter = nameof(Index))]
   public class SimpleFilterWithMethod : TestBase
   {
-    public static Expression<Func<SimpleFilterWithMethod, bool>> Index()
-    {
-      return test => test.TestField.GreaterThan("hello world");
-    }
+    public static Expression<Func<SimpleFilterWithMethod, bool>> Index() =>
+      test => test.TestField.GreaterThan("hello world");
 
     [Field]
     public string TestField { get; set; }
   }
 
-  [HierarchyRoot, Index("TestField", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(TestField), Filter = nameof(Index))]
   public class SimpleFilterWithProperty : TestBase
   {
-    public static Expression<Func<SimpleFilterWithProperty, bool>> Index
-    {
-      get { return test => test.TestField.GreaterThan("hello world"); }
-    }
+    public static Expression<Func<SimpleFilterWithProperty, bool>> Index =>
+      test => test.TestField.GreaterThan("hello world");
 
     [Field]
     public string TestField { get; set; }
   }
 
-  [HierarchyRoot, Index("Target", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
   public class FilterOnReferenceField : TestBase
   {
-    public static Expression<Func<FilterOnReferenceField, bool>> Index()
-    {
-      return test => test.Target!=null;
-    }
+    public static Expression<Func<FilterOnReferenceField, bool>> Index() =>
+      test => test.Target != null;
 
     [Field]
     public TargetEntity Target { get; set; } 
   }
 
-  [HierarchyRoot, Index("Target", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
   public class FilterOnComplexReferenceField : TestBase
   {
-    public static Expression<Func<FilterOnComplexReferenceField, bool>> Index()
-    {
-      return test => test.Target!=null;
-    }
+    public static Expression<Func<FilterOnComplexReferenceField, bool>> Index() =>
+      test => test.Target != null;
 
     [Field]
     public ComplexTargetEntity Target { get; set; }
   }
 
-  [HierarchyRoot, Index("Target", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
   public class FilterOnReferenceIdField : TestBase
   {
-    public static Expression<Func<FilterOnReferenceIdField, bool>> Index()
-    {
-      return test => test.Target.Id > 0;
-    }
+    public static Expression<Func<FilterOnReferenceIdField, bool>> Index() =>
+      test => test.Target.Id > 0;
 
     [Field]
     public TargetEntity Target { get; set; }
   }
 
-  [HierarchyRoot, Index("TestField1", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(TestField1), Filter = nameof(Index))]
   public class FilterOnAlienField : TestBase
   {
-    public static Expression<Func<FilterOnAlienField, bool>> Index
-    {
-      get { return test => test.TestField2.GreaterThan("hello world"); }
-    }
+    public static Expression<Func<FilterOnAlienField, bool>> Index =>
+      test => test.TestField2.GreaterThan("hello world");
 
     [Field]
     public string TestField1 { get; set; }
@@ -124,103 +112,83 @@ namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
     public string TestField2 { get; set; }
   }
 
-  [HierarchyRoot, Index("TestField", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(TestField), Filter = nameof(Index))]
   public class MultipleFieldUses : TestBase
   {
-    public static Expression<Func<MultipleFieldUses, bool>> Index
-    {
-      get { return test => test.TestField.GreaterThan("hello") && test.TestField.LessThan("world"); }
-    }
+    public static Expression<Func<MultipleFieldUses, bool>> Index =>
+      test => test.TestField.GreaterThan("hello") && test.TestField.LessThan("world");
 
     [Field]
     public string TestField { get; set; }
   }
 
-  [HierarchyRoot, Index("TestField", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(TestField), Filter = nameof(Index))]
   public class InterfaceSupport : TestBase, ITestInterface
   {
-    public static Expression<Func<InterfaceSupport, bool>> Index
-    {
-      get { return test => test.TestField.LessThan("bye world"); }
-    }
+    public static Expression<Func<InterfaceSupport, bool>> Index =>
+      test => test.TestField.LessThan("bye world");
 
     [Field]
     public string TestField { get; set; }
   }
 
-  [HierarchyRoot, Index("TestField", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(TestField), Filter = nameof(Index))]
   public class InOperatorSupport : TestBase
   {
-    public static Expression<Func<InOperatorSupport, bool>> Index
-    {
-      get { return test => test.TestField.In("1", "2", "3"); }
-    }
+    public static Expression<Func<InOperatorSupport, bool>> Index =>
+      test => test.TestField.In("1", "2", "3");
 
     [Field]
     public string TestField { get; set; }
   }
 
-  [HierarchyRoot, Index("TestField", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(TestField), Filter = nameof(Index))]
   public class InOperatorSupport2 : TestBase
   {
-    public static Expression<Func<InOperatorSupport2, bool>> Index
-    {
-      get {
-        return test => test.TestField.In(
-          new Guid("{D27F71D7-D4FC-446C-8C7E-E89DC2209863}"),
-          new Guid("{94ED80D9-6749-41E2-B60D-BEDE1CDCA237}"));
-      }
-    }
+    public static Expression<Func<InOperatorSupport2, bool>> Index =>
+      test => test.TestField.In(
+        new Guid("{D27F71D7-D4FC-446C-8C7E-E89DC2209863}"),
+        new Guid("{94ED80D9-6749-41E2-B60D-BEDE1CDCA237}"));
 
     [Field]
     public Guid TestField { get; set; }
   }
 
-  [HierarchyRoot, Index("TestField", Filter = "Index")]
+  [HierarchyRoot, Index(nameof(TestField), Filter = nameof(Index))]
   public class ContainsOperatorSupport : TestBase
   {
-    public static Expression<Func<ContainsOperatorSupport, bool>> Index
-    {
-      get { return test => new[] {"1", "2", "3"}.Contains(test.TestField); }
-    }
+    public static Expression<Func<ContainsOperatorSupport, bool>> Index =>
+      test => new[] { "1", "2", "3" }.Contains(test.TestField);
 
     [Field]
     public string TestField { get; set; }
   }
 
   [HierarchyRoot,
-    Index("TestField", Filter = "More", Name = "MoreIndex"),
-    Index("TestField", Filter = "Less", Name = "LessIndex")]
+    Index(nameof(TestField), Filter = nameof(More), Name = "MoreIndex"),
+    Index(nameof(TestField), Filter = nameof(Less), Name = "LessIndex")]
   public class DoubleIndexWithName : TestBase
   {
-    public static Expression<Func<DoubleIndexWithName, bool>> More()
-    {
-      return test => test.TestField > 1000;
-    }
+    public static Expression<Func<DoubleIndexWithName, bool>> More() =>
+      test => test.TestField > 1000;
 
-    public static Expression<Func<DoubleIndexWithName, bool>> Less()
-    {
-      return test => test.TestField < 100;
-    }
+    public static Expression<Func<DoubleIndexWithName, bool>> Less() =>
+      test => test.TestField < 100;
 
     [Field]
     public int TestField { get; set; }
   }
 
   [HierarchyRoot,
-    Index("TestField", Filter = "More"),
-    Index("TestField", Filter = "Less")]
+    Index(nameof(TestField), Filter = nameof(More)),
+    Index(nameof(TestField), Filter = nameof(Less))]
   public class DoubleIndexWithoutName : TestBase
   {
-    public static Expression<Func<DoubleIndexWithoutName, bool>> More()
-    {
-      return test => test.TestField > 1000;
-    }
+    public static Expression<Func<DoubleIndexWithoutName, bool>> More() =>
+      test => test.TestField > 1000;
 
-    public static Expression<Func<DoubleIndexWithoutName, bool>> Less()
-    {
-      return test => test.TestField < 100;
-    }
+    public static Expression<Func<DoubleIndexWithoutName, bool>> Less() =>
+      test => test.TestField < 100;
 
     [Field]
     public int TestField { get; set; }
@@ -233,13 +201,11 @@ namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
     public int BaseField { get; set; }
   }
 
-  [Index("TestField", Filter = "Index")]
+  [Index(nameof(TestField), Filter = nameof(Index))]
   public class InheritanceClassTable : InheritanceClassTableBase
   {
-    public static Expression<Func<InheritanceClassTable, bool>> Index()
-    {
-      return test => test.BaseField > 0;
-    }
+    public static Expression<Func<InheritanceClassTable, bool>> Index() =>
+      test => test.BaseField > 0;
 
     [Field]
     public int TestField { get; set; }
@@ -252,13 +218,11 @@ namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
     public int BaseField { get; set; }
   }
 
-  [Index("TestField", Filter = "Index")]
+  [Index(nameof(TestField), Filter = nameof(Index))]
   public class InheritanceSingleTable : InheritanceSingleTableBase
   {
-    public static Expression<Func<InheritanceSingleTable, bool>> Index()
-    {
-      return test => test.BaseField > 0;
-    }
+    public static Expression<Func<InheritanceSingleTable, bool>> Index() =>
+      test => test.BaseField > 0;
 
     [Field]
     public int TestField { get; set; }
@@ -271,16 +235,229 @@ namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
     public int BaseField { get; set; }
   }
 
-  [Index("TestField", Filter = "Index")]
+  [Index(nameof(TestField), Filter = nameof(Index))]
   public class InheritanceConcreteTable : InheritanceConcreteTableBase
   {
-    public static Expression<Func<InheritanceConcreteTable, bool>> Index()
-    {
-      return test => test.BaseField > 0;
-    }
+    public static Expression<Func<InheritanceConcreteTable, bool>> Index() =>
+      test => test.BaseField > 0;
 
     [Field]
     public int TestField { get; set; }
+  }
+
+  #region Enums
+  public enum ByteEnum : byte
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Max = byte.MaxValue
+  }
+
+  public enum SByteEnum : sbyte
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Max = sbyte.MaxValue
+  }
+
+  public enum ShortEnum : short
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Max = short.MaxValue
+  }
+
+  public enum UShortEnum : ushort
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Max = ushort.MaxValue
+  }
+
+  public enum IntEnum : int
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Max = int.MaxValue
+  }
+
+  public enum UIntEnum : uint
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Max = uint.MaxValue
+  }
+
+  public enum LongEnum : long
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Max = long.MaxValue
+  }
+
+  public enum ULongEnum : ulong
+  {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Max = ulong.MaxValue
+  }
+  #endregion
+
+  [HierarchyRoot]
+  [Index(nameof(ByteEnumField), Filter = nameof(ByteIndex))]
+  [Index(nameof(NByteEnumField), Filter = nameof(NByteIndex))]
+  [Index(nameof(SByteEnumField), Filter = nameof(SByteIndex))]
+  [Index(nameof(NSByteEnumField), Filter = nameof(SNByteIndex))]
+  [Index(nameof(ShortEnumField), Filter = nameof(ShortIndex))]
+  [Index(nameof(NShortEnumField), Filter = nameof(NShortIndex))]
+  [Index(nameof(UShortEnumField), Filter = nameof(UShortIndex))]
+  [Index(nameof(NUShortEnumField), Filter = nameof(NUShortIndex))]
+  [Index(nameof(IntEnumField), Filter = nameof(IntIndex))]
+  [Index(nameof(NIntEnumField), Filter = nameof(NIntIndex))]
+  [Index(nameof(UIntEnumField), Filter = nameof(UIntIndex))]
+  [Index(nameof(NUIntEnumField), Filter = nameof(NUIntIndex))]
+  [Index(nameof(LongEnumField), Filter = nameof(LongIndex))]
+  [Index(nameof(NLongEnumField), Filter = nameof(NLongIndex))]
+  [Index(nameof(ULongEnumField), Filter = nameof(ULongIndex))]
+  [Index(nameof(NULongEnumField), Filter = nameof(NULongIndex))]
+  public class EnumFieldFilter : Entity
+  {
+    public const string Zero = "Zero";
+    public const string One = "One";
+    public const string Two = "Two";
+    public const string Max = "Max";
+
+    #region Filters
+    public static Expression<Func<EnumFieldFilter, bool>> ByteIndex() =>
+      test => test.ByteEnumField > ByteEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> NByteIndex() =>
+      test => test.NByteEnumField > ByteEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> SByteIndex() =>
+      test => test.ByteEnumField > ByteEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> SNByteIndex() =>
+      test => test.ByteEnumField > ByteEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> ShortIndex() =>
+      test => test.ShortEnumField > ShortEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> NShortIndex() =>
+      test => test.NShortEnumField > ShortEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> UShortIndex() =>
+      test => test.UShortEnumField > UShortEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> NUShortIndex() =>
+      test => test.NUShortEnumField > UShortEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> IntIndex() =>
+      test => test.IntEnumField > IntEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> NIntIndex() =>
+      test => test.NIntEnumField > IntEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> UIntIndex() =>
+      test => test.UIntEnumField > UIntEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> NUIntIndex() =>
+      test => test.NUIntEnumField > UIntEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> LongIndex() =>
+      test => test.LongEnumField > LongEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> NLongIndex() =>
+      test => test.NLongEnumField > LongEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> ULongIndex() =>
+      test => test.ULongEnumField > ULongEnum.Two;
+
+    public static Expression<Func<EnumFieldFilter, bool>> NULongIndex() =>
+      test => test.NULongEnumField > ULongEnum.Two;
+
+    #endregion
+
+    [Field, Key]
+    public int Id { get; private set; }
+
+    [Field]
+    public ByteEnum ByteEnumField { get; set; }
+
+    [Field]
+    public SByteEnum SByteEnumField { get; set; }
+
+    [Field]
+    public ShortEnum ShortEnumField { get; set; }
+
+    [Field]
+    public UShortEnum UShortEnumField { get; set; }
+
+    [Field]
+    public IntEnum IntEnumField { get; set; }
+
+    [Field]
+    public UIntEnum UIntEnumField { get; set; }
+
+    [Field]
+    public LongEnum LongEnumField { get; set; }
+
+    [Field]
+    public ULongEnum ULongEnumField { get; set; }
+
+    [Field]
+    public ByteEnum? NByteEnumField { get; set; }
+
+    [Field]
+    public SByteEnum? NSByteEnumField { get; set; }
+
+    [Field]
+    public ShortEnum? NShortEnumField { get; set; }
+
+    [Field]
+    public UShortEnum? NUShortEnumField { get; set; }
+
+    [Field]
+    public IntEnum? NIntEnumField { get; set; }
+
+    [Field]
+    public UIntEnum? NUIntEnumField { get; set; }
+
+    [Field]
+    public LongEnum? NLongEnumField { get; set; }
+
+    [Field]
+    public ULongEnum? NULongEnumField { get; set; }
+
+    public EnumFieldFilter(Session session, string enumValue)
+      : base(session)
+    {
+      ByteEnumField = (ByteEnum) Enum.Parse(typeof(ByteEnum), enumValue);
+      SByteEnumField = (SByteEnum) Enum.Parse(typeof(SByteEnum), enumValue);
+      ShortEnumField = (ShortEnum) Enum.Parse(typeof(ShortEnum), enumValue);
+      UShortEnumField = (UShortEnum) Enum.Parse(typeof(UShortEnum), enumValue);
+      IntEnumField = (IntEnum) Enum.Parse(typeof(IntEnum), enumValue);
+      UIntEnumField = (UIntEnum) Enum.Parse(typeof(UIntEnum), enumValue);
+      LongEnumField = (LongEnum) Enum.Parse(typeof(LongEnum), enumValue);
+      ULongEnumField = (ULongEnum) Enum.Parse(typeof(ULongEnum), enumValue);
+
+      NByteEnumField = (ByteEnum) Enum.Parse(typeof(ByteEnum), enumValue);
+      NSByteEnumField = (SByteEnum) Enum.Parse(typeof(SByteEnum), enumValue);
+      NShortEnumField = (ShortEnum) Enum.Parse(typeof(ShortEnum), enumValue);
+      NUShortEnumField = (UShortEnum) Enum.Parse(typeof(UShortEnum), enumValue);
+      NIntEnumField = (IntEnum) Enum.Parse(typeof(IntEnum), enumValue);
+      NUIntEnumField = (UIntEnum) Enum.Parse(typeof(UIntEnum), enumValue);
+      NLongEnumField = (LongEnum) Enum.Parse(typeof(LongEnum), enumValue);
+      NULongEnumField = (ULongEnum) Enum.Parse(typeof(ULongEnum), enumValue);
+    }
   }
 }
 
@@ -292,16 +469,11 @@ namespace Xtensive.Orm.Tests.Storage
     private Domain domain;
 
     [OneTimeSetUp]
-    public void TestFixtureSetUp()
-    {
+    public void TestFixtureSetUp() =>
       Require.AllFeaturesSupported(ProviderFeatures.PartialIndexes);
-    }
 
     [TearDown]
-    public void TearDown()
-    {
-      CleanDomain();
-    }
+    public void TearDown() => CleanDomain();
 
     private void CleanDomain()
     {
@@ -319,8 +491,10 @@ namespace Xtensive.Orm.Tests.Storage
     {
       CleanDomain();
       var config = DomainConfigurationFactory.Create();
-      foreach (var entity in entities)
+      foreach (var entity in entities) {
         config.Types.Register(entity);
+      }
+
       config.UpgradeMode = mode;
       domain = Domain.Build(config);
     }
@@ -329,7 +503,7 @@ namespace Xtensive.Orm.Tests.Storage
     {
       BuildDomain(entities, DomainUpgradeMode.Recreate);
       var partialIndexes = domain.Model.RealIndexes
-        .Where(index => index.IsPartial && index.FilterExpression!=null && index.Filter!=null)
+        .Where(index => index.IsPartial && index.FilterExpression != null && index.Filter != null)
         .ToList();
       Assert.IsNotEmpty(partialIndexes);
     }
@@ -340,107 +514,62 @@ namespace Xtensive.Orm.Tests.Storage
     }
 
     [Test]
-    public void SimpleFilterWithMethodTest()
-    {
-      AssertBuildSuccess(typeof (SimpleFilterWithMethod));
-    }
+    public void SimpleFilterWithMethodTest() => AssertBuildSuccess(typeof(SimpleFilterWithMethod));
 
     [Test]
-    public void SimpleFilterWithPropertyTest()
-    {
-      AssertBuildSuccess(typeof (SimpleFilterWithProperty));
-    }
+    public void SimpleFilterWithPropertyTest() => AssertBuildSuccess(typeof(SimpleFilterWithProperty));
 
     [Test]
-    public void FilterOnReferenceFieldTest()
-    {
-      AssertBuildSuccess(typeof (FilterOnReferenceField));
-    }
+    public void FilterOnReferenceFieldTest() => AssertBuildSuccess(typeof(FilterOnReferenceField));
 
     [Test]
-    public void FilterOnComplexReferenceFieldTest()
-    {
-      AssertBuildSuccess(typeof (FilterOnComplexReferenceField));
-    }
+    public void FilterOnComplexReferenceFieldTest() => AssertBuildSuccess(typeof(FilterOnComplexReferenceField));
 
     [Test]
-    public void FilterOnReferenceFieldIdTest()
-    {
-      AssertBuildSuccess(typeof (FilterOnReferenceIdField));
-    }
+    public void FilterOnReferenceFieldIdTest() => AssertBuildSuccess(typeof(FilterOnReferenceIdField));
 
     [Test]
-    public void FilterOnAlienFieldTest()
-    {
-      AssertBuildSuccess(typeof (FilterOnAlienField));
-    }
+    public void FilterOnAlienFieldTest() => AssertBuildSuccess(typeof(FilterOnAlienField));
 
     [Test]
-    public void MultipleFieldUsesTest()
-    {
-      AssertBuildSuccess(typeof(MultipleFieldUses));
-    }
+    public void MultipleFieldUsesTest() => AssertBuildSuccess(typeof(MultipleFieldUses));
 
     [Test]
-    public void InOperatorSupportTest()
-    {
-      AssertBuildSuccess(typeof (InOperatorSupport));
-    }
+    public void InOperatorSupportTest() => AssertBuildSuccess(typeof(InOperatorSupport));
 
     [Test]
-    public void InOperatorSupport2Test()
-    {
-      AssertBuildSuccess(typeof(InOperatorSupport2));
-    }
+    public void InOperatorSupport2Test() => AssertBuildSuccess(typeof(InOperatorSupport2));
 
     [Test]
-    public void ContainsOperatorSupportTest()
-    {
-      AssertBuildSuccess(typeof(ContainsOperatorSupport));
-    }
+    public void ContainsOperatorSupportTest() => AssertBuildSuccess(typeof(ContainsOperatorSupport));
 
     [Test]
-    public void DoubleIndexWithNameTest()
-    {
-      AssertBuildSuccess(typeof (DoubleIndexWithName));
-    }
-    
-    [Test]
-    public void DoubleIndexWithoutNameTest()
-    {
-      AssertBuildSuccess(typeof (DoubleIndexWithoutName));
-    }
+    public void DoubleIndexWithNameTest() => AssertBuildSuccess(typeof(DoubleIndexWithName));
 
     [Test]
-    public void InterfaceSupportTest()
-    {
-      AssertBuildSuccess(typeof(InterfaceSupport));
-    }
+    public void DoubleIndexWithoutNameTest() => AssertBuildSuccess(typeof(DoubleIndexWithoutName));
 
     [Test]
-    public void InheritanceClassTableTest()
-    {
-      AssertBuildFailure(typeof (InheritanceClassTable));
-    }
+    public void InterfaceSupportTest() => AssertBuildSuccess(typeof(InterfaceSupport));
 
     [Test]
-    public void InheritanceSingleTableTest()
-    {
-      AssertBuildSuccess(typeof(InheritanceSingleTable));
-    }
+    public void InheritanceClassTableTest() => AssertBuildFailure(typeof(InheritanceClassTable));
 
     [Test]
-    public void InheritanceConcreteTableTest()
-    {
-      AssertBuildSuccess(typeof(InheritanceConcreteTable));
-    }
+    public void InheritanceSingleTableTest() => AssertBuildSuccess(typeof(InheritanceSingleTable));
+
+    [Test]
+    public void InheritanceConcreteTableTest() => AssertBuildSuccess(typeof(InheritanceConcreteTable));
+
+    [Test]
+    public void EnumFieldFilterTest() => AssertBuildSuccess(typeof(EnumFieldFilter));
 
     [Test]
     public void ValidateTest()
     {
-      var types = typeof (TestBase).Assembly
+      var types = typeof(TestBase).Assembly
         .GetTypes()
-        .Where(type => type.Namespace==typeof (TestBase).Namespace && type!=typeof (InheritanceClassTable))
+        .Where(type => type.Namespace == typeof(TestBase).Namespace && type != typeof(InheritanceClassTable))
         .ToList();
       BuildDomain(types, DomainUpgradeMode.Recreate);
       BuildDomain(types, DomainUpgradeMode.Validate);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -47,29 +47,31 @@ namespace Xtensive.Orm.Building.Builders
     protected override Expression VisitBinary(BinaryExpression b)
     {
       if (EnumRewritableOperations(b)) {
-        var bareLeft = b.Left.StripCasts();
-        var bareLeftType = bareLeft.Type.StripNullable();
-        var bareRight = b.Right.StripCasts();
-        var bareRightType = bareRight.Type.StripNullable();
+        var leftNoCasts = b.Left.StripCasts();
+        var leftNoCastsType = leftNoCasts.Type;
+        var bareLeftType = leftNoCastsType.StripNullable();
+        var rightNoCasts = b.Right.StripCasts();
+        var rightNoCastsType = rightNoCasts.Type;
+        var bareRightType = rightNoCastsType.StripNullable();
 
-        if (bareLeftType.IsEnum && bareRight.NodeType == ExpressionType.Constant) {
-          var typeToCast = bareLeft.Type.IsNullable()
+        if (bareLeftType.IsEnum && rightNoCasts.NodeType == ExpressionType.Constant) {
+          var typeToCast = leftNoCastsType.IsNullable()
             ? bareLeftType.GetEnumUnderlyingType().ToNullable()
-            : bareLeft.Type.GetEnumUnderlyingType();
+            : leftNoCastsType.GetEnumUnderlyingType();
 
           return base.VisitBinary(Expression.MakeBinary(
             b.NodeType,
-            Expression.Convert(bareLeft, typeToCast),
+            Expression.Convert(leftNoCasts, typeToCast),
             Expression.Convert(b.Right, typeToCast)));
         }
-        else if (bareRightType.IsEnum && bareLeft.NodeType == ExpressionType.Constant) {
-          var typeToCast = bareRight.Type.IsNullable()
+        else if (bareRightType.IsEnum && leftNoCasts.NodeType == ExpressionType.Constant) {
+          var typeToCast = rightNoCastsType.IsNullable()
             ? bareRightType.GetEnumUnderlyingType().ToNullable()
-            : bareRight.Type.GetEnumUnderlyingType();
+            : rightNoCastsType.GetEnumUnderlyingType();
 
           return base.VisitBinary(Expression.MakeBinary(
             b.NodeType,
-            Expression.Convert(bareRight, typeToCast),
+            Expression.Convert(rightNoCasts, typeToCast),
             Expression.Convert(b.Left, typeToCast)));
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -47,29 +47,29 @@ namespace Xtensive.Orm.Building.Builders
     protected override Expression VisitBinary(BinaryExpression b)
     {
       if (EnumRewritableOperations(b)) {
-        var rawLeft = b.Left.StripCasts();
-        var rawLeftType = rawLeft.Type.StripNullable();
-        var rawRight = b.Right.StripCasts();
-        var rawRightType = rawRight.Type.StripNullable();
+        var bareLeft = b.Left.StripCasts();
+        var bareLeftType = bareLeft.Type.StripNullable();
+        var bareRight = b.Right.StripCasts();
+        var bareRightType = bareRight.Type.StripNullable();
 
-        if (rawLeftType.IsEnum && rawRight.NodeType == ExpressionType.Constant) {
-          var typeToCast = rawLeft.Type.IsNullable()
-            ? rawLeftType.GetEnumUnderlyingType().ToNullable()
-            : rawLeft.Type.GetEnumUnderlyingType();
+        if (bareLeftType.IsEnum && bareRight.NodeType == ExpressionType.Constant) {
+          var typeToCast = bareLeft.Type.IsNullable()
+            ? bareLeftType.GetEnumUnderlyingType().ToNullable()
+            : bareLeft.Type.GetEnumUnderlyingType();
 
           return base.VisitBinary(Expression.MakeBinary(
             b.NodeType,
-            Expression.Convert(rawLeft, typeToCast),
+            Expression.Convert(bareLeft, typeToCast),
             Expression.Convert(b.Right, typeToCast)));
         }
-        else if (rawRightType.IsEnum && rawLeft.NodeType == ExpressionType.Constant) {
-          var typeToCast = rawRight.Type.IsNullable()
-            ? rawRightType.GetEnumUnderlyingType().ToNullable()
-            : rawRight.Type.GetEnumUnderlyingType();
+        else if (bareRightType.IsEnum && bareLeft.NodeType == ExpressionType.Constant) {
+          var typeToCast = bareRight.Type.IsNullable()
+            ? bareRightType.GetEnumUnderlyingType().ToNullable()
+            : bareRight.Type.GetEnumUnderlyingType();
 
           return base.VisitBinary(Expression.MakeBinary(
             b.NodeType,
-            Expression.Convert(rawRight, typeToCast),
+            Expression.Convert(bareRight, typeToCast),
             Expression.Convert(b.Left, typeToCast)));
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -209,8 +209,7 @@ namespace Xtensive.Orm.Linq
       }
       // Following two checks for enums are here to improve result query
       // performance because they let not to cast columns to integer.
-      else if (binaryExpression.NodeType.In(ExpressionType.Equal, ExpressionType.NotEqual)
-          && binaryExpression.Left.StripCasts().Type.StripNullable().IsEnum
+      else if (binaryExpression.Left.StripCasts().Type.StripNullable().IsEnum
           && binaryExpression.Right.StripCasts().NodeType == ExpressionType.Constant) {
         var rawEnum = binaryExpression.Left.StripCasts();
 
@@ -220,8 +219,7 @@ namespace Xtensive.Orm.Linq
         left = Visit(Expression.Convert(rawEnum, typeToCast));
         right = Visit(Expression.Convert(binaryExpression.Right, typeToCast));
       }
-      else if (binaryExpression.NodeType.In(ExpressionType.Equal, ExpressionType.NotEqual)
-          && binaryExpression.Right.StripCasts().Type.StripNullable().IsEnum
+      else if (binaryExpression.Right.StripCasts().Type.StripNullable().IsEnum
           && binaryExpression.Left.StripCasts().NodeType == ExpressionType.Constant) {
         var rawEnum = binaryExpression.Right.StripCasts();
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -210,24 +210,25 @@ namespace Xtensive.Orm.Linq
       else if (EnumRewritableOperations(binaryExpression)) {
         // Following two checks for enums are here to improve result query
         // performance because they let not to cast columns to integer.
+        var leftNoCasts = binaryExpression.Left.StripCasts();
+        var leftNoCastsType = leftNoCasts.Type;
+        var bareLeftType = leftNoCastsType.StripNullable();
+        var rightNoCasts = binaryExpression.Right.StripCasts();
+        var rightNoCastsType = rightNoCasts.Type;
+        var bareRightType = rightNoCastsType.StripNullable();
 
-        var bareLeft = binaryExpression.Left.StripCasts();
-        var bareLeftType = bareLeft.Type.StripNullable();
-        var bareRight = binaryExpression.Right.StripCasts();
-        var bareRightType = bareRight.Type.StripNullable();
-
-        if (bareLeftType.IsEnum && bareRight.NodeType == ExpressionType.Constant) {
-          var typeToCast = bareLeft.Type.IsNullable()
+        if (bareLeftType.IsEnum && rightNoCasts.NodeType == ExpressionType.Constant) {
+          var typeToCast = leftNoCastsType.IsNullable()
             ? bareLeftType.GetEnumUnderlyingType().ToNullable()
-            : bareLeft.Type.GetEnumUnderlyingType();
-          left = Visit(Expression.Convert(bareLeft, typeToCast));
+            : leftNoCastsType.GetEnumUnderlyingType();
+          left = Visit(Expression.Convert(leftNoCasts, typeToCast));
           right = Visit(Expression.Convert(binaryExpression.Right, typeToCast));
         }
-        else if (bareRightType.IsEnum && bareLeft.NodeType == ExpressionType.Constant) {
-          var typeToCast = (bareRight.Type.IsNullable())
+        else if (bareRightType.IsEnum && leftNoCasts.NodeType == ExpressionType.Constant) {
+          var typeToCast = rightNoCastsType.IsNullable()
             ? bareRightType.GetEnumUnderlyingType().ToNullable()
-            : bareRight.Type.GetEnumUnderlyingType();
-          left = Visit(Expression.Convert(bareRight, typeToCast));
+            : rightNoCastsType.GetEnumUnderlyingType();
+          left = Visit(Expression.Convert(rightNoCasts, typeToCast));
           right = Visit(Expression.Convert(binaryExpression.Left, typeToCast));
         }
         else {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -258,9 +258,10 @@ namespace Xtensive.Orm.Linq
 
       static bool EnumRewritableOperations(BinaryExpression b)
       {
-        return b.NodeType.In(ExpressionType.Equal, ExpressionType.NotEqual,
-          ExpressionType.GreaterThan, ExpressionType.GreaterThanOrEqual,
-          ExpressionType.LessThan, ExpressionType.LessThanOrEqual);
+        var nt = b.NodeType;
+        return nt == ExpressionType.Equal || nt == ExpressionType.NotEqual
+          || nt == ExpressionType.GreaterThan || nt == ExpressionType.GreaterThanOrEqual
+          || nt == ExpressionType.LessThan || nt == ExpressionType.LessThanOrEqual;
       }
     }
 


### PR DESCRIPTION
Addresses #189

In certain cases Translator changes binary expression to make following operations not add cast of column to real underlying type of the ```enum``` constants. Basically, it works around C# compiler feature of using integer constants instead of smaller types constants e.g ```byte``` constants.