### PR TITLE
Addresses issues appeared in tagging

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/TagTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/TagTest.cs
@@ -152,6 +152,7 @@ namespace Xtensive.Orm.Tests.Linq
     [TestCase(TagsLocation.AfterStatement, TestName = nameof(TagsLocation.AfterStatement))]
     public void VariousPlacements(TagsLocation tagsLocation)
     {
+      Require.ProviderIsNot(StorageProvider.Sqlite | StorageProvider.Firebird);
       var config = Domain.Configuration.Clone();
       config.TagsLocation = tagsLocation;
       config.UpgradeMode = DomainUpgradeMode.Skip;
@@ -290,6 +291,8 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void TagInExcept()
     {
+      Require.ProviderIsNot(StorageProvider.MySql | StorageProvider.Firebird);
+
       var session = Session.Demand();
 
       using (var innerTx = session.OpenTransaction(TransactionOpenMode.New)) {
@@ -310,6 +313,7 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void TagInIntersect()
     {
+      Require.ProviderIsNot(StorageProvider.MySql | StorageProvider.Firebird);
       var session = Session.Demand();
 
       using (var innerTx = session.OpenTransaction(TransactionOpenMode.New)) {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlSelect.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlSelect.cs
@@ -217,7 +217,7 @@ namespace Xtensive.Sql.Dml
       clone.Limit = Limit;
       clone.Offset = Offset;
       clone.Lock = Lock;
-      clone.Comment = (SqlComment)Comment.Clone(context);
+      clone.Comment = (SqlComment) Comment?.Clone(context);
 
       if (Hints.Count > 0)
         foreach (SqlHint hint in Hints)


### PR DESCRIPTION
1) SqlSelect.Clone() no longer throws NRE when Comment is null
2) Some tests ignore certain providers for various reasons.