### PR TITLE
Change DATEDIFF to DATEDIFF_BIG for Sql Server v13+

### DIFF
--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
@@ -379,12 +379,12 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
 
     #region Static helpers
 
-    protected static SqlCast CastToLong(SqlExpression arg)
+    private static SqlCast CastToLong(SqlExpression arg)
     {
       return SqlDml.Cast(arg, SqlType.Int64);
     }
 
-    protected static SqlCast CastToDecimal(SqlExpression arg, short precision, short scale)
+    private static SqlCast CastToDecimal(SqlExpression arg, short precision, short scale)
     {
       return SqlDml.Cast(arg, SqlType.Decimal, precision, scale);
     }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
@@ -379,12 +379,12 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
 
     #region Static helpers
 
-    private static SqlCast CastToLong(SqlExpression arg)
+    protected static SqlCast CastToLong(SqlExpression arg)
     {
       return SqlDml.Cast(arg, SqlType.Int64);
     }
 
-    private static SqlCast CastToDecimal(SqlExpression arg, short precision, short scale)
+    protected static SqlCast CastToDecimal(SqlExpression arg, short precision, short scale)
     {
       return SqlDml.Cast(arg, SqlType.Decimal, precision, scale);
     }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v13/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v13/Compiler.cs
@@ -1,13 +1,48 @@
-﻿// Copyright (C) 2018 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2018-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
 // Created:    2018.09.21
+
+using Xtensive.Sql.Dml;
 
 namespace Xtensive.Sql.Drivers.SqlServer.v13
 {
   internal class Compiler : v12.Compiler
   {
+    protected const string DayPart = "DAY";
+    protected const string MillisecondPart = "MS";
+    protected const string NanosecondPart = "NS";
+    protected const string ZeroTime = "'00:00:00.0000000'";
+
+    /// <inheritdoc/>
+    public override void Visit(SqlFunctionCall node)
+    {
+      if (node.FunctionType == SqlFunctionType.DateTimeOffsetTimeOfDay) {
+        DateTimeOffsetTimeOfDay(node.Arguments[0]).AcceptVisitor(this);
+      }
+      else {
+        base.Visit(node);
+      }
+    }
+
+    protected override SqlExpression DateTimeSubtractDateTime(SqlExpression date1, SqlExpression date2)
+    {
+      return DateDiffBigNanosecond(date2, date1);
+    }
+
+    #region Static Helpers
+
+    protected static SqlUserFunctionCall DateDiffBigNanosecond(SqlExpression date1, SqlExpression date2) =>
+      SqlDml.FunctionCall("DATEDIFF_BIG", SqlDml.Native(NanosecondPart), date1, date2);
+
+    private static SqlExpression DateTimeOffsetTimeOfDay(SqlExpression dateTimeOffset) =>
+      DateDiffBigNanosecond(
+        SqlDml.Native(ZeroTime),
+        SqlDml.Cast(dateTimeOffset, new SqlValueType("time")));
+
+    #endregion
+
     public Compiler(SqlDriver driver)
       : base(driver)
     {


### PR DESCRIPTION
DATEDIFF_BIG has bigger resolution and does not throw overflow exception even on vastly spaced dates. This allows to get rid of compute-expensive formula that served overflow prevention (as I understood).