### PR TITLE
Fix for async execution of queries with .Store() and .In() operations

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Xtensive.Orm.Providers;
 using Xtensive.Orm.Rse;
@@ -24,17 +25,43 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var list = new List<string> {"Michelle", "Jack"};
       var query1 = from c in Session.Query.All<Customer>()
-      where !c.FirstName.In(list)
-      select c.Invoices;
+                   where !c.FirstName.In(list)
+                   select c.Invoices;
       var query2 = from c in Session.Query.All<Customer>()
-      where !c.FirstName.In("Michelle", "Jack")
-      select c.Invoices;
+                   where !c.FirstName.In("Michelle", "Jack")
+                   select c.Invoices;
       var expected1 = from c in Customers
-      where !list.Contains(c.FirstName)
-      select c.Invoices;
+                      where !list.Contains(c.FirstName)
+                      select c.Invoices;
       var expected2 = from c in Customers
-      where !c.FirstName.In(list)
-      select c.Invoices;
+                      where !c.FirstName.In(list)
+                      select c.Invoices;
+      Assert.That(query1, Is.Not.Empty);
+      Assert.That(query2, Is.Not.Empty);
+      Assert.AreEqual(0, expected1.Except(query1).Count());
+      Assert.AreEqual(0, expected2.Except(query1).Count());
+      Assert.AreEqual(0, expected1.Except(query2).Count());
+      Assert.AreEqual(0, expected2.Except(query2).Count());
+      QueryDumper.Dump(query1);
+      QueryDumper.Dump(query2);
+    }
+
+    [Test]
+    public async Task StringContainsAsyncTest()
+    {
+      var list = new List<string> { "Michelle", "Jack" };
+      var query1 = (await (from c in Session.Query.All<Customer>()
+                   where !c.FirstName.In(list)
+                   select c.Invoices).AsAsync()).ToList();
+      var query2 = (await (from c in Session.Query.All<Customer>()
+                   where !c.FirstName.In("Michelle", "Jack")
+                   select c.Invoices).AsAsync()).ToList();
+      var expected1 = from c in Customers
+                      where !list.Contains(c.FirstName)
+                      select c.Invoices;
+      var expected2 = from c in Customers
+                      where !c.FirstName.In(list)
+                      select c.Invoices;
       Assert.That(query1, Is.Not.Empty);
       Assert.That(query2, Is.Not.Empty);
       Assert.AreEqual(0, expected1.Except(query1).Count());
@@ -48,10 +75,10 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void MartinTest()
     {
-      Session.Query.All<Customer>()
-        .LeftJoin(Session.Query.All<Invoice>(), c => c, i => i.Customer, (c, i) => new {Customer = c, Invoice = i})
-        .GroupBy(i => new {i.Customer.FirstName, i.Customer.LastName})
-        .Select(g => new {Key = g.Key, Count = g.Count(j => j.Invoice!=null)})
+      _ = Session.Query.All<Customer>()
+        .LeftJoin(Session.Query.All<Invoice>(), c => c, i => i.Customer, (c, i) => new { Customer = c, Invoice = i })
+        .GroupBy(i => new { i.Customer.FirstName, i.Customer.LastName })
+        .Select(g => new { Key = g.Key, Count = g.Count(j => j.Invoice != null) })
         .ToList();
     }
 
@@ -64,14 +91,37 @@ namespace Xtensive.Orm.Tests.Linq
       for (var i = 0; i < 100; i++) 
         list2.AddRange(list1);
       var query1 = from invoice in Session.Query.All<Invoice>()
-      where (invoice.Commission).In(list1)
-      select invoice;
+                   where (invoice.Commission).In(list1)
+                   select invoice;
       var query2 = from invoice in Session.Query.All<Invoice>()
-      where (invoice.Commission).In(list2)
-      select invoice;
+                   where (invoice.Commission).In(list2)
+                   select invoice;
       var expected = from invoice in Invoices
-      where (invoice.Commission).In(list1)
-      select invoice;
+                     where (invoice.Commission).In(list1)
+                     select invoice;
+      Assert.That(query1, Is.Not.Empty);
+      Assert.That(query2, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query1).Count());
+      Assert.AreEqual(0, expected.Except(query2).Count());
+    }
+
+    [Test]
+    public async Task LongSequenceIntAsyncTest()
+    {
+      // Wrong JOIN mapping for temptable version of .In
+      var list1 = new List<decimal?> { 0.05m, 0.18m, 0.41m };
+      var list2 = new List<decimal?>();
+      for (var i = 0; i < 100; i++)
+        list2.AddRange(list1);
+      var query1 = (await (from invoice in Session.Query.All<Invoice>()
+                   where (invoice.Commission).In(list1)
+                   select invoice).AsAsync()).ToList();
+      var query2 = (await (from invoice in Session.Query.All<Invoice>()
+                   where (invoice.Commission).In(list2)
+                   select invoice).AsAsync()).ToList();
+      var expected = from invoice in Invoices
+                     where (invoice.Commission).In(list1)
+                     select invoice;
       Assert.That(query1, Is.Not.Empty);
       Assert.That(query2, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query1).Count());
@@ -84,11 +134,27 @@ namespace Xtensive.Orm.Tests.Linq
       // casts int to decimal
       var list = new List<int> {5, 18, 41};
       var query = from invoice in Session.Query.All<Invoice>()
-      where !((int) invoice.Commission).In(list)
-      select invoice;
+                  where !((int) invoice.Commission).In(list)
+                  select invoice;
       var expected = from invoice in Invoices
-      where !((int) invoice.Commission).In(list)
-      select invoice;
+                     where !((int) invoice.Commission).In(list)
+                     select invoice;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task IntAndDecimalContains1AsyncTest()
+    {
+      // casts int to decimal
+      var list = new List<int> { 5, 18, 41 };
+      var query = (await (from invoice in Session.Query.All<Invoice>()
+                  where !((int) invoice.Commission).In(list)
+                  select invoice).AsAsync()).ToList();
+      var expected = from invoice in Invoices
+                     where !((int) invoice.Commission).In(list)
+                     select invoice;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -99,11 +165,26 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var list = new List<int> {276192, 349492, 232463};
       var query = from track in Session.Query.All<Track>()
-      where track.Milliseconds.In(list)
-      select track;
+                  where track.Milliseconds.In(list)
+                  select track;
       var expected = from track in Tracks
-      where track.Milliseconds.In(list)
-      select track;
+                     where track.Milliseconds.In(list)
+                     select track;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task SimpleIntContainsAsyncTest()
+    {
+      var list = new List<int> { 276192, 349492, 232463 };
+      var query = (await (from track in Session.Query.All<Track>()
+                  where track.Milliseconds.In(list)
+                  select track).AsAsync()).ToList();
+      var expected = from track in Tracks
+                     where track.Milliseconds.In(list)
+                     select track;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -131,11 +212,27 @@ namespace Xtensive.Orm.Tests.Linq
       // casts decimal to int
       var list = new List<decimal> {7, 22, 46};
       var query = from invoice in Session.Query.All<Invoice>()
-      where !((decimal) invoice.InvoiceId).In(list)
-      select invoice;
+                  where !((decimal) invoice.InvoiceId).In(list)
+                  select invoice;
       var expected = from invoice in Invoices
-      where !((decimal) invoice.InvoiceId).In(list)
-      select invoice;
+                     where !((decimal) invoice.InvoiceId).In(list)
+                     select invoice;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task IntAndDecimalContains2AsyncTest()
+    {
+      // casts decimal to int
+      var list = new List<decimal> { 7, 22, 46 };
+      var query = (await (from invoice in Session.Query.All<Invoice>()
+                  where !((decimal) invoice.InvoiceId).In(list)
+                  select invoice).AsAsync()).ToList();
+      var expected = from invoice in Invoices
+                     where !((decimal) invoice.InvoiceId).In(list)
+                     select invoice;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -146,11 +243,26 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var list = Session.Query.All<Customer>().Take(5).ToList();
       var query = from c in Session.Query.All<Customer>()
-      where !c.In(list)
-      select c.Invoices;
+                  where !c.In(list)
+                  select c.Invoices;
       var expected = from c in Customers
-      where !c.In(list)
-      select c.Invoices;
+                     where !c.In(list)
+                     select c.Invoices;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task EntityContainsAsyncTest()
+    {
+      var list = Session.Query.All<Customer>().Take(5).ToList();
+      var query = (await (from c in Session.Query.All<Customer>()
+                  where !c.In(list)
+                  select c.Invoices).AsAsync()).ToList();
+      var expected = from c in Customers
+                     where !c.In(list)
+                     select c.Invoices;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -161,11 +273,26 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var list = Session.Query.All<Customer>().Take(5).Select(c => c.Address).ToList();
       var query = from c in Session.Query.All<Customer>()
-      where !c.Address.In(list)
-      select c.Invoices;
+                  where !c.Address.In(list)
+                  select c.Invoices;
       var expected = from c in Customers
-      where !c.Address.In(list)
-      select c.Invoices;
+                     where !c.Address.In(list)
+                     select c.Invoices;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task StructContainsAsyncTest()
+    {
+      var list = Session.Query.All<Customer>().Take(5).Select(c => c.Address).ToList();
+      var query = (await (from c in Session.Query.All<Customer>()
+                  where !c.Address.In(list)
+                  select c.Invoices).AsAsync()).ToList();
+      var expected = from c in Customers
+                     where !c.Address.In(list)
+                     select c.Invoices;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -180,11 +307,33 @@ namespace Xtensive.Orm.Tests.Linq
     }
 
     [Test]
+    public async Task StructSimpleContainsAsyncTest()
+    {
+      var list = (await Session.Query.All<Customer>().Take(5).Select(c => c.Address).AsAsync()).ToList();
+      var query = Session.Query.All<Customer>().Select(c => c.Address).Where(c => c.In(list));
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
     public void AnonimousContainsTest()
     {
       var list = new[] {new {FirstName = "Michelle"}, new {FirstName = "Jack"}};
       var query = Session.Query.All<Customer>().Where(c => new {c.FirstName}.In(list)).Select(c => c.Invoices);
       var expected = Customers.Where(c => new {c.FirstName}.In(list)).Select(c => c.Invoices);
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task AnonimousContainsAsyncTest()
+    {
+      var list = new[] { new { FirstName = "Michelle" }, new { FirstName = "Jack" } };
+      var query = (await Session.Query.All<Customer>()
+        .Where(c => new { c.FirstName }.In(list))
+        .Select(c => c.Invoices)
+        .AsAsync()).ToList();
+      var expected = Customers.Where(c => new { c.FirstName }.In(list)).Select(c => c.Invoices);
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -202,6 +351,20 @@ namespace Xtensive.Orm.Tests.Linq
     }
 
     [Test]
+    public async Task AnonimousContains2AsyncTest()
+    {
+      var list = new[] { new { Id1 = "Michelle", Id2 = "Michelle" }, new { Id1 = "Jack", Id2 = "Jack" } };
+      var query = (await Session.Query.All<Customer>()
+        .Where(c => new { Id1 = c.FirstName, Id2 = c.FirstName }.In(list))
+        .Select(c => c.Invoices)
+        .AsAsync()).ToList();
+      var expected = Customers.Where(c => new { Id1 = c.FirstName, Id2 = c.FirstName }.In(list)).Select(c => c.Invoices);
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
     public void QueryableDoubleContainsTest()
     {
       var list = Session.Query.All<Invoice>()
@@ -209,11 +372,29 @@ namespace Xtensive.Orm.Tests.Linq
         .Distinct()
         .Take(10);
       var query = from invoice in Session.Query.All<Invoice>()
-      where !invoice.Commission.In(list)
-      select invoice;
+                  where !invoice.Commission.In(list)
+                  select invoice;
       var expected = from invoice in Invoices
-      where !invoice.Commission.In(list)
-      select invoice;
+                     where !invoice.Commission.In(list)
+                     select invoice;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task QueryableDoubleContainsAsyncTest()
+    {
+      var list = Session.Query.All<Invoice>()
+        .Select(o => o.Commission)
+        .Distinct()
+        .Take(10);
+      var query = (await (from invoice in Session.Query.All<Invoice>()
+                  where !invoice.Commission.In(list)
+                  select invoice).AsAsync()).ToList();
+      var expected = from invoice in Invoices
+                     where !invoice.Commission.In(list)
+                     select invoice;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -224,11 +405,26 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var list = Session.Query.All<Customer>().Take(5);
       var query = from c in Session.Query.All<Customer>()
-      where !c.In(list)
-      select c.Invoices;
+                  where !c.In(list)
+                  select c.Invoices;
       var expected = from c in Customers
-      where !c.In(list)
-      select c.Invoices;
+                     where !c.In(list)
+                     select c.Invoices;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task QueryableEntityContainsAsyncTest()
+    {
+      var list = Session.Query.All<Customer>().Take(5);
+      var query = (await (from c in Session.Query.All<Customer>()
+                  where !c.In(list)
+                  select c.Invoices).AsAsync()).ToList();
+      var expected = from c in Customers
+                     where !c.In(list)
+                     select c.Invoices;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -241,11 +437,28 @@ namespace Xtensive.Orm.Tests.Linq
         .Take(5)
         .Select(c => c.Address);
       var query = from c in Session.Query.All<Customer>()
-      where !c.Address.In(list)
-      select c.Invoices;
+                  where !c.Address.In(list)
+                  select c.Invoices;
       var expected = from c in Customers
-      where !c.Address.In(list)
-      select c.Invoices;
+                     where !c.Address.In(list)
+                     select c.Invoices;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task QueryableStructContainsAsyncTest()
+    {
+      var list = Session.Query.All<Customer>()
+        .Take(5)
+        .Select(c => c.Address);
+      var query = (await (from c in Session.Query.All<Customer>()
+                  where !c.Address.In(list)
+                  select c.Invoices).AsAsync()).ToList();
+      var expected = from c in Customers
+                     where !c.Address.In(list)
+                     select c.Invoices;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -257,6 +470,20 @@ namespace Xtensive.Orm.Tests.Linq
       var list = Session.Query.All<Customer>().Take(10).Select(c => new {c.FirstName});
       var query = Session.Query.All<Customer>().Where(c => new {c.FirstName}.In(list)).Select(c => c.Invoices);
       var expected = Customers.Where(c => new {c.FirstName}.In(list)).Select(c => c.Invoices);
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task QueryableAnonimousContainsAsyncTest()
+    {
+      var list = Session.Query.All<Customer>().Take(10).Select(c => new { c.FirstName });
+      var query = (await Session.Query.All<Customer>()
+        .Where(c => new { c.FirstName }.In(list))
+        .Select(c => c.Invoices)
+        .AsAsync()).ToList();
+      var expected = Customers.Where(c => new { c.FirstName }.In(list)).Select(c => c.Invoices);
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -276,11 +503,27 @@ namespace Xtensive.Orm.Tests.Linq
       var includeAlgorithm = IncludeAlgorithm.TemporaryTable;
       var list = new List<int> {276192, 349492, 232463};
       var query = from track in Session.Query.All<Track>()
-      where track.Milliseconds.In(includeAlgorithm, list)
-      select track;
+                  where track.Milliseconds.In(includeAlgorithm, list)
+                  select track;
       var expected = from track in Tracks
-      where track.Milliseconds.In(includeAlgorithm, list)
-      select track;
+                     where track.Milliseconds.In(includeAlgorithm, list)
+                     select track;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task ComplexCondition1AsyncTest()
+    {
+      var includeAlgorithm = IncludeAlgorithm.TemporaryTable;
+      var list = new List<int> { 276192, 349492, 232463 };
+      var query = (await (from track in Session.Query.All<Track>()
+                  where track.Milliseconds.In(includeAlgorithm, list)
+                  select track).AsAsync()).ToList();
+      var expected = from track in Tracks
+                     where track.Milliseconds.In(includeAlgorithm, list)
+                     select track;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);
@@ -291,11 +534,26 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var includeAlgorithm = IncludeAlgorithm.TemporaryTable;
       var query = from track in Session.Query.All<Track>()
-      where track.Milliseconds.In(includeAlgorithm, 276192, 349492, 232463)
-      select track;
+                  where track.Milliseconds.In(includeAlgorithm, 276192, 349492, 232463)
+                  select track;
       var expected = from track in Tracks
-      where track.Milliseconds.In(includeAlgorithm, 276192, 349492, 232463)
-      select track;
+                     where track.Milliseconds.In(includeAlgorithm, 276192, 349492, 232463)
+                     select track;
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+      QueryDumper.Dump(query);
+    }
+
+    [Test]
+    public async Task ComplexCondition2AsyncTest()
+    {
+      var includeAlgorithm = IncludeAlgorithm.TemporaryTable;
+      var query = (await (from track in Session.Query.All<Track>()
+                  where track.Milliseconds.In(includeAlgorithm, 276192, 349492, 232463)
+                  select track).AsAsync()).ToList();
+      var expected = from track in Tracks
+                     where track.Milliseconds.In(includeAlgorithm, 276192, 349492, 232463)
+                     select track;
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());
       QueryDumper.Dump(query);

--- a/Orm/Xtensive.Orm.Tests/Linq/LocalCollectionsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/LocalCollectionsTest.cs
@@ -14,6 +14,7 @@ using Xtensive.Orm.Linq;
 using Xtensive.Orm.Tests.Linq.LocalCollectionsTest_Model;
 using Xtensive.Orm.Tests.ObjectModel;
 using Xtensive.Orm.Tests.ObjectModel.ChinookDO;
+using System.Threading.Tasks;
 
 namespace Xtensive.Orm.Tests.Linq.LocalCollectionsTest_Model
 {
@@ -253,7 +254,7 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void Poco1Test()
     {
-      Assert.Throws<QueryTranslationException>(() => {
+      _ = Assert.Throws<QueryTranslationException>(() => {
         var pocos = Customers
           .Select(customer => new Poco<string>() { Value = customer.LastName })
           .ToList();
@@ -357,7 +358,7 @@ namespace Xtensive.Orm.Tests.Linq
       var nodes = new Node[10];
       var query = Session.Query.All<Invoice>()
         .Join(nodes, invoice => invoice.Customer.Address.City, node => node.Name, (invoice, node) => new {invoice, node});
-      Assert.Throws<QueryTranslationException>(() => QueryDumper.Dump(query));
+      _ = Assert.Throws<QueryTranslationException>(() => QueryDumper.Dump(query));
     }
 
     [Test]
@@ -403,7 +404,7 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void KeyTest()
     {
-      Assert.Throws<QueryTranslationException>( () => {
+      _ = Assert.Throws<QueryTranslationException>(() => {
         var keys = Session.Query.All<Invoice>().Take(10).Select(invoice => invoice.Key).ToList();
         var query = Session.Query.All<Invoice>()
           .Join(keys, invoice => invoice.Key, key => key, (invoice, key) => new {invoice, key});
@@ -863,7 +864,6 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.AreEqual(result, expected);
     }
 
-
     [Test]
     public void Aggregate2Test()
     {
@@ -882,9 +882,26 @@ namespace Xtensive.Orm.Tests.Linq
     }
 
     [Test]
+    public async Task Aggregate2AsyncTest()
+    {
+      Require.AllFeaturesSupported(ProviderFeatures.TemporaryTables);
+      Require.ProviderIsNot(StorageProvider.SqlServerCe);
+      var localItems = GetLocalItems(100);
+      var queryable = Session.Query.Store(localItems);
+      var result = (await Session.Query.All<Invoice>()
+        .Where(invoice => invoice.Commission > queryable.Max(poco => poco.Value2)).AsAsync()).ToList();
+      var expected = Invoices
+        .Where(invoice => invoice.Commission > localItems.Max(poco => poco.Value2));
+
+      Assert.That(result, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(result).Count());
+      QueryDumper.Dump(result);
+    }
+
+    [Test]
     public void ClosureCacheTest()
     {
-      Assert.Throws<QueryTranslationException>( () => {
+      _ = Assert.Throws<QueryTranslationException>( () => {
         var localItems = GetLocalItems(100);
         var queryable = Session.Query.Store(localItems);
         var result = Session.Query.Execute(qe => qe.All<Invoice>().Where(invoice => invoice.Commission > queryable.Max(poco => poco.Value2)));

--- a/Orm/Xtensive.Orm.Tests/Linq/QueryMethodTests.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/QueryMethodTests.cs
@@ -121,7 +121,7 @@ namespace Xtensive.Orm.Tests.Linq
     }
 
     [Test]
-    public async Task Store1TestAsync()
+    public async Task Store1AsyncTest()
     {
       Require.AllFeaturesSupported(ProviderFeatures.TemporaryTables);
 
@@ -160,6 +160,28 @@ namespace Xtensive.Orm.Tests.Linq
           customer => customer,
           localCustomer => localCustomer,
           (customer, localCustomer) => new {customer, localCustomer});
+
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+    }
+
+    [Test]
+    public async Task Store2AsyncTest()
+    {
+      Require.AllFeaturesSupported(ProviderFeatures.TemporaryTables);
+
+      var query = (await Session.Query.All<Customer>()
+        .Join(
+          Session.Query.Store(Session.Query.All<Customer>().Take(10)),
+          customer => customer,
+          localCustomer => localCustomer,
+          (customer, localCustomer) => new { customer, localCustomer }).AsAsync()).ToList();
+      var expected = Session.Query.All<Customer>().AsEnumerable()
+        .Join(
+          Session.Query.Store(Session.Query.All<Customer>().Take(10)),
+          customer => customer,
+          localCustomer => localCustomer,
+          (customer, localCustomer) => new { customer, localCustomer });
 
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());

--- a/Orm/Xtensive.Orm.Tests/Linq/QueryMethodTests.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/QueryMethodTests.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Xtensive.Collections;
 using Xtensive.Core;
@@ -114,6 +115,29 @@ namespace Xtensive.Orm.Tests.Linq
           customer => customer,
           localCustomer => localCustomer,
           (customer, localCustomer) => new {customer, localCustomer});
+
+      Assert.That(query, Is.Not.Empty);
+      Assert.AreEqual(0, expected.Except(query).Count());
+    }
+
+    [Test]
+    public async Task Store1TestAsync()
+    {
+      Require.AllFeaturesSupported(ProviderFeatures.TemporaryTables);
+
+      var localCustomers = Session.Query.All<Customer>().Take(10).ToList();
+      var query = (await Session.Query.All<Customer>()
+        .Join(
+          Session.Query.Store(localCustomers),
+          customer => customer,
+          localCustomer => localCustomer,
+          (customer, localCustomer) => new { customer, localCustomer }).AsAsync()).ToList();
+      var expected = Session.Query.All<Customer>().AsEnumerable()
+        .Join(
+          Session.Query.Store(localCustomers),
+          customer => customer,
+          localCustomer => localCustomer,
+          (customer, localCustomer) => new { customer, localCustomer });
 
       Assert.That(query, Is.Not.Empty);
       Assert.AreEqual(0, expected.Except(query).Count());

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
@@ -129,7 +129,7 @@ namespace Xtensive.Orm.Providers
 
       token.ThrowIfCancellationRequested();
 
-      await ExecuteTasksAsync(context, token);
+      await ExecuteTasksAsync(context, token).ConfigureAwait(false);
       context.AllowPartialExecution = oldValue;
 
       var lastRequestCommand = Factory.CreateCommand();
@@ -137,7 +137,7 @@ namespace Xtensive.Orm.Providers
       ValidateCommandParameters(commandPart);
       lastRequestCommand.AddPart(commandPart);
       token.ThrowIfCancellationRequested();
-      await lastRequestCommand.ExecuteReaderAsync(token);
+      await lastRequestCommand.ExecuteReaderAsync(token).ConfigureAwait(false);
       return lastRequestCommand.AsReaderOf(lastRequest);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IProviderExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IProviderExecutor.cs
@@ -39,6 +39,13 @@ namespace Xtensive.Orm.Providers
     void Store(IPersistDescriptor descriptor, IEnumerable<Tuple> tuples);
 
     /// <summary>
+    /// Asynchronously stores the specified tuples in specified table.
+    /// </summary>
+    /// <param name="descriptor">Persist descriptor.</param>
+    /// <param name="tuples">The tuples to store.</param>
+    Task StoreAsync(EnumerationContext context, IPersistDescriptor descriptor, IEnumerable<Tuple> tuples, CancellationToken token);
+
+    /// <summary>
     /// Clears the specified table.
     /// </summary>
     /// <param name="descriptor">Persist descriptor.</param>

--- a/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IProviderExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IProviderExecutor.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.10.30
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlIncludeProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlIncludeProvider.cs
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Providers
           // nothing
           break;
         case IncludeAlgorithm.TemporaryTable:
-          await LockAndStoreAsync(context, filterDataSource.Invoke(), token);
+          await LockAndStoreAsync(context, filterDataSource.Invoke(), token).ConfigureAwait(false);
           break;
         default:
           throw new ArgumentOutOfRangeException("Origin.Algorithm");

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IProviderExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IProviderExecutor.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2010-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
 // Created:    2010.02.09
 
@@ -40,31 +40,35 @@ namespace Xtensive.Orm.Providers
     void IProviderExecutor.Store(IPersistDescriptor descriptor, IEnumerable<Tuple> tuples)
     {
       Prepare();
-      foreach (var tuple in tuples)
+      foreach (var tuple in tuples) {
         commandProcessor.RegisterTask(new SqlPersistTask(descriptor.StoreRequest, tuple));
-      using (var context = new CommandProcessorContext())
+      }
+
+      using (var context = new CommandProcessorContext()) {
         commandProcessor.ExecuteTasks(context);
+      }
     }
 
-
-
+    /// <inheritdoc/>
     async Task IProviderExecutor.StoreAsync(EnumerationContext enumerationContext,IPersistDescriptor descriptor, IEnumerable<Tuple> tuples, CancellationToken token)
     {
-      await PrepareAsync(token);
+      await PrepareAsync(token).ConfigureAwait(false);
 
       if (tuples is ExecutableRawProvider rawProvider) {
-        var enumerator = await rawProvider.GetEnumeratorAsync(enumerationContext, token);
+        var enumerator = await rawProvider.GetEnumeratorAsync(enumerationContext, token).ConfigureAwait(false);
         while(enumerator.MoveNext()) {
           commandProcessor.RegisterTask(new SqlPersistTask(descriptor.StoreRequest, enumerator.Current));
         }
       }
       else {
-        foreach (var tuple in tuples)
+        foreach (var tuple in tuples) {
           commandProcessor.RegisterTask(new SqlPersistTask(descriptor.StoreRequest, tuple));
+        }
       }
 
-      using (var context = new CommandProcessorContext())
-        await commandProcessor.ExecuteTasksAsync(context, token);
+      using (var context = new CommandProcessorContext()) {
+        await commandProcessor.ExecuteTasksAsync(context, token).ConfigureAwait(false);
+      }
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -162,7 +163,8 @@ namespace Xtensive.Orm.Providers
     private async Task PrepareAsync(CancellationToken cancellationToken)
     {
       Session.EnsureNotDisposed();
-      await driver.OpenConnectionAsync(Session, connection, cancellationToken).ConfigureAwait(false);
+      if (connection.State != ConnectionState.Open)
+        await driver.OpenConnectionAsync(Session, connection, cancellationToken).ConfigureAwait(false);
 
       try {
         foreach (var initializationSqlScript in initializationSqlScripts)

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.cs
@@ -165,7 +165,7 @@ namespace Xtensive.Orm.Providers
     private async Task PrepareAsync(CancellationToken cancellationToken)
     {
       Session.EnsureNotDisposed();
-      await driver.EnsureConnectionIsOpenAsync(Session, connection, cancellationToken);
+      await driver.EnsureConnectionIsOpenAsync(Session, connection, cancellationToken).ConfigureAwait(false);
 
       try {
         foreach (var initializationSqlScript in initializationSqlScripts) {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.cs
@@ -165,7 +165,7 @@ namespace Xtensive.Orm.Providers
     private async Task PrepareAsync(CancellationToken cancellationToken)
     {
       Session.EnsureNotDisposed();
-      await driver.EnsureConnectionIsOpenAsync(Session, connection);
+      await driver.EnsureConnectionIsOpenAsync(Session, connection, cancellationToken);
 
       try {
         foreach (var initializationSqlScript in initializationSqlScripts) {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlStoreProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlStoreProvider.cs
@@ -35,8 +35,8 @@ namespace Xtensive.Orm.Providers
     /// <inheritdoc/>
     protected override async Task OnBeforeEnumerateAsync(Rse.Providers.EnumerationContext context, CancellationToken token)
     {
-      await base.OnBeforeEnumerateAsync(context, token);
-      await LockAndStoreAsync(context, Source, token);
+      await base.OnBeforeEnumerateAsync(context, token).ConfigureAwait(false);
+      await LockAndStoreAsync(context, Source, token).ConfigureAwait(false);
     }
 
     protected override void OnAfterEnumerate(Rse.Providers.EnumerationContext context)

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlStoreProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlStoreProvider.cs
@@ -4,6 +4,8 @@
 // Created by: Dmitri Maximov
 // Created:    2008.09.05
 
+using System.Threading;
+using System.Threading.Tasks;
 using Xtensive.Orm.Rse.Providers;
 
 namespace Xtensive.Orm.Providers
@@ -28,6 +30,12 @@ namespace Xtensive.Orm.Providers
     {
       base.OnBeforeEnumerate(context);
       LockAndStore(context, Source);
+    }
+
+    protected override async Task OnBeforeEnumerateAsync(Rse.Providers.EnumerationContext context, CancellationToken token)
+    {
+      await base.OnBeforeEnumerateAsync(context, token);
+      await LockAndStoreAsync(context, Source, token);
     }
 
     protected override void OnAfterEnumerate(Rse.Providers.EnumerationContext context)

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlStoreProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlStoreProvider.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2008.09.05
 
@@ -32,6 +32,7 @@ namespace Xtensive.Orm.Providers
       LockAndStore(context, Source);
     }
 
+    /// <inheritdoc/>
     protected override async Task OnBeforeEnumerateAsync(Rse.Providers.EnumerationContext context, CancellationToken token)
     {
       await base.OnBeforeEnumerateAsync(context, token);
@@ -40,7 +41,7 @@ namespace Xtensive.Orm.Providers
 
     protected override void OnAfterEnumerate(Rse.Providers.EnumerationContext context)
     {
-      ClearAndUnlock(context);
+      _ = ClearAndUnlock(context);
       base.OnAfterEnumerate(context);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlTemporaryDataProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlTemporaryDataProvider.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.11.13
 
@@ -43,7 +43,7 @@ namespace Xtensive.Orm.Providers
         return;
       storageContext.SetValue(this, TemporaryTableLockName, tableLock);
       var executor = storageContext.Session.Services.Demand<IProviderExecutor>();
-      await executor.StoreAsync(storageContext, tableDescriptor, data, token);
+      await executor.StoreAsync(storageContext, tableDescriptor, data, token).ConfigureAwait(false);
     }
 
     protected bool ClearAndUnlock(Rse.Providers.EnumerationContext context)

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -119,8 +119,16 @@ namespace Xtensive.Orm.Providers
 
     public void EnsureConnectionIsOpen(Session session, SqlConnection connection)
     {
-      if (connection.State!=ConnectionState.Open)
+      if (connection.State != ConnectionState.Open) {
         OpenConnection(session, connection);
+      }
+    }
+
+    public async Task EnsureConnectionIsOpenAsync(Session session, SqlConnection connection)
+    {
+      if (connection.State != ConnectionState.Open) {
+        await OpenConnectionAsync(session, connection).ConfigureAwait(false);
+      }
     }
 
     public void CloseConnection(Session session, SqlConnection connection)

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -124,10 +124,10 @@ namespace Xtensive.Orm.Providers
       }
     }
 
-    public async Task EnsureConnectionIsOpenAsync(Session session, SqlConnection connection)
+    public async Task EnsureConnectionIsOpenAsync(Session session, SqlConnection connection, CancellationToken token)
     {
       if (connection.State != ConnectionState.Open) {
-        await OpenConnectionAsync(session, connection).ConfigureAwait(false);
+        await OpenConnectionAsync(session, connection, token).ConfigureAwait(false);
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Executable/ExecutableRawProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Executable/ExecutableRawProvider.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2008.05.08
 
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <inheritdoc/>
     protected override async Task OnBeforeEnumerateAsync(EnumerationContext context, CancellationToken token)
     {
-      await base.OnBeforeEnumerateAsync(context, token);
+      await base.OnBeforeEnumerateAsync(context, token).ConfigureAwait(false);
       context.SetValue(this, CachedSourceName, Origin.CompiledSource.Invoke());
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Executable/ExecutableRawProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Executable/ExecutableRawProvider.cs
@@ -6,6 +6,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Tuple = Xtensive.Tuples.Tuple;
 
 namespace Xtensive.Orm.Rse.Providers
@@ -16,28 +18,26 @@ namespace Xtensive.Orm.Rse.Providers
   [Serializable]
   public sealed class ExecutableRawProvider : ExecutableProvider<Providers.RawProvider>
   {
-    #region Cached properties
-
     private const string CachedSourceName = "CachedSource";
-
-    private IEnumerable<Tuple> CachedSource {
-      get { return GetValue<IEnumerable<Tuple>>(EnumerationContext.Current, CachedSourceName); }
-      set { SetValue(EnumerationContext.Current, CachedSourceName, value); }
-    }
-
-    #endregion
 
     /// <inheritdoc/>
     protected override void OnBeforeEnumerate(EnumerationContext context)
     {
       base.OnBeforeEnumerate(context);
-      CachedSource = Origin.CompiledSource.Invoke();
+      context.SetValue(this, CachedSourceName, Origin.CompiledSource.Invoke());
+    }
+
+    /// <inheritdoc/>
+    protected override async Task OnBeforeEnumerateAsync(EnumerationContext context, CancellationToken token)
+    {
+      await base.OnBeforeEnumerateAsync(context, token);
+      context.SetValue(this, CachedSourceName, Origin.CompiledSource.Invoke());
     }
 
     /// <inheritdoc/>
     protected override IEnumerable<Tuple> OnEnumerate(EnumerationContext context)
     {
-      return CachedSource;
+      return context.GetValue<IEnumerable<Tuple>>(this, CachedSourceName);
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/ExecutableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/ExecutableProvider.cs
@@ -41,6 +41,16 @@ namespace Xtensive.Orm.Rse.Providers
       }
     }
 
+    protected virtual async Task OnBeforeEnumerateAsync(EnumerationContext context, CancellationToken token)
+    {
+      token.ThrowIfCancellationRequested();
+      foreach (var source in Sources) {
+        var ep = source as ExecutableProvider;
+        if (ep != null)
+          await ep.OnBeforeEnumerateAsync(context, token);
+      }
+    }
+
     /// <summary>
     /// Called when enumeration is finished.
     /// </summary>
@@ -117,7 +127,7 @@ namespace Xtensive.Orm.Rse.Providers
       var enumerated = context.GetValue<bool>(this, enumerationMarker);
       bool onEnumerationExecuted = false;
       if (!enumerated)
-        OnBeforeEnumerate(context);
+        await OnBeforeEnumerateAsync(context, token);
       try {
         context.SetValue(this, enumerationMarker, true);
         var enumerator = (await OnEnumerateAsync(context, token).ConfigureAwait(false))

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/ExecutableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/ExecutableProvider.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2008.07.07
 
@@ -35,19 +35,24 @@ namespace Xtensive.Orm.Rse.Providers
     protected virtual void OnBeforeEnumerate(EnumerationContext context)
     {
       foreach (var source in Sources) {
-        var ep = source as ExecutableProvider;
-        if (ep!=null)
+        if (source is ExecutableProvider ep) {
           ep.OnBeforeEnumerate(context);
+        }
       }
     }
 
+    /// <summary>
+    /// Called when enumerator is created on this provider.
+    /// </summary>
+    /// <param name="context">The enumeration context.</param>
+    /// <param name="token">The cancellation token for operation</param>
     protected virtual async Task OnBeforeEnumerateAsync(EnumerationContext context, CancellationToken token)
     {
       token.ThrowIfCancellationRequested();
       foreach (var source in Sources) {
-        var ep = source as ExecutableProvider;
-        if (ep != null)
-          await ep.OnBeforeEnumerateAsync(context, token);
+        if (source is ExecutableProvider ep) {
+          await ep.OnBeforeEnumerateAsync(context, token).ConfigureAwait(false);
+        }
       }
     }
 
@@ -125,9 +130,10 @@ namespace Xtensive.Orm.Rse.Providers
     {
       const string enumerationMarker = "Enumerated";
       var enumerated = context.GetValue<bool>(this, enumerationMarker);
-      bool onEnumerationExecuted = false;
-      if (!enumerated)
-        await OnBeforeEnumerateAsync(context, token);
+      var onEnumerationExecuted = false;
+      if (!enumerated) {
+        await OnBeforeEnumerateAsync(context, token).ConfigureAwait(false);
+      }
       try {
         context.SetValue(this, enumerationMarker, true);
         var enumerator = (await OnEnumerateAsync(context, token).ConfigureAwait(false))
@@ -141,8 +147,9 @@ namespace Xtensive.Orm.Rse.Providers
         return enumerator;
       }
       finally {
-        if (!enumerated && !onEnumerationExecuted)
+        if (!enumerated && !onEnumerationExecuted) {
           OnAfterEnumerate(context);
+        }
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSet.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSet.cs
@@ -111,8 +111,15 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     private async Task<IEnumerator<Tuple>> GetBatchedEnumeratorAsync(CancellationToken token)
     {
-      EnumerationScope currentScope = null;
-      var enumerator = await Source.GetEnumeratorAsync(Context, token).ConfigureAwait(false);
+      var currentScope = Context.Activate();
+      IEnumerator<Tuple> enumerator = null;
+      try {
+        enumerator = await Source.GetEnumeratorAsync(Context, token).ConfigureAwait(false);
+      }
+      finally {
+        currentScope.DisposeSafely();
+      }
+        
       var batched = enumerator.ToEnumerable().Batch(2);
 
       var cs = Context.BeginEnumeration();
@@ -124,10 +131,11 @@ namespace Xtensive.Orm.Rse
           completableScope.Complete();
           completableScope.Dispose();
         };
-      return GetTwoLevelEnumerator(batched, afterEnumerationAction, cs);
+        return GetTwoLevelEnumerator(batched, afterEnumerationAction, cs);
     }
 
-    private static IEnumerator<Tuple> GetTwoLevelEnumerator(IEnumerable<IEnumerable<Tuple>> enumerable, Action<object> afterEnumerationAction, object parameterForAction)
+    private static IEnumerator<Tuple> GetTwoLevelEnumerator(IEnumerable<IEnumerable<Tuple>> enumerable,
+      Action<object> afterEnumerationAction, ICompletableScope parameterForAction)
     {
       try {
         foreach (var batch in enumerable)

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSet.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSet.cs
@@ -131,7 +131,7 @@ namespace Xtensive.Orm.Rse
           completableScope.Complete();
           completableScope.Dispose();
         };
-        return GetTwoLevelEnumerator(batched, afterEnumerationAction, cs);
+      return GetTwoLevelEnumerator(batched, afterEnumerationAction, cs);
     }
 
     private static IEnumerator<Tuple> GetTwoLevelEnumerator(IEnumerable<IEnumerable<Tuple>> enumerable,


### PR DESCRIPTION
The PR addresses NRE on asynchronous execution of the operations due to EnumerationContext.Current is null.