### PR TITLE
Minor optimizations (#59)

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/BulkDeleteOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/BulkDeleteOperation.cs
@@ -51,10 +51,10 @@ namespace Xtensive.Orm.BulkOperations
       }
     }
 
-    private QueryCommand CreateCommand(QueryTranslationResult request)
+    private QueryCommand CreateCommand(in QueryTranslationResult request)
     {
       var delete = SqlDml.Delete(SqlDml.TableRef(PrimaryIndexes[0].Table));
-      Join(delete, (SqlSelect) request.Query);
+      Join(delete, request.Query);
       return ToCommand(delete);
     }
 

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/BulkUpdateOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/BulkUpdateOperation.cs
@@ -54,11 +54,11 @@ namespace Xtensive.Orm.BulkOperations
       }
     }
 
-    private QueryCommand CreateCommand(QueryTranslationResult request)
+    private QueryCommand CreateCommand(in QueryTranslationResult request)
     {
       var update = SqlDml.Update(SqlDml.TableRef(PrimaryIndexes[0].Table));
       setOperation.Statement = SetStatement.Create(update);
-      Join(update, (SqlSelect) request.Query);
+      Join(update, request.Query);
       setOperation.AddValues();
       return ToCommand(update);
     }

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
@@ -103,7 +103,7 @@ namespace Xtensive.Orm.BulkOperations
         all,
         addContext.Lambda);
       QueryTranslationResult request = parent.GetRequest(parent.QueryProvider.CreateQuery<T>(selectExpression));
-      var sqlSelect = ((SqlSelect)request.Query);
+      var sqlSelect = request.Query;
       SqlExpression ex = sqlSelect.OrderBy[0].Expression;
       var placeholder = ex as SqlPlaceholder;
       if (placeholder == null)
@@ -133,7 +133,7 @@ namespace Xtensive.Orm.BulkOperations
         all,
         addContext.Lambda);
       QueryTranslationResult request = parent.GetRequest(parent.QueryProvider.CreateQuery<T>(selectExpression));
-      var sqlSelect = ((SqlSelect) request.Query);
+      var sqlSelect = request.Query;
       SqlExpression ex = sqlSelect.OrderBy[0].Expression;
       parent.Bindings.AddRange(request.ParameterBindings);
       
@@ -217,7 +217,7 @@ namespace Xtensive.Orm.BulkOperations
             QueryTranslationResult request = parent.GetRequest(field.ValueType, q);
             parent.Bindings.AddRange(request.ParameterBindings);
             SqlTableColumn c = SqlDml.TableColumn(addContext.Statement.Table, addContext.Field.Columns[i].Name);
-            addContext.Statement.AddValue(c, SqlDml.SubQuery((ISqlQueryExpression) request.Query));
+            addContext.Statement.AddValue(c, SqlDml.SubQuery(request.Query));
           }
           return;
         }

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerAdvancedTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerAdvancedTest.cs
@@ -20,6 +20,7 @@ using Xtensive.Orm.Internals.Prefetch;
 using Xtensive.Orm.Providers;
 using Xtensive.Orm.Rse.Providers;
 using Xtensive.Orm.Tests.Storage.Prefetch.Model;
+using GraphContainerDictionary = System.Collections.Generic.Dictionary<(Xtensive.Orm.Key key, Xtensive.Orm.Model.TypeInfo type), Xtensive.Orm.Internals.Prefetch.GraphContainer>;
 
 namespace Xtensive.Orm.Tests.Storage.Prefetch
 {
@@ -103,9 +104,9 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
         prefetchManager.InvokePrefetch(order0Key, null, new PrefetchFieldDescriptor(EmployeeField, true, true));
         prefetchManager.InvokePrefetch(order1Key, null, new PrefetchFieldDescriptor(EmployeeField, true, true));
-        var graphContainers = (HashSet<GraphContainer>) GraphContainersField.GetValue(prefetchManager);
+        var graphContainers = (GraphContainerDictionary) GraphContainersField.GetValue(prefetchManager);
         Assert.AreEqual(2, graphContainers.Count);
-        Func<Key, ReferencedEntityContainer> taskSelector = containerKey => graphContainers
+        Func<Key, ReferencedEntityContainer> taskSelector = containerKey => graphContainers.Values
           .Where(container => container.Key==containerKey)
           .SelectMany(container => container.ReferencedEntityContainers).Single();
         var entityContainer0 = taskSelector.Invoke(order0Key);
@@ -180,7 +181,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         var prefetchManager = (PrefetchManager) PrefetchProcessorField.GetValue(session.Handler);
         session.Handler.FetchEntityState(orderKey);
         prefetchManager.InvokePrefetch(orderKey, null, new PrefetchFieldDescriptor(DetailsField, null));
-        var graphContainers = (HashSet<GraphContainer>) GraphContainersField.GetValue(prefetchManager);
+        var graphContainers = (GraphContainerDictionary) GraphContainersField.GetValue(prefetchManager);
         Assert.AreEqual(1, graphContainers.Count);
         prefetchManager.ExecuteTasks(true);
         EntitySetState actualState;
@@ -202,8 +203,8 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         prefetchManager.InvokePrefetch(keyWithoutType, Domain.Model.Types[typeof (PersonalProduct)],
           new PrefetchFieldDescriptor(Domain.Model.Types[typeof (PersonalProduct)].Fields["Employee"],
             true, true));
-        var graphContainers = (HashSet<GraphContainer>) GraphContainersField.GetValue(prefetchManager);
-        var referencedEntityContainer = graphContainers
+        var graphContainers = (GraphContainerDictionary) GraphContainersField.GetValue(prefetchManager);
+        var referencedEntityContainer = graphContainers.Values
           .Where(container => container.ReferencedEntityContainers!=null).Single()
           .ReferencedEntityContainers.Single();
         prefetchManager.ExecuteTasks(true);
@@ -218,10 +219,10 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
       using (var session = Domain.OpenSession()) {
         var prefetchManager = (PrefetchManager) PrefetchProcessorField.GetValue(session.Handler);
-        HashSet<GraphContainer> graphContainers;
+        GraphContainerDictionary graphContainers;
         using (var tx = session.OpenTransaction()) {
           prefetchManager.InvokePrefetch(orderKey, null, new PrefetchFieldDescriptor(CustomerField));
-          graphContainers = (HashSet<GraphContainer>) GraphContainersField.GetValue(prefetchManager);
+          graphContainers = (GraphContainerDictionary) GraphContainersField.GetValue(prefetchManager);
           Assert.AreEqual(1, graphContainers.Count);
           tx.Complete();
         }
@@ -251,7 +252,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
       using (var session = Domain.OpenSession())
       using (var tx = session.OpenTransaction()) {
         var prefetchManager = (PrefetchManager) PrefetchProcessorField.GetValue(session.Handler);
-        var graphContainers = (HashSet<GraphContainer>) GraphContainersField.GetValue(prefetchManager);
+        var graphContainers = (GraphContainerDictionary) GraphContainersField.GetValue(prefetchManager);
         var idField = BookType.Fields["Id"];
         for (var i = 1; i < keys.Count; i++) {
           prefetchManager.InvokePrefetch(keys[i - 1], null, new PrefetchFieldDescriptor(idField));

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
@@ -20,6 +20,7 @@ using Xtensive.Orm.Providers;
 using Xtensive.Orm.Rse;
 using Xtensive.Orm.Services;
 using Xtensive.Orm.Tests.Storage.Prefetch.Model;
+using GraphContainerDictionary = System.Collections.Generic.Dictionary<(Xtensive.Orm.Key key, Xtensive.Orm.Model.TypeInfo type), Xtensive.Orm.Internals.Prefetch.GraphContainer>;
 
 namespace Xtensive.Orm.Tests.Storage.Prefetch
 {
@@ -380,12 +381,12 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         var prefetchManager = (PrefetchManager) PrefetchProcessorField.GetValue(session.Handler);
 
         prefetchManager.InvokePrefetch(orderKey, null, new PrefetchFieldDescriptor(EmployeeField, true, true));
-        var graphContainers = (HashSet<GraphContainer>) GraphContainersField.GetValue(prefetchManager);
+        var graphContainers = (GraphContainerDictionary) GraphContainersField.GetValue(prefetchManager);
         Assert.AreEqual(2, graphContainers.Count);
-        foreach (var container in graphContainers)
+        foreach (var container in graphContainers.Values)
           Assert.IsNull(container.ReferencedEntityContainers);
-        var orderContainer = graphContainers.Where(container => container.Key==orderKey).SingleOrDefault();
-        var employeeContainer = graphContainers.Where(container => container.Key!=orderKey).SingleOrDefault();
+        var orderContainer = graphContainers.Values.Where(container => container.Key==orderKey).SingleOrDefault();
+        var employeeContainer = graphContainers.Values.Where(container => container.Key!=orderKey).SingleOrDefault();
         Assert.IsNotNull(orderContainer);
         Assert.IsNotNull(employeeContainer);
         prefetchManager.ExecuteTasks();
@@ -431,9 +432,9 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         var prefetchManager = (PrefetchManager) PrefetchProcessorField.GetValue(session.Handler);
         session.Handler.FetchEntityState(orderKey);
         prefetchManager.InvokePrefetch(orderKey, null, new PrefetchFieldDescriptor(EmployeeField, true, true));
-        var taskContainers = (HashSet<GraphContainer>) GraphContainersField.GetValue(prefetchManager);
+        var taskContainers = (GraphContainerDictionary) GraphContainersField.GetValue(prefetchManager);
         Assert.AreEqual(1, taskContainers.Count);
-        Assert.AreEqual(orderKey, taskContainers.Single().Key);
+        Assert.AreEqual(orderKey, taskContainers.Values.Single().Key);
       }
     }
 

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerTestBase.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerTestBase.cs
@@ -17,6 +17,7 @@ using Xtensive.Orm.Providers;
 using Xtensive.Orm.Tests.Storage.Prefetch.Model;
 using FieldInfo=Xtensive.Orm.Model.FieldInfo;
 using TypeInfo = Xtensive.Orm.Model.TypeInfo;
+using GraphContainerDictionary = System.Collections.Generic.Dictionary<(Xtensive.Orm.Key key, Xtensive.Orm.Model.TypeInfo type), Xtensive.Orm.Internals.Prefetch.GraphContainer>;
 
 namespace Xtensive.Orm.Tests.Storage.Prefetch
 {
@@ -103,7 +104,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
     internal GraphContainer GetSingleGraphContainer(PrefetchManager prefetchManager)
     {
-      return ((IEnumerable<GraphContainer>) GraphContainersField.GetValue(prefetchManager)).Single();
+      return ((GraphContainerDictionary) GraphContainersField.GetValue(prefetchManager)).Values.Single();
     }
 
     internal static bool IsFieldKeyOrSystem(FieldInfo field)

--- a/Orm/Xtensive.Orm.Tests/Storage/QueryBuilderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/QueryBuilderTest.cs
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.That(translated.Query, Is.Not.Null);
         Assert.That(translated.ParameterBindings, Is.Not.Null);
 
-        var select = (SqlSelect) translated.Query;
+        var select = translated.Query;
         select.Columns.Clear();
         select.Columns.Add(SqlDml.Count());
         var compiled = builder.CompileQuery(translated.Query);

--- a/Orm/Xtensive.Orm/Caching/WeakestCache.cs
+++ b/Orm/Xtensive.Orm/Caching/WeakestCache.cs
@@ -236,9 +236,7 @@ namespace Xtensive.Caching
     public override void RemoveKey(TKey key)
     {
       ArgumentValidator.EnsureArgumentNotNull(key, "key");
-      WeakEntry entry;
-      if (items.TryGetValue(key, out entry)) {
-        items.Remove(key);
+      if (items.Remove(key, out var entry)) {
         entry.Dispose();
       }
     }

--- a/Orm/Xtensive.Orm/Collections/ExtensionCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/ExtensionCollection.cs
@@ -153,12 +153,13 @@ namespace Xtensive.Collections
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
       if (source.Count==0)
         return;
-      var sourceLikeMe = source as ExtensionCollection;
-      if (sourceLikeMe!=null)
+      if (source is ExtensionCollection sourceLikeMe) {
         extensions = new Dictionary<Type, object>(sourceLikeMe.extensions);
-      else
+      }
+      else {
         foreach (Type extensionType in source)
           Set(extensionType, source.Get(extensionType));
+      }
     }
   }
 }

--- a/Orm/Xtensive.Orm/Collections/Graphs/TopologicalSorter.cs
+++ b/Orm/Xtensive.Orm/Collections/Graphs/TopologicalSorter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2003-2012 Xtensive LLC.
+// Copyright (C) 2003-2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alex Yakunin
@@ -41,10 +41,8 @@ namespace Xtensive.Collections.Graphs
 
       public void Remove(T item)
       {
-        LinkedListNode<T> node;
-        if (map.TryGetValue(item, out node)) {
+        if (map.Remove(item, out var node)) {
           list.Remove(node);
-          map.Remove(item);
         }
       }
 
@@ -104,8 +102,7 @@ namespace Xtensive.Collections.Graphs
 
     restart:
       // Sorting
-      while (nodesWithoutIncomingEdges.Count!=0) {
-        var node = nodesWithoutIncomingEdges.Dequeue();
+      while (nodesWithoutIncomingEdges.TryDequeue(out var node)) {
         if (unsortedNodes!=null) // Break edges
           unsortedNodes.Remove(node);
         else
@@ -126,8 +123,7 @@ namespace Xtensive.Collections.Graphs
       if (unsortedNodes!=null) { // Break edges
         if (unsortedNodes.Count != 0) {
           // Trying to break edges (collection is always empty when breakEdges==false)
-          while (breakableEdges.Count != 0) {
-            var edge = breakableEdges.Dequeue();
+          while (breakableEdges.TryDequeue(out var edge)) {
             if (!edge.IsAttached || !edgeBreaker(edge))
               continue;
             result.BrokenEdges.Add(edge);

--- a/Orm/Xtensive.Orm/Collections/TopDeque.cs
+++ b/Orm/Xtensive.Orm/Collections/TopDeque.cs
@@ -253,10 +253,8 @@ namespace Xtensive.Collections
     /// <inheritdoc/>
     public void Remove(K key)
     {
-      LinkedListNode<Pair<K, V>> valueContainer;
-      if (map.TryGetValue(key, out valueContainer)) {
+      if (map.Remove(key, out var valueContainer)) {
         list.Remove(valueContainer);
-        map.Remove(key);
       }
     }
 

--- a/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
+++ b/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
@@ -61,12 +61,9 @@ namespace Xtensive.Collections
       ArgumentValidator.EnsureArgumentNotNull(type, "type");
       if (!isProcessingPendingActions)
         Register(new TypeRegistration(type));
-      else {
-        if (typeSet.Contains(type))
-          return;
+      else if (typeSet.Add(type)) {
         serviceRegistrations = null;
         types.Add(type);
-        typeSet.Add(type);
         assemblies.Add(type.Assembly);
       }
     }

--- a/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Comparison
   /// Describes how to compare values of comparable objects.
   /// </summary>
   [Serializable]
-  public struct ComparisonRule :
+  public readonly struct ComparisonRule :
     IEquatable<ComparisonRule>,
     ISerializable
   {
@@ -75,12 +75,8 @@ namespace Xtensive.Comparison
     #region Equals, GetHashCode
 
     /// <inheritdoc/>
-    public bool Equals(ComparisonRule other)
-    {
-      if (Direction != other.Direction)
-        return false;
-      return Equals(Culture, other.Culture);
-    }
+    public bool Equals(ComparisonRule other) =>
+      Direction == other.Direction && Equals(Culture, other.Culture);
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Comparer.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Comparer.cs
@@ -296,11 +296,13 @@ namespace Xtensive.Modelling.Comparison
             continue;
 
           if (any.Nesting.PropertyInfo != null && accessor.DependencyRootType==any.Nesting.PropertyInfo.PropertyType) {
-            if (propertyDifference is NodeDifference)
-              ((NodeDifference) propertyDifference).IsDependentOnParent = true;
-            else if (propertyDifference is NodeCollectionDifference)
-              ((NodeCollectionDifference) propertyDifference).ItemChanges
+            if (propertyDifference is NodeDifference nodeDifference) {
+              nodeDifference.IsDependentOnParent = true;
+            }
+            else if (propertyDifference is NodeCollectionDifference nodeCollectionDifference) {
+              nodeCollectionDifference.ItemChanges
                 .ForEach(item=>item.IsDependentOnParent = true);
+            }
           }
           difference.PropertyChanges.Add(property.Name, propertyDifference);
         }
@@ -411,12 +413,12 @@ namespace Xtensive.Modelling.Comparison
         return difference.ItemChanges.Count != 0 ? difference : null;
       }
     }
-    
+
     // Sort by items only with source, then by (target ?? source).Index then with source and target and then only with target
     private static int CompareNodeDifference(NodeDifference curr, NodeDifference other)
     {
-      var currType = curr.Source != null && curr.Target != null ? 1 : curr.Source == null ? 3 : 0; 
-      var otherType = other.Source != null && other.Target != null ? 1 : other.Source == null ? 3 : 0; 
+      var currType = curr.Source != null && curr.Target != null ? 1 : curr.Source == null ? 3 : 0;
+      var otherType = other.Source != null && other.Target != null ? 1 : other.Source == null ? 3 : 0;
       var typeIsNot0Comparison = (currType != 0).CompareTo(otherType != 0);
       if (typeIsNot0Comparison != 0) {
         return typeIsNot0Comparison;
@@ -590,10 +592,10 @@ namespace Xtensive.Modelling.Comparison
     /// <returns>Comparison key for the specified node.</returns>
     protected virtual string GetNodeComparisonKey(Node node)
     {
-      if (!(node is INodeReference))
+      if (!(node is INodeReference nodeReference))
         return GetTargetName(node);
 
-      var targetNode = ((INodeReference) node).Value;
+      var targetNode = nodeReference.Value;
       return targetNode==null ? null : GetTargetPath(targetNode);
     }
 

--- a/Orm/Xtensive.Orm/Modelling/NodeCollection.cs
+++ b/Orm/Xtensive.Orm/Modelling/NodeCollection.cs
@@ -252,8 +252,7 @@ namespace Xtensive.Modelling
       string name = node.Name;
       try {
         list.RemoveAt(index);
-        if (nameIndex.ContainsKey(name))
-          nameIndex.Remove(name);
+        nameIndex.Remove(name);
         OnCollectionChanged(new NotifyCollectionChangedEventArgs(
           NotifyCollectionChangedAction.Remove, index));
       }
@@ -309,21 +308,18 @@ namespace Xtensive.Modelling
     internal void AddName(Node node)
     {
       this.EnsureNotLocked();
-      string name = node.Name;
-      if (nameIndex.ContainsKey(name))
+      if (!nameIndex.TryAdd(node.Name, node)) {
         throw Exceptions.InternalError("Wrong NodeCollection.AddName arguments: nameIndex[node.Name]!=null!", CoreLog.Instance);
-      nameIndex.Add(name, node);
+      }
     }
 
     /// <exception cref="InvalidOperationException">Internal error.</exception>
     internal void CheckIntegrity()
     {
       foreach (var node in list) {
-        var name = node.Name;
-        if (!nameIndex.ContainsKey(name))
+        if (!nameIndex.TryGetValue(node.Name, out var value) || value != node) {
           throw Exceptions.InternalError("Integrity check failed.", CoreLog.Instance);
-        if (node!=nameIndex[name])
-          throw Exceptions.InternalError("Integrity check failed.", CoreLog.Instance);
+        }
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClusteredIndexes.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClusteredIndexes.cs
@@ -22,8 +22,7 @@ namespace Xtensive.Orm.Building.Builders
         var queue = new Queue<TypeInfo>();
         var clusteredIndexesMap = new Dictionary<TypeInfo, IndexInfo>();
         queue.Enqueue(hierarchy.Root);
-        while (queue.Count > 0) {
-          var type = queue.Dequeue();
+        while (queue.TryDequeue(out var type)) {
           foreach (var decendant in type.GetDescendants())
             queue.Enqueue(decendant);
           var clusteredIndexes = type.Indexes

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.FullText.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.FullText.cs
@@ -127,8 +127,7 @@ namespace Xtensive.Orm.Building.Builders
         ftid => model.Types[ftid.Type.UnderlyingType],
         ftid => new List<FullTextIndexDef>() {ftid});
 
-      while (processQueue.Count > 0) {
-        var type = processQueue.Dequeue();
+      while (processQueue.TryDequeue(out var type)) {
         List<FullTextIndexDef> indexes;
         List<FullTextIndexDef> parentIndexes;
         var typeHasIndexDef = indexDefs.TryGetValue(type, out indexes);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelDefBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelDefBuilder.cs
@@ -28,8 +28,7 @@ namespace Xtensive.Orm.Building.Builders
       var closedGenericTypes = new List<Type>();
       var openGenericTypes = new List<Type>();
 
-      while (types.Count != 0) {
-        var type = types.Dequeue();
+      while (types.TryDequeue(out var type)) {
         if (!IsTypeAvailable(type)) {
           continue;
         }

--- a/Orm/Xtensive.Orm/Orm/Building/FixupActionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/FixupActionProcessor.cs
@@ -28,8 +28,7 @@ namespace Xtensive.Orm.Building
     private void ProcessAll()
     {
       using (BuildLog.InfoRegion(Strings.LogProcessingFixupActions))
-        while (context.ModelInspectionResult.Actions.Count > 0) {
-          var action = context.ModelInspectionResult.Actions.Dequeue();
+        while (context.ModelInspectionResult.Actions.TryDequeue(out var action)) {
           BuildLog.Info(string.Format(Strings.LogExecutingActionX, action));
           action.Run(this);
         }
@@ -103,8 +102,7 @@ namespace Xtensive.Orm.Building
           where !root.IsSystem && !root.IsAutoGenericInstance
           select root.UnderlyingType);
         var types = new List<Type>();
-        while (queue.Count > 0) {
-          var candidate = queue.Dequeue();
+        while (queue.TryDequeue(out var candidate)) {
           if (constraints.All(ct => ct.IsAssignableFrom(candidate)))
             // First suitable descendant is found
             types.Add(candidate);
@@ -146,8 +144,7 @@ namespace Xtensive.Orm.Building
       var queue = new Queue<TypeDef>();
       var interfaces = new HashSet<TypeDef>();
       queue.Enqueue(type);
-      while (queue.Count > 0) {
-        var item = queue.Dequeue();
+      while (queue.TryDequeue(out var item)) {
         foreach (var @interface in context.ModelDef.Types.FindInterfaces(item.UnderlyingType)) {
           queue.Enqueue(@interface);
           interfaces.Add(@interface);

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -119,8 +119,9 @@ namespace Xtensive.Orm
 
     internal KeyGeneratorRegistry KeyGenerators { get; private set; }
 
-    internal ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; private set; }
-    
+    internal ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; } =
+       new ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>>();
+
     internal ICache<object, Pair<object, ParameterizedQuery>> QueryCache { get; private set; }
 
     internal ICache<Key, Key> KeyCache { get; private set; }
@@ -420,7 +421,6 @@ namespace Xtensive.Orm
       GenericKeyFactories = new ConcurrentDictionary<TypeInfo, GenericKeyFactory>();
       EntityDataReader = new EntityDataReader(this);
       KeyGenerators = new KeyGeneratorRegistry();
-      PrefetchFieldDescriptorCache = new ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>>();
       KeyCache = new LruCache<Key, Key>(Configuration.KeyCacheSize, k => k);
       QueryCache = new FastConcurrentLruCache<object, Pair<object, ParameterizedQuery>>(Configuration.QueryCacheSize, k => k.First);
       PrefetchActionMap = new Dictionary<TypeInfo, Action<SessionHandler, IEnumerable<Key>>>();

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -119,8 +119,7 @@ namespace Xtensive.Orm
 
     internal KeyGeneratorRegistry KeyGenerators { get; private set; }
 
-    internal ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; } =
-       new ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>>();
+    internal ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; }
 
     internal ICache<object, Pair<object, ParameterizedQuery>> QueryCache { get; private set; }
 
@@ -421,6 +420,7 @@ namespace Xtensive.Orm
       GenericKeyFactories = new ConcurrentDictionary<TypeInfo, GenericKeyFactory>();
       EntityDataReader = new EntityDataReader(this);
       KeyGenerators = new KeyGeneratorRegistry();
+      PrefetchFieldDescriptorCache = new ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>>();
       KeyCache = new LruCache<Key, Key>(Configuration.KeyCacheSize, k => k);
       QueryCache = new FastConcurrentLruCache<object, Pair<object, ParameterizedQuery>>(Configuration.QueryCacheSize, k => k.First);
       PrefetchActionMap = new Dictionary<TypeInfo, Action<SessionHandler, IEnumerable<Key>>>();

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
@@ -13,11 +13,10 @@ using Xtensive.Core;
 
 namespace Xtensive.Orm.Internals.Prefetch
 {
-  internal sealed class Fetcher
+  internal readonly struct Fetcher
   {
-    private readonly HashSet<EntityGroupTask> tasks = new HashSet<EntityGroupTask>();
-    private readonly HashSet<Key> foundKeys = new HashSet<Key>();
-
+    private readonly HashSet<EntityGroupTask> tasks;
+    private readonly HashSet<Key> foundKeys;
     private readonly PrefetchManager manager;
 
     public async ValueTask<int> ExecuteTasks(IReadOnlyCollection<GraphContainer> containers, bool skipPersist,
@@ -126,6 +125,8 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public Fetcher(PrefetchManager manager)
     {
+      tasks = new HashSet<EntityGroupTask>();
+      foundKeys = new HashSet<Key>();
       ArgumentValidator.EnsureArgumentNotNull(manager, nameof(manager));
       this.manager = manager;
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchHelper.cs
@@ -13,18 +13,16 @@ namespace Xtensive.Orm.Internals.Prefetch
 {
   internal static class PrefetchHelper
   {
-    public static bool IsFieldToBeLoadedByDefault(FieldInfo field)
-    {
-      return field.IsPrimaryKey || field.IsSystem || (!field.IsLazyLoad && !field.IsEntitySet);
-    }
-
-    public static IReadOnlyList<PrefetchFieldDescriptor> CreateDescriptorsForFieldsLoadedByDefault(TypeInfo type)
-    {
-      return type.Fields
+    private static readonly Func<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> CreateDescriptorsForFieldsLoadedByDefault = type =>
+      type.Fields
         .Where(field => field.Parent == null && IsFieldToBeLoadedByDefault(field))
         .Select(field => new PrefetchFieldDescriptor(field, false, false))
         .ToList()
         .AsReadOnly();
+
+    public static bool IsFieldToBeLoadedByDefault(FieldInfo field)
+    {
+      return field.IsPrimaryKey || field.IsSystem || (!field.IsLazyLoad && !field.IsEntitySet);
     }
 
     public static IReadOnlyList<PrefetchFieldDescriptor> GetCachedDescriptorsForFieldsLoadedByDefault(Domain domain, TypeInfo type)

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchKeyIterator.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchKeyIterator.cs
@@ -51,8 +51,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         }
 
         if (unknownTypeQueue.Count > 0) {
-          while (unknownTypeQueue.Count > 0) {
-            var unknownKey = unknownTypeQueue.Dequeue();
+          while (unknownTypeQueue.TryDequeue(out var unknownKey)) {
             var unknownType = session.EntityStateCache[unknownKey, false].Type;
             var unknownDescriptors =
               PrefetchHelper.GetCachedDescriptorsForFieldsLoadedByDefault(session.Domain, unknownType);
@@ -62,8 +61,8 @@ namespace Xtensive.Orm.Internals.Prefetch
           session.Handler.ExecutePrefetchTasks();
         }
 
-        while (resultQueue.Count > 0) {
-          yield return (T) (IEntity) session.EntityStateCache[resultQueue.Dequeue(), true].Entity;
+        while (resultQueue.TryDequeue(out var item)) {
+          yield return (T) (IEntity) session.EntityStateCache[item, true].Entity;
         }
 
         taskCount = session.Handler.PrefetchTaskExecutionCount;
@@ -106,8 +105,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         }
 
         if (unknownTypeQueue.Count > 0) {
-          while (unknownTypeQueue.Count > 0) {
-            var unknownKey = unknownTypeQueue.Dequeue();
+          while (unknownTypeQueue.TryDequeue(out var unknownKey)) {
             var unknownType = session.EntityStateCache[unknownKey, false].Type;
             var unknownDescriptors =
               PrefetchHelper.GetCachedDescriptorsForFieldsLoadedByDefault(session.Domain, unknownType);
@@ -118,8 +116,8 @@ namespace Xtensive.Orm.Internals.Prefetch
           await session.Handler.ExecutePrefetchTasksAsync(token).ConfigureAwait(false);
         }
 
-        while (resultQueue.Count > 0) {
-          yield return (T) (IEntity) session.EntityStateCache[resultQueue.Dequeue(), true].Entity;
+        while (resultQueue.TryDequeue(out var item)) {
+          yield return (T) (IEntity) session.EntityStateCache[item, true].Entity;
         }
 
         taskCount = session.Handler.PrefetchTaskExecutionCount;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchQueryEnumerable.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchQueryEnumerable.cs
@@ -46,16 +46,16 @@ namespace Xtensive.Orm.Internals.Prefetch
         while (container.JoinIfPossible(sessionHandler.ExecutePrefetchTasks())) {
           _ = container.JoinIfPossible(ProcessFetchedElements(enumerationIdentifier));
         }
-        while (resultQueue.Count > 0) {
-          yield return resultQueue.Dequeue();
+        while (resultQueue.TryDequeue(out var queueElement)) {
+          yield return queueElement;
         }
         currentTaskCount = sessionHandler.PrefetchTaskExecutionCount;
       }
       while (container.JoinIfPossible(sessionHandler.ExecutePrefetchTasks())) {
         _ = container.JoinIfPossible(ProcessFetchedElements(enumerationIdentifier));
       }
-      while (resultQueue.Count > 0) {
-        yield return resultQueue.Dequeue();
+      while (resultQueue.TryDequeue(out var queueElement)) {
+        yield return queueElement;
       }
     }
 
@@ -96,8 +96,7 @@ namespace Xtensive.Orm.Internals.Prefetch
     private StrongReferenceContainer ProcessFetchedElements(Guid enumerationId)
     {
       var container = new StrongReferenceContainer(null);
-      while (unknownTypeQueue.Count > 0) {
-        var unknownKey = unknownTypeQueue.Dequeue();
+      while (unknownTypeQueue.TryDequeue(out var unknownKey)) {
         var unknownType = session.EntityStateCache[unknownKey, false].Type;
         var unknownDescriptors = PrefetchHelper.GetCachedDescriptorsForFieldsLoadedByDefault(session.Domain, unknownType);
         _ = sessionHandler.Prefetch(unknownKey, unknownType, unknownDescriptors);

--- a/Orm/Xtensive.Orm/Orm/Internals/ReferentialIntegrity/RemovalContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/ReferentialIntegrity/RemovalContext.cs
@@ -40,8 +40,7 @@ namespace Xtensive.Orm.ReferentialIntegrity
 
     public List<Entity> GatherEntitiesForProcessing()
     {
-      while (types.Count > 0) {
-        var type = types.Dequeue();
+      while (types.TryDequeue(out var type)) {
         var list = queue[type];
         if (list.Count == 0) {
           continue;

--- a/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Linq
     {
       // TODO: AG: Take info from storage!
       type = type.StripNullable();
-      return type.IsPrimitive || 
+      return type.IsPrimitive ||
         type.IsEnum ||
         type==WellKnownTypes.ByteArray ||
         type==WellKnownTypes.Decimal ||
@@ -112,44 +112,43 @@ namespace Xtensive.Orm.Linq
       if (item==null)
         return;
       // LocalCollectionExpression
-      if (expression is LocalCollectionExpression) {
-        var itemExpression = (LocalCollectionExpression) expression;
-        foreach (var field in itemExpression.Fields) {
-          var propertyInfo = field.Key as PropertyInfo;
-          object value = propertyInfo==null
-            ? ((FieldInfo) field.Key).GetValue(item)
-            : propertyInfo.GetValue(item, BindingFlags.InvokeMethod, null, null, null);
-          if (value!=null)
-            FillLocalCollectionField(value, tuple, (Expression) field.Value);
+      switch (expression) {
+        case LocalCollectionExpression itemExpression:
+          foreach (var field in itemExpression.Fields) {
+            var propertyInfo = field.Key as PropertyInfo;
+            object value = propertyInfo==null
+              ? ((FieldInfo) field.Key).GetValue(item)
+              : propertyInfo.GetValue(item, BindingFlags.InvokeMethod, null, null, null);
+            if (value!=null)
+              FillLocalCollectionField(value, tuple, (Expression) field.Value);
+          }
+          break;
+        case ColumnExpression columnExpression:
+          tuple.SetValue(columnExpression.Mapping.Offset, item);
+          break;
+        case StructureExpression structureExpression:
+          var structure = (Structure) item;
+          var typeInfo = structureExpression.PersistentType;
+          var tupleDescriptor = typeInfo.TupleDescriptor;
+          var tupleSegment = new Segment<int>(0, tupleDescriptor.Count);
+          var structureTuple = structure.Tuple.GetSegment(tupleSegment);
+          structureTuple.CopyTo(tuple, 0, structureExpression.Mapping.Offset, structureTuple.Count);
+          break;
+        case EntityExpression entityExpression: {
+          var entity = (Entity) item;
+          var keyTuple = entity.Key.Value;
+          keyTuple.CopyTo(tuple, 0, entityExpression.Key.Mapping.Offset, keyTuple.Count);
         }
+        break;
+        case KeyExpression keyExpression: {
+          var key = (Key) item;
+          var keyTuple = key.Value;
+          keyTuple.CopyTo(tuple, 0, keyExpression.Mapping.Offset, keyTuple.Count);
+        }
+        break;
+        default:
+          throw new NotSupportedException();
       }
-      else if (expression is ColumnExpression) {
-        var columnExpression = (ColumnExpression) expression;
-        tuple.SetValue(columnExpression.Mapping.Offset, item);
-      }
-      else if (expression is StructureExpression) {
-        var structureExpression = (StructureExpression) expression;
-        var structure = (Structure) item;
-        var typeInfo = structureExpression.PersistentType;
-        var tupleDescriptor = typeInfo.TupleDescriptor;
-        var tupleSegment = new Segment<int>(0, tupleDescriptor.Count);
-        var structureTuple = structure.Tuple.GetSegment(tupleSegment);
-        structureTuple.CopyTo(tuple, 0, structureExpression.Mapping.Offset, structureTuple.Count);
-      }
-      else if (expression is EntityExpression) {
-        var entityExpression = (EntityExpression) expression;
-        var entity = (Entity) item;
-        var keyTuple = entity.Key.Value;
-        keyTuple.CopyTo(tuple, 0, entityExpression.Key.Mapping.Offset, keyTuple.Count);
-      }
-      else if (expression is KeyExpression) {
-        var keyExpression = (KeyExpression) expression;
-        var key = (Key) item;
-        var keyTuple = key.Value;
-        keyTuple.CopyTo(tuple, 0, keyExpression.Mapping.Offset, keyTuple.Count);
-      }
-      else
-        throw new NotSupportedException();
     }
 
     private LocalCollectionExpression BuildLocalCollectionExpression(Type type, HashSet<Type> processedTypes, ref int columnIndex, MemberInfo parentMember, TupleTypeCollection types)

--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -321,8 +321,8 @@ namespace Xtensive.Orm.Linq.MemberCompilation
         else if (canonicalMember is MethodInfo methodInfo) {
           canonicalMember = GetCanonicalMethod(methodInfo, targetType.GetMethods());
         }
-        else if (canonicalMember is ConstructorInfo)
-          canonicalMember = GetCanonicalMethod((ConstructorInfo) canonicalMember, targetType.GetConstructors());
+        else if (canonicalMember is ConstructorInfo constructorInfo)
+          canonicalMember = GetCanonicalMethod(constructorInfo, targetType.GetConstructors());
         else
           canonicalMember = null;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -702,12 +702,12 @@ namespace Xtensive.Orm.Linq
       var leftIsConstant = context.Evaluator.CanBeEvaluated(left);
       bool leftOrRightIsIndex = false;
 
-      if (left is IndexExpression) {
-        left = VisitIndex((IndexExpression) left);
+      if (left is IndexExpression leftIndexExpression) {
+        left = VisitIndex(leftIndexExpression);
         leftOrRightIsIndex = true;
       }
-      if (right is IndexExpression) {
-        right = VisitIndex((IndexExpression) right);
+      if (right is IndexExpression rightIndexExpression) {
+        right = VisitIndex(rightIndexExpression);
         leftOrRightIsIndex = true;
       }
 
@@ -975,12 +975,13 @@ namespace Xtensive.Orm.Linq
       Type structureType)
     {
       expression = expression.StripCasts();
-      if (expression is IPersistentExpression)
-        return ((IPersistentExpression) expression)
+      if (expression is IPersistentExpression persistentExpression) {
+        return persistentExpression
           .Fields
           .Where(field => field.GetMemberType()==MemberType.Primitive)
           .Select(e => (Expression) e)
           .ToList();
+      }
 
       ConstantExpression nullExpression = Expression.Constant(null, structureType);
       BinaryExpression isNullExpression = Expression.Equal(expression, nullExpression);
@@ -1036,8 +1037,9 @@ namespace Xtensive.Orm.Linq
     private static IList<Expression> GetEntityFields(Expression expression, IEnumerable<Type> keyFieldTypes)
     {
       expression = expression.StripCasts();
-      if (expression is IEntityExpression)
-        return GetKeyFields(((IEntityExpression) expression).Key, null);
+      if (expression is IEntityExpression entityExpression) {
+        return GetKeyFields(entityExpression.Key, null);
+      }
 
 
       Expression keyExpression;

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1594,7 +1594,10 @@ namespace Xtensive.Orm.Linq
     {
       var storedEntityType = translator.State.TypeOfEntityStoredInKey;
       var itemToTupleConverter = ItemToTupleConverter.BuildConverter(itemType, storedEntityType, value, translator.context.Model, sourceExpression);
-      var rsHeader = new RecordSetHeader(itemToTupleConverter.TupleDescriptor, itemToTupleConverter.TupleDescriptor.Select(x => new SystemColumn(translator.context.GetNextColumnAlias(), 0, x)).Cast<Column>());
+      var rsHeader = new RecordSetHeader(
+        itemToTupleConverter.TupleDescriptor,
+        itemToTupleConverter.TupleDescriptor.Select(x => new SystemColumn(translator.context.GetNextColumnAlias(), 0, x)).Cast<Column>().ToArray(itemToTupleConverter.TupleDescriptor.Count)
+      );
       var rawProvider = new RawProvider(rsHeader, itemToTupleConverter.GetEnumerable());
       var recordset = new StoreProvider(rawProvider);
       var itemProjector = new ItemProjectorExpression(itemToTupleConverter.Expression, recordset, translator.context);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1594,10 +1594,12 @@ namespace Xtensive.Orm.Linq
     {
       var storedEntityType = translator.State.TypeOfEntityStoredInKey;
       var itemToTupleConverter = ItemToTupleConverter.BuildConverter(itemType, storedEntityType, value, translator.context.Model, sourceExpression);
-      var rsHeader = new RecordSetHeader(
-        itemToTupleConverter.TupleDescriptor,
-        itemToTupleConverter.TupleDescriptor.Select(x => new SystemColumn(translator.context.GetNextColumnAlias(), 0, x)).Cast<Column>().ToArray(itemToTupleConverter.TupleDescriptor.Count)
-      );
+      var tupleDescriptor = itemToTupleConverter.TupleDescriptor;
+      var columns = tupleDescriptor
+        .Select(x => new SystemColumn(translator.context.GetNextColumnAlias(), 0, x))
+        .Cast<Column>()
+        .ToArray(tupleDescriptor.Count);
+      var rsHeader = new RecordSetHeader(tupleDescriptor, columns);
       var rawProvider = new RawProvider(rsHeader, itemToTupleConverter.GetEnumerable());
       var recordset = new StoreProvider(rawProvider);
       var itemProjector = new ItemProjectorExpression(itemToTupleConverter.Expression, recordset, translator.context);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1593,16 +1593,17 @@ namespace Xtensive.Orm.Linq
     private static ProjectionExpression CreateLocalCollectionProjectionExpression(Type itemType, object value, Translator translator, Expression sourceExpression)
     {
       var storedEntityType = translator.State.TypeOfEntityStoredInKey;
-      var itemToTupleConverter = ItemToTupleConverter.BuildConverter(itemType, storedEntityType, value, translator.context.Model, sourceExpression);
+      var translatorContext = translator.context;
+      var itemToTupleConverter = ItemToTupleConverter.BuildConverter(itemType, storedEntityType, value, translatorContext.Model, sourceExpression);
       var tupleDescriptor = itemToTupleConverter.TupleDescriptor;
       var columns = tupleDescriptor
-        .Select(x => new SystemColumn(translator.context.GetNextColumnAlias(), 0, x))
+        .Select(x => new SystemColumn(translatorContext.GetNextColumnAlias(), 0, x))
         .Cast<Column>()
         .ToArray(tupleDescriptor.Count);
       var rsHeader = new RecordSetHeader(tupleDescriptor, columns);
       var rawProvider = new RawProvider(rsHeader, itemToTupleConverter.GetEnumerable());
       var recordset = new StoreProvider(rawProvider);
-      var itemProjector = new ItemProjectorExpression(itemToTupleConverter.Expression, recordset, translator.context);
+      var itemProjector = new ItemProjectorExpression(itemToTupleConverter.Expression, recordset, translatorContext);
       if (translator.State.JoinLocalCollectionEntity)
         itemProjector = EntityExpressionJoiner.JoinEntities(translator, itemProjector);
       return new ProjectionExpression(itemType, itemProjector, TranslatedQuery.EmptyTupleParameterBindings);

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
@@ -17,23 +17,23 @@ namespace Xtensive.Orm.Model
   /// </summary>
   [Serializable]
   [DebuggerDisplay("Type = {TypeInfoRef}, Keys = {Keys}, Columns = {Columns}")]
-  public sealed class ColumnGroup
+  public readonly struct ColumnGroup
   {
     /// <summary>
     /// Gets the <see cref="Model.TypeInfoRef"/> pointing to <see cref="TypeInfo"/>
     /// this column group belongs to.
     /// </summary>
-    public TypeInfoRef TypeInfoRef { get; private set; }
+    public TypeInfoRef TypeInfoRef { get; }
 
     /// <summary>
     /// Gets the indexes of key columns.
     /// </summary>
-    public IReadOnlyList<int> Keys { get; private set; }
+    public IReadOnlyList<int> Keys { get; }
 
     /// <summary>
     /// Gets the indexes of all columns.
     /// </summary>
-    public IReadOnlyList<int> Columns { get; private set; }
+    public IReadOnlyList<int> Columns { get; }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2007.09.21
 
@@ -18,52 +18,44 @@ namespace Xtensive.Orm.Model
   /// </summary>
   [Serializable]
   [DebuggerDisplay("TypeName = {TypeName}, FieldName = {FieldName}, ColumnName = {ColumnName}, CultureInfo = {CultureInfo}")]
-  public sealed class ColumnInfoRef: IEquatable<ColumnInfoRef>
+  public readonly struct ColumnInfoRef: IEquatable<ColumnInfoRef>
   {
     /// <summary>
     /// Gets type name of reflecting <see cref="TypeInfo"/>.
     /// </summary>
-    public string TypeName { get; private set; }
+    public string TypeName { get; }
 
     /// <summary>
     /// Gets name of the <see cref="FieldInfo"/>.
     /// </summary>
-    public string FieldName { get; private set; }
+    public string FieldName { get; }
 
     /// <summary>
     /// Gets name of the <see cref="ColumnInfo"/>.
     /// </summary>
-    public string ColumnName { get; private set; }
+    public string ColumnName { get; }
 
     /// <summary>
     /// Gets <see cref="CultureInfo"/> info of the <see cref="ColumnInfo"/>.
     /// </summary>
-    public CultureInfo CultureInfo { get; private set; }
+    public CultureInfo CultureInfo { get; }
 
     /// <summary>
     /// Resolves this instance to <see cref="ColumnInfo"/> object within specified <paramref name="model"/>.
     /// </summary>
     /// <param name="model">Domain model.</param>
-    public ColumnInfo Resolve(DomainModel model)
-    {
-      TypeInfo type;
-      if (!model.Types.TryGetValue(TypeName, out type))
-        throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "type", TypeName));
-      FieldInfo field;
-      if (!type.Fields.TryGetValue(FieldName, out field))
-        throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "field", FieldName));
-      if (field.Column == null)
-        throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "column", ColumnName));
-      return field.Column;
-    }
+    public ColumnInfo Resolve(DomainModel model) =>
+      !model.Types.TryGetValue(TypeName, out var type)
+        ? throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "type", TypeName))
+        : !type.Fields.TryGetValue(FieldName, out var field)
+          ? throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "field", FieldName))
+          : field.Column ?? throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "column", ColumnName));
 
     /// <summary>
     /// Creates reference for <see cref="ColumnInfo"/>.
     /// </summary>
-    public static implicit operator ColumnInfoRef (ColumnInfo columnInfo)
-    {
-      return new ColumnInfoRef(columnInfo);
-    }
+    public static implicit operator ColumnInfoRef(ColumnInfo columnInfo) => 
+      new ColumnInfoRef(columnInfo);
 
     #region Equality members, ==, !=
 
@@ -75,10 +67,7 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator !=(ColumnInfoRef x, ColumnInfoRef y)
-    {
-      return !Equals(x, y);
-    }
+    public static bool operator !=(in ColumnInfoRef x, in ColumnInfoRef y) => !x.Equals(y);
 
     /// <summary>
     /// Implements the operator ==.
@@ -88,47 +77,31 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator ==(ColumnInfoRef x, ColumnInfoRef y)
-    {
-      return Equals(x, y);
-    }
+    public static bool operator ==(in ColumnInfoRef x, in ColumnInfoRef y) => x.Equals(y);
 
     /// <inheritdoc/>
-    public bool Equals(ColumnInfoRef other)
-    {
-      if (ReferenceEquals(other, null))
-        return false;
-      return 
-        FieldName==other.FieldName && TypeName==other.TypeName;
-    }
+    public bool Equals(ColumnInfoRef other) =>
+        FieldName == other.FieldName && TypeName == other.TypeName;
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(this, obj))
-        return true;
-      return Equals(obj as ColumnInfoRef);
-    }
+    public override bool Equals(object obj) =>
+      obj is ColumnInfoRef other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return unchecked( FieldName.GetHashCode() + 29*TypeName.GetHashCode() );
-    }
+    public override int GetHashCode() =>
+      HashCode.Combine(FieldName, TypeName);
 
     #endregion
 
     /// <inheritdoc/>
-    public override string ToString()
-    {
-      return $"{TypeName}.{FieldName} ({ColumnName})";
-    }
+    public override string ToString() =>
+      $"{TypeName}.{FieldName} ({ColumnName})";
 
 
     // Constructors
 
     /// <summary>
-    ///   Initializes a new instance of this class.
+    ///   Initializes a new instance of this struct.
     /// </summary>
     /// <param name="columnInfo">The <see cref="ColumnInfo"/> instance.</param>
     public ColumnInfoRef(ColumnInfo columnInfo)
@@ -142,7 +115,7 @@ namespace Xtensive.Orm.Model
 
 
     /// <summary>
-    ///   Initializes a new instance of this class.
+    ///   Initializes a new instance of this struct.
     /// </summary>
     /// <param name="typeName">Column type name.</param>
     /// <param name="columnName">Column name.</param>

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
@@ -40,6 +40,8 @@ namespace Xtensive.Orm.Model
     /// </summary>
     public CultureInfo CultureInfo { get; }
 
+    public bool HasValue => TypeName != null;
+
     /// <summary>
     /// Resolves this instance to <see cref="ColumnInfo"/> object within specified <paramref name="model"/>.
     /// </summary>

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
@@ -40,8 +40,6 @@ namespace Xtensive.Orm.Model
     /// </summary>
     public CultureInfo CultureInfo { get; }
 
-    public bool HasValue => TypeName != null;
-
     /// <summary>
     /// Resolves this instance to <see cref="ColumnInfo"/> object within specified <paramref name="model"/>.
     /// </summary>

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
@@ -51,12 +51,6 @@ namespace Xtensive.Orm.Model
           ? throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "field", FieldName))
           : field.Column ?? throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "column", ColumnName));
 
-    /// <summary>
-    /// Creates reference for <see cref="ColumnInfo"/>.
-    /// </summary>
-    public static implicit operator ColumnInfoRef(ColumnInfo columnInfo) => 
-      new ColumnInfoRef(columnInfo);
-
     #region Equality members, ==, !=
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Model/Stored/StoredFieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Stored/StoredFieldInfo.cs
@@ -70,8 +70,7 @@ namespace Xtensive.Orm.Model.Stored
         else {
           var queue = new Queue<StoredFieldInfo>();
           queue.Enqueue(this);
-          while (queue.Count > 0) {
-            var field = queue.Dequeue();
+          while (queue.TryDequeue(out var field)) {
             if (field.IsPrimitive)
               result.Add(field);
             else

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -45,12 +45,12 @@ namespace Xtensive.Orm.Model
     private readonly NodeCollection<IndexInfo> affectedIndexes;
     private readonly DomainModel               model;
     private TypeAttributes                     attributes;
-    private ReadOnlyCollection<TypeInfo>             ancestors;
-    private ReadOnlyCollection<AssociationInfo>      targetAssociations;
-    private ReadOnlyCollection<AssociationInfo>      ownerAssociations;
+    private IReadOnlyList<TypeInfo>             ancestors;
+    private IReadOnlyList<AssociationInfo>      targetAssociations;
+    private IReadOnlyList<AssociationInfo>      ownerAssociations;
     private IReadOnlyList<AssociationInfo>      removalSequence;
-    private ReadOnlyCollection<FieldInfo>            versionFields;
-    private ReadOnlyCollection<ColumnInfo> versionColumns;
+    private IReadOnlyList<FieldInfo>            versionFields;
+    private IReadOnlyList<ColumnInfo> versionColumns;
     private IList<IObjectValidator> validators;
     private Type                               underlyingType;
     private HierarchyInfo                      hierarchy;
@@ -610,8 +610,8 @@ namespace Xtensive.Orm.Model
 
       if (IsEntity) {
         if (HasVersionRoots) {
-          versionFields = Array.AsReadOnly(Array.Empty<FieldInfo>());
-          versionColumns = Array.AsReadOnly(Array.Empty<ColumnInfo>());
+          versionFields = Array.Empty<FieldInfo>();
+          versionColumns = Array.Empty<ColumnInfo>();
         }
         else {
           versionFields = InnerGetVersionFields().AsReadOnly();

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfoRef.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2008.07.22
 
@@ -16,34 +16,26 @@ namespace Xtensive.Orm.Model
   /// </summary>
   [Serializable]
   [DebuggerDisplay("TypeName = {TypeName}")]
-  public sealed class TypeInfoRef : IEquatable<TypeInfoRef>
+  public readonly struct TypeInfoRef : IEquatable<TypeInfoRef>
   {
-    private const string ToStringFormat = "Type '{0}'";
-
     /// <summary>
     /// Name of the type.
     /// </summary>
-    public string TypeName { get; private set; }
+    public string TypeName { get; }
 
     /// <summary>
     /// Resolves this instance to <see cref="TypeInfo"/> object within specified <paramref name="model"/>.
     /// </summary>
     /// <param name="model">Domain model.</param>
-    public TypeInfo Resolve(DomainModel model)
-    {
-      TypeInfo type;
-      if (!model.Types.TryGetValue(TypeName, out type))
-        throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "type", TypeName));
-      return type;
-    }
+    public TypeInfo Resolve(DomainModel model) =>
+      model.Types.TryGetValue(TypeName, out var type)
+        ? type
+        : throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "type", TypeName));
 
     /// <summary>
     /// Creates reference for <see cref="TypeInfo"/>.
     /// </summary>
-    public static implicit operator TypeInfoRef (TypeInfo typeInfo)
-    {
-      return new TypeInfoRef(typeInfo);
-    }
+    public static implicit operator TypeInfoRef (TypeInfo typeInfo) => new TypeInfoRef(typeInfo);
 
     #region Equality members, ==, !=
 
@@ -55,10 +47,7 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator !=(TypeInfoRef x, TypeInfoRef y)
-    {
-      return !Equals(x, y);
-    }
+    public static bool operator !=(TypeInfoRef x, TypeInfoRef y) => !Equals(x, y);
 
     /// <summary>
     /// Implements the operator ==.
@@ -68,41 +57,23 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator ==(TypeInfoRef x, TypeInfoRef y)
-    {
-      return Equals(x, y);
-    }
+    public static bool operator ==(TypeInfoRef x, TypeInfoRef y) => Equals(x, y);
 
     /// <inheritdoc/>
-    public bool Equals(TypeInfoRef other)
-    {
-      if (ReferenceEquals(other, null))
-        return false;
-      return 
-        TypeName==other.TypeName;
-    }
+    public bool Equals(TypeInfoRef other) =>
+        TypeName == other.TypeName;
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(this, obj))
-        return true;
-      return Equals(obj as TypeInfoRef);
-    }
+    public override bool Equals(object obj) =>
+      obj is TypeInfoRef other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return unchecked( TypeName.GetHashCode() );
-    }
+    public override int GetHashCode() => TypeName.GetHashCode();
 
     #endregion
 
     /// <inheritdoc/>
-    public override string ToString()
-    {
-      return string.Format(ToStringFormat, TypeName);
-    }
+    public override string ToString() => $"Type '{TypeName}'";
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/Command.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/Command.cs
@@ -136,7 +136,7 @@ namespace Xtensive.Orm.Providers
       }
 
       prepared = true;
-      underlyingCommand.CommandText = origin.Driver.BuildBatch(statements.ToArray());
+      underlyingCommand.CommandText = origin.Driver.BuildBatch(statements);
       return underlyingCommand;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/DbCommandExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DbCommandExtensions.cs
@@ -29,10 +29,14 @@ namespace Xtensive.Orm.Providers
       result.Append(" [");
       foreach (DbParameter parameter in command.Parameters) {
         var value = parameter.Value;
-        if (value is DateTime)
-          value = ((DateTime) value).ToString("yyyy-MM-dd HH:mm:ss.fffffff");
-        else if (value is DateTimeOffset)
-          value = ((DateTimeOffset) value).ToString("yyyy-MM-dd HH:mm:ss.fffffffK");
+        switch (value) {
+          case DateTime dateTime:
+            value = dateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff");
+            break;
+          case DateTimeOffset dateTimeOffset:
+            value = dateTimeOffset.ToString("yyyy-MM-dd HH:mm:ss.fffffffK");
+            break;
+        }
         result.AppendFormat("{0}='{1}';", parameter.ParameterName, value);
       }
       result.Remove(result.Length - 1, 1);

--- a/Orm/Xtensive.Orm/Orm/Providers/EnumerationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/EnumerationContext.cs
@@ -36,8 +36,7 @@ namespace Xtensive.Orm.Providers
 
       public void Dispose()
       {
-        while (finalizationQueue.Count > 0) {
-          var materializeSelf = finalizationQueue.Dequeue();
+        while (finalizationQueue.TryDequeue(out var materializeSelf)) {
           materializeSelf.Invoke();
         }
         transactionScope.DisposeSafely();

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -253,13 +253,11 @@ namespace Xtensive.Orm.Providers
       }
 
       //handle wrapped enums
-      var container = left as SqlContainer;
-      if (container != null) {
-        left = TryUnwrapEnum(container);
+      if (left is SqlContainer leftContainer) {
+        left = TryUnwrapEnum(leftContainer);
       }
-      container = right as SqlContainer;
-      if (container != null) {
-        right = TryUnwrapEnum(container);
+      if (right is SqlContainer rightContainer) {
+        right = TryUnwrapEnum(rightContainer);
       }
 
       switch (expression.NodeType) {

--- a/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.cs
@@ -38,8 +38,9 @@ namespace Xtensive.Orm.Providers
     public SessionHandler GetRealHandler()
     {
       var handler = this;
-      while (handler is ChainingSessionHandler)
-        handler = (handler as ChainingSessionHandler).ChainedHandler;
+      while (handler is ChainingSessionHandler chainingSessionHandler) {
+        handler = chainingSessionHandler.ChainedHandler;
+      }
       return handler;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
@@ -194,7 +194,7 @@ namespace Xtensive.Orm.Providers
     {
       var groups = SplitOnEmptyEntries(statements);
       foreach (var group in groups) {
-        var batch = driver.BuildBatch(group.ToArray());
+        var batch = driver.BuildBatch(group);
         if (string.IsNullOrEmpty(batch)) {
           return;
         }
@@ -208,7 +208,7 @@ namespace Xtensive.Orm.Providers
     {
       var groups = SplitOnEmptyEntries(statements);
       foreach (var group in groups) {
-        var batch = driver.BuildBatch(group.ToArray());
+        var batch = driver.BuildBatch(group);
         if (string.IsNullOrEmpty(batch)) {
           return;
         }
@@ -220,7 +220,7 @@ namespace Xtensive.Orm.Providers
       }
     }
 
-    private static IEnumerable<IEnumerable<string>> SplitOnEmptyEntries(IEnumerable<string> items)
+    private static IEnumerable<IReadOnlyList<string>> SplitOnEmptyEntries(IEnumerable<string> items)
     {
       var group = new List<string>();
       foreach (var item in items) {

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Providers
 
     public ServerInfo ServerInfo { get; private set; }
 
-    public string BuildBatch(string[] statements)
+    public string BuildBatch(IReadOnlyList<string> statements)
     {
       return translator.BuildBatch(statements);
     }

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -925,11 +925,12 @@ namespace Xtensive.Orm
       if (keyValues.Length == 0)
         throw new ArgumentException(Strings.ExKeyValuesArrayIsEmpty, "keyValues");
       if (keyValues.Length == 1) {
-        var keyValue = keyValues[0];
-        if (keyValue is Key)
-          return keyValue as Key;
-        if (keyValue is Entity)
-          return (keyValue as Entity).Key;
+        switch (keyValues[0]) {
+          case Key key:
+            return key;
+          case Entity entity:
+            return entity.Key;
+        }
       }
       return Key.Create(session.Domain, session.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, keyValues);
     }

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -40,10 +40,11 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
       ArgumentValidator.EnsureArgumentNotNull(tag, "tag");
 
-      var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
       var providerType = source.Provider.GetType();
-      if (providerType != WellKnownOrmTypes.QueryProvider)
+      if (providerType != WellKnownOrmTypes.QueryProvider) {
+        var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
         throw new NotSupportedException(string.Format(errorMessage, providerType));
+      }
 
       var genericMethod = WellKnownMembers.Queryable.ExtensionTag.MakeGenericMethod(new[] { typeof(TSource) });
       var expression = Expression.Call(null, genericMethod, new[] { source.Expression, Expression.Constant(tag)});
@@ -63,10 +64,11 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
       ArgumentValidator.EnsureArgumentNotNull(tag, "tag");
 
-      var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
       var providerType = source.Provider.GetType();
-      if (providerType != WellKnownOrmTypes.QueryProvider)
+      if (providerType != WellKnownOrmTypes.QueryProvider) {
+        var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
         throw new NotSupportedException(string.Format(errorMessage, providerType));
+      }
 
       var genericMethod = WellKnownMembers.Queryable.ExtensionTag.MakeGenericMethod(new[] { source.ElementType });
       var expression = Expression.Call(null, genericMethod, new[] { source.Expression, Expression.Constant(tag) });

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Rse
   public sealed class ColumnCollection : IReadOnlyList<Column>
   {
     private readonly Dictionary<string, int> nameIndex;
-    private readonly List<Column> columns;
+    private readonly IReadOnlyList<Column> columns;
 
     /// <summary>
     /// Gets the number of <see href="Column"/>s in the collection.
@@ -39,14 +39,8 @@ namespace Xtensive.Orm.Rse
     /// Returns <see cref="Column"/> if it was found; otherwise <see langword="null"/>.
     /// </remarks>
     /// <param name="fullName">Full name of the <see cref="Column"/> to find.</param>
-    public Column this[string fullName] {
-      get {
-        int index;
-        if (nameIndex.TryGetValue(fullName, out index))
-          return this[index];
-        return null;
-      }
-    }
+    public Column this[string fullName] =>
+      nameIndex.TryGetValue(fullName, out var index) ? columns[index] : null;
 
     /// <summary>
     /// Joins this collection with specified the column collection.
@@ -72,10 +66,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Returns an enumerator that iterates through the <see href="ColumnCollection"/>.
     /// </summary>
-    public List<Column>.Enumerator GetEnumerator() => columns.GetEnumerator();
-
-    /// <inheritdoc/>
-    IEnumerator<Column> IEnumerable<Column>.GetEnumerator() => GetEnumerator();
+    public IEnumerator<Column> GetEnumerator() => columns.GetEnumerator();
     
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -85,23 +76,14 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Initializes a new instance of this class.
     /// </summary>
-    /// <param name="collection">Collection of items to add.</param>
-    public ColumnCollection(IEnumerable<Column> collection)
-      : this(collection.ToList())
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
     /// <param name="columns">Collection of items to add.</param>
-    public ColumnCollection(List<Column> columns)
+    public ColumnCollection(IEnumerable<Column> columns)
     {
-      this.columns = columns;
-      var count = columns.Count;
+      this.columns = columns as IReadOnlyList<Column> ?? columns.ToList();
+      var count = this.columns.Count;
       nameIndex = new Dictionary<string, int>(count);
       for (var index = count; index-- > 0;) {
-        nameIndex.Add(columns[index].Name, index);
+        nameIndex.Add(this.columns[index].Name, index);
       }
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -19,6 +19,46 @@ namespace Xtensive.Orm.Rse
   [Serializable]
   public sealed class ColumnCollection : IReadOnlyList<Column>
   {
+    public struct Enumerator : IEnumerator<Column>, IEnumerator
+    {
+      private readonly IReadOnlyList<Column> list;
+      private int index;
+      public Column Current { get; private set; }
+
+      object IEnumerator.Current =>
+        index == 0 || index == list.Count + 1
+          ? throw new InvalidOperationException("Enumeration cannot happen")
+          : Current;
+
+      public void Dispose()
+      {
+      }
+
+      public bool MoveNext()
+      {
+        if (index < list.Count) {
+          Current = list[index++];
+          return true;
+        }
+        index = list.Count + 1;
+        Current = default;
+        return false;
+      }
+
+      void IEnumerator.Reset()
+      {
+        index = 0;
+        Current = default;
+      }
+
+      internal Enumerator(IReadOnlyList<Column> list)
+      {
+        this.list = list;
+        index = 0;
+        Current = default;
+      }
+    }
+
     private readonly Dictionary<string, int> nameIndex;
     private readonly IReadOnlyList<Column> columns;
 
@@ -66,8 +106,13 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Returns an enumerator that iterates through the <see href="ColumnCollection"/>.
     /// </summary>
-    public IEnumerator<Column> GetEnumerator() => columns.GetEnumerator();
-    
+    public Enumerator GetEnumerator() => new Enumerator(this);
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the <see href="ColumnCollection"/>.
+    /// </summary>
+    IEnumerator<Column> IEnumerable<Column>.GetEnumerator() => GetEnumerator();
+
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2021 Xtensive LLC.
+// Copyright (C) 2007-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
@@ -89,7 +89,7 @@ namespace Xtensive.Orm.Rse
     /// <returns>The joined collection.</returns>
     public ColumnCollection Join(IEnumerable<Column> joined)
     {
-      return new ColumnCollection(this.Concat(joined));
+      return new ColumnCollection(this.Concat(joined).ToList());
     }
 
     /// <summary>
@@ -100,7 +100,7 @@ namespace Xtensive.Orm.Rse
     public ColumnCollection Alias(string alias)
     {
       ArgumentValidator.EnsureArgumentNotNullOrEmpty(alias, "alias");
-      return new ColumnCollection(this.Select(column => column.Clone(alias + "." + column.Name)));
+      return new ColumnCollection(this.Select(column => column.Clone(alias + "." + column.Name)).ToArray(Count));
     }
 
     /// <summary>
@@ -122,9 +122,9 @@ namespace Xtensive.Orm.Rse
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="columns">Collection of items to add.</param>
-    public ColumnCollection(IEnumerable<Column> columns)
+    public ColumnCollection(IReadOnlyList<Column> columns)
     {
-      this.columns = columns as IReadOnlyList<Column> ?? columns.ToList();
+      this.columns = columns;
       var count = this.columns.Count;
       nameIndex = new Dictionary<string, int>(count);
       for (var index = count; index-- > 0;) {

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnGroupCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnGroupCollection.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Rse
 
     /// <summary>
     /// Gets the empty <see cref="ColumnGroupCollection"/>.
-    /// </summary>    
+    /// </summary>
     public static ColumnGroupCollection Empty {
       [DebuggerStepThrough]
       get {
@@ -50,15 +50,6 @@ namespace Xtensive.Orm.Rse
     public IEnumerator<ColumnGroup> GetEnumerator() => items.GetEnumerator();
 
     // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="items">The collection items.</param>
-    public ColumnGroupCollection(IEnumerable<ColumnGroup> items)
-    {
-      this.items = items.ToList();
-    }
 
     /// <summary>
     /// Initializes a new instance of this class.

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2007.09.21
 
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Gets the reference that describes a column.
     /// </summary>    
-    public ColumnInfoRef ColumnInfoRef { get; private set; }
+    public ColumnInfoRef ColumnInfoRef { get; }
 
     /// <inheritdoc/>
     public override string ToString()
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="columnInfoRef"><see cref="ColumnInfoRef"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(ColumnInfoRef columnInfoRef, int index, Type type)
+    public MappedColumn(in ColumnInfoRef columnInfoRef, int index, Type type)
       : this(columnInfoRef, columnInfoRef.ColumnName, index, type)
     {
     }
@@ -73,7 +73,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="name"><see cref="Column.Name"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(ColumnInfoRef columnInfoRef, string name, int index, Type type)
+    public MappedColumn(in ColumnInfoRef columnInfoRef, string name, int index, Type type)
       : base(name, index, type, null)
     {
       ColumnInfoRef = columnInfoRef;

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -17,10 +17,11 @@ namespace Xtensive.Orm.Rse
   {
     private const string ToStringFormat = "{0} = {1}";
 
+    private readonly ColumnInfoRef _columnInfo;
     /// <summary>
     /// Gets the reference that describes a column.
     /// </summary>    
-    public ColumnInfoRef ColumnInfoRef { get; }
+    public ref readonly ColumnInfoRef ColumnInfoRef => ref _columnInfo;
 
     /// <inheritdoc/>
     public override string ToString()
@@ -76,7 +77,7 @@ namespace Xtensive.Orm.Rse
     public MappedColumn(in ColumnInfoRef columnInfoRef, string name, int index, Type type)
       : base(name, index, type, null)
     {
-      ColumnInfoRef = columnInfoRef;
+      _columnInfo = columnInfoRef;
     }
 
     #endregion
@@ -86,13 +87,13 @@ namespace Xtensive.Orm.Rse
     private MappedColumn(MappedColumn column, string newName)
       : base(newName, column.Index, column.Type, column)
     {
-      ColumnInfoRef = column.ColumnInfoRef;
+      _columnInfo = column.ColumnInfoRef;
     }
 
     private MappedColumn(MappedColumn column, int newIndex)
       : base(column.Name, newIndex, column.Type, column)
     {
-      ColumnInfoRef = column.ColumnInfoRef;
+      _columnInfo = column.ColumnInfoRef;
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -17,11 +17,11 @@ namespace Xtensive.Orm.Rse
   {
     private const string ToStringFormat = "{0} = {1}";
 
-    private readonly ColumnInfoRef _columnInfo;
+    private readonly ColumnInfoRef columnInfo;
     /// <summary>
     /// Gets the reference that describes a column.
     /// </summary>    
-    public ref readonly ColumnInfoRef ColumnInfoRef => ref _columnInfo;
+    public ref readonly ColumnInfoRef ColumnInfoRef => ref columnInfo;
 
     /// <inheritdoc/>
     public override string ToString()
@@ -77,7 +77,7 @@ namespace Xtensive.Orm.Rse
     public MappedColumn(in ColumnInfoRef columnInfoRef, string name, int index, Type type)
       : base(name, index, type, null)
     {
-      _columnInfo = columnInfoRef;
+      columnInfo = columnInfoRef;
     }
 
     #endregion
@@ -87,13 +87,13 @@ namespace Xtensive.Orm.Rse
     private MappedColumn(MappedColumn column, string newName)
       : base(newName, column.Index, column.Type, column)
     {
-      _columnInfo = column.ColumnInfoRef;
+      columnInfo = column.ColumnInfoRef;
     }
 
     private MappedColumn(MappedColumn column, int newIndex)
       : base(column.Name, newIndex, column.Type, column)
     {
-      _columnInfo = column.ColumnInfoRef;
+      columnInfo = column.ColumnInfoRef;
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
     public MappedColumn(string name, int index, Type type)
-      : this(null, name, index, type)
+      : this(default, name, index, type)
     {
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
@@ -28,9 +28,7 @@ namespace Xtensive.Orm.Rse.Providers
       for (int i = 0; i < Left.Header.Columns.Count; i++) {
         var leftColumn = Left.Header.Columns[i];
         var rightColumn = Right.Header.Columns[i];
-        if (leftColumn is MappedColumn && rightColumn is MappedColumn) {
-          var leftMappedColumn = (MappedColumn) leftColumn;
-          var rightMappedColumn = (MappedColumn) rightColumn;
+        if (leftColumn is MappedColumn leftMappedColumn && rightColumn is MappedColumn rightMappedColumn) {
           if (leftMappedColumn.ColumnInfoRef.Equals(rightMappedColumn.ColumnInfoRef)) {
             columns.Add(leftMappedColumn);
             mappedColumnIndexes.Add(i);

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2016-2020 Xtensive LLC.
+// Copyright (C) 2016-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
@@ -74,7 +74,8 @@ namespace Xtensive.Orm.Rse.Providers
         var tupleDescriptor = TupleDescriptor.Create(fieldTypes);
         var columns = primaryIndexKeyColumns
           .Select((c, i) => (Column) new MappedColumn("KEY", i, c.Key.ValueType))
-          .Append(new MappedColumn("RANK", tupleDescriptor.Count, WellKnownTypes.Double));
+          .Append(new MappedColumn("RANK", tupleDescriptor.Count, WellKnownTypes.Double))
+          .ToArray(primaryIndexKeyColumns.Count + 1);;
         indexHeader = new RecordSetHeader(tupleDescriptor, columns);
       }
       Initialize();

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FreeTextProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FreeTextProvider.cs
@@ -67,7 +67,8 @@ namespace Xtensive.Orm.Rse.Providers
         var tupleDescriptor = TupleDescriptor.Create(fieldTypes);
         var columns = primaryIndexKeyColumns
           .Select((c, i) => (Column) new MappedColumn("KEY", i, c.Key.ValueType))
-          .Append(new MappedColumn("RANK", tupleDescriptor.Count, WellKnownTypes.Double));
+          .Append(new MappedColumn("RANK", tupleDescriptor.Count, WellKnownTypes.Double))
+          .ToArray(primaryIndexKeyColumns.Count + 1);
         indexHeader = new RecordSetHeader(tupleDescriptor, columns);
       }
       Initialize();

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
@@ -67,7 +67,10 @@ namespace Xtensive.Orm.Rse.Providers
       for (int i = 0; i < Order.Count; i++) {
         var orderItem = Order[i];
         var column = Header.Columns[orderItem.Key];
-        var culture = (column as MappedColumn)?.ColumnInfoRef.CultureInfo ?? CultureInfo.InvariantCulture;
+
+        var culture = column is MappedColumn mColumn && mColumn.ColumnInfoRef.TypeName != null
+          ? mColumn.ColumnInfoRef.CultureInfo
+          : CultureInfo.InvariantCulture;
         comparisonRules[i] = new ComparisonRule(orderItem.Value, culture);
       }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
@@ -66,11 +66,10 @@ namespace Xtensive.Orm.Rse.Providers
       var comparisonRules = new ComparisonRules[Order.Count];
       for (int i = 0; i < Order.Count; i++) {
         var orderItem = Order[i];
-        var culture = CultureInfo.InvariantCulture;
         var column = Header.Columns[orderItem.Key];
-        var mappedColumn = column as MappedColumn;
-        if (mappedColumn != null && mappedColumn.ColumnInfoRef != null)
-          culture = mappedColumn.ColumnInfoRef.CultureInfo;
+        var culture = column is MappedColumn mappedColumn && mappedColumn.ColumnInfoRef != default
+            ? mappedColumn.ColumnInfoRef.CultureInfo
+            : CultureInfo.InvariantCulture;
         comparisonRules[i] = new ComparisonRule(orderItem.Value, culture);
       }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
@@ -67,10 +67,7 @@ namespace Xtensive.Orm.Rse.Providers
       for (int i = 0; i < Order.Count; i++) {
         var orderItem = Order[i];
         var column = Header.Columns[orderItem.Key];
-        var columnInfoRef = (column as MappedColumn)?.ColumnInfoRef;
-        var culture = columnInfoRef?.HasValue == true
-            ? columnInfoRef.Value.CultureInfo
-            : CultureInfo.InvariantCulture;
+        var culture = (column as MappedColumn)?.ColumnInfoRef.CultureInfo ?? CultureInfo.InvariantCulture;
         comparisonRules[i] = new ComparisonRule(orderItem.Value, culture);
       }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
@@ -67,8 +67,9 @@ namespace Xtensive.Orm.Rse.Providers
       for (int i = 0; i < Order.Count; i++) {
         var orderItem = Order[i];
         var column = Header.Columns[orderItem.Key];
-        var culture = column is MappedColumn mappedColumn && mappedColumn.ColumnInfoRef != default
-            ? mappedColumn.ColumnInfoRef.CultureInfo
+        var columnInfoRef = (column as MappedColumn)?.ColumnInfoRef;
+        var culture = columnInfoRef?.HasValue == true
+            ? columnInfoRef.Value.CultureInfo
             : CultureInfo.InvariantCulture;
         comparisonRules[i] = new ComparisonRule(orderItem.Value, culture);
       }

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2021 Xtensive LLC.
+// Copyright (C) 2007-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
@@ -181,7 +181,7 @@ namespace Xtensive.Orm.Rse
           .Select(o => new KeyValuePair<int, Direction>(columnsMap[o.Key], o.Value))
           .TakeWhile(o => o.Key >= 0));
 
-      var resultColumns = columns.Select((oldIndex, newIndex) => Columns[oldIndex].Clone(newIndex));
+      var resultColumns = columns.Select((oldIndex, newIndex) => Columns[oldIndex].Clone(newIndex)).ToArray(columns.Count);
 
       var resultGroups = ColumnGroups
         .Where(g => g.Keys.All(k => columnsMap[k]>=0))
@@ -251,7 +251,7 @@ namespace Xtensive.Orm.Rse
         .ToArray(indexInfoKeyColumns.Count);
       var keyDescriptor = TupleDescriptor.Create(keyFieldTypes);
 
-      var resultColumns = indexInfoColumns.Select((c,i) => (Column) new MappedColumn(new ColumnInfoRef(c), i,c.ValueType));
+      var resultColumns = indexInfoColumns.Select((c,i) => (Column) new MappedColumn(new ColumnInfoRef(c), i,c.ValueType)).ToArray(indexInfoColumns.Count);
       var resultGroups = new[]{indexInfo.Group};
 
       return new RecordSetHeader(
@@ -278,7 +278,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="columns">Result columns.</param>
     public RecordSetHeader(
       TupleDescriptor tupleDescriptor,
-      IEnumerable<Column> columns)
+      IReadOnlyList<Column> columns)
       : this(tupleDescriptor, columns, null, null, null)
     {
     }
@@ -291,7 +291,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="columnGroups">Column groups.</param>
     public RecordSetHeader(
       TupleDescriptor tupleDescriptor,
-      IEnumerable<Column> columns,
+      IReadOnlyList<Column> columns,
       IReadOnlyList<ColumnGroup> columnGroups)
       : this(tupleDescriptor, columns, columnGroups, null, null)
     {
@@ -306,7 +306,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="order">Result sort order.</param>
     public RecordSetHeader(
       TupleDescriptor tupleDescriptor,
-      IEnumerable<Column> columns,
+      IReadOnlyList<Column> columns,
       TupleDescriptor orderKeyDescriptor,
       DirectionCollection<int> order)
       : this(tupleDescriptor, columns, null, orderKeyDescriptor, order)
@@ -324,7 +324,7 @@ namespace Xtensive.Orm.Rse
     /// <exception cref="ArgumentOutOfRangeException"><c>columns.Count</c> is out of range.</exception>
     public RecordSetHeader(
       TupleDescriptor tupleDescriptor,
-      IEnumerable<Column> columns,
+      IReadOnlyList<Column> columns,
       IReadOnlyList<ColumnGroup> columnGroups,
       TupleDescriptor orderKeyDescriptor,
       DirectionCollection<int> order)

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -251,7 +251,7 @@ namespace Xtensive.Orm.Rse
         .ToArray(indexInfoKeyColumns.Count);
       var keyDescriptor = TupleDescriptor.Create(keyFieldTypes);
 
-      var resultColumns = indexInfoColumns.Select((c,i) => (Column) new MappedColumn(c,i,c.ValueType));
+      var resultColumns = indexInfoColumns.Select((c,i) => (Column) new MappedColumn(new ColumnInfoRef(c), i,c.ValueType));
       var resultGroups = new[]{indexInfo.Group};
 
       return new RecordSetHeader(

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -195,7 +195,7 @@ namespace Xtensive.Orm.Rse
       return new RecordSetHeader(
         resultTupleDescriptor,
         resultColumns,
-        resultGroups,
+        resultGroups.ToList(),
         null,
         resultOrder);
     }
@@ -292,7 +292,7 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader(
       TupleDescriptor tupleDescriptor,
       IEnumerable<Column> columns,
-      IEnumerable<ColumnGroup> columnGroups)
+      IReadOnlyList<ColumnGroup> columnGroups)
       : this(tupleDescriptor, columns, columnGroups, null, null)
     {
     }
@@ -325,7 +325,7 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader(
       TupleDescriptor tupleDescriptor,
       IEnumerable<Column> columns,
-      IEnumerable<ColumnGroup> columnGroups,
+      IReadOnlyList<ColumnGroup> columnGroups,
       TupleDescriptor orderKeyDescriptor,
       DirectionCollection<int> order)
     {
@@ -334,18 +334,14 @@ namespace Xtensive.Orm.Rse
 
       TupleDescriptor = tupleDescriptor;
       // Unsafe perf. optimization: if you pass a list, it should be immutable!
-      Columns = columns is List<Column> columnList
-        ? new ColumnCollection(columnList)
-        : new ColumnCollection(columns);
-      if (tupleDescriptor.Count!=Columns.Count)
+      Columns = new ColumnCollection(columns);
+      if (tupleDescriptor.Count != Columns.Count)
         throw new ArgumentOutOfRangeException("columns.Count");
 
       ColumnGroups = columnGroups == null
         ? ColumnGroupCollection.Empty
         // Unsafe perf. optimization: if you pass a list, it should be immutable!
-        : (columnGroups is List<ColumnGroup> columnGroupList
-          ? new ColumnGroupCollection(columnGroupList)
-          : new ColumnGroupCollection(columnGroups));
+        : new ColumnGroupCollection(columnGroups);
 
       orderTupleDescriptor = orderKeyDescriptor ?? TupleDescriptor.Empty;
       Order = order ?? new DirectionCollection<int>();

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryParameterBinding.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryParameterBinding.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2020 Xtensive LLC.
+// Copyright (C) 2012-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -13,7 +13,7 @@ namespace Xtensive.Orm.Services
   /// <summary>
   /// Binding of a query parameter.
   /// </summary>
-  public sealed class QueryParameterBinding
+  public readonly struct QueryParameterBinding
   {
     /// <summary>
     /// Gets type of the parameter.
@@ -22,14 +22,7 @@ namespace Xtensive.Orm.Services
     /// Any user-created <see cref="QueryParameterBinding"/>
     /// always has this property set to non <see langword="null"/> value.
     /// </summary>
-    public Type ValueType
-    {
-      get
-      {
-        var mapping = RealBinding.TypeMapping;
-        return mapping!=null ? mapping.Type : null;
-      }
-    }
+    public Type ValueType => RealBinding.TypeMapping?.Type;
 
     /// <summary>
     /// Gets accessor of the parameter.
@@ -37,21 +30,15 @@ namespace Xtensive.Orm.Services
     /// to <see cref="ValueType"/>
     /// unless <see cref="ValueType"/> is null.
     /// </summary>
-    public Func<ParameterContext, object> ValueAccessor
-    {
-      get { return RealBinding.ValueAccessor; }
-    }
+    public Func<ParameterContext, object> ValueAccessor => RealBinding.ValueAccessor;
 
     /// <summary>
     /// Gets <see cref="SqlExpression"/> that allows
     /// to access parameter in SQL DOM query.
     /// </summary>
-    public SqlExpression ParameterReference
-    {
-      get { return RealBinding.ParameterReference; }
-    }
+    public SqlExpression ParameterReference => RealBinding.ParameterReference;
 
-    internal Providers.QueryParameterBinding RealBinding { get; private set; }
+    internal Providers.QueryParameterBinding RealBinding { get; }
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryRequest.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.02.26
 
@@ -17,25 +17,20 @@ namespace Xtensive.Orm.Services
   /// might contain reference to a session thus turning corresponding request
   /// to a session-dependent object.
   /// </summary>
-  public sealed class QueryRequest
+  public readonly struct QueryRequest
   {
     /// <summary>
     /// Gets compiled statement.
     /// </summary>
-    public SqlCompilationResult CompiledQuery
-    {
-      get { return RealRequest.GetCompiledStatement(); }
-    }
+    public SqlCompilationResult CompiledQuery => RealRequest.GetCompiledStatement();
 
     /// <summary>
     /// Gets all <see cref="QueryParameterBinding"/> associated with this request.
     /// </summary>
-    public IEnumerable<QueryParameterBinding> ParameterBindings
-    {
-      get { return RealRequest.ParameterBindings.Select(b => new QueryParameterBinding(b)); }
-    }
+    public IEnumerable<QueryParameterBinding> ParameterBindings =>
+      RealRequest.ParameterBindings.Select(b => new QueryParameterBinding(b));
 
-    internal UserQueryRequest RealRequest { get; private set; }
+    internal UserQueryRequest RealRequest { get; }
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryTranslationResult.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryTranslationResult.cs
@@ -1,33 +1,34 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.02.27
 
 using System.Collections.Generic;
 using System.Linq;
 using Xtensive.Sql;
+using Xtensive.Sql.Dml;
 
 namespace Xtensive.Orm.Services
 {
   /// <summary>
   /// Result of LINQ query translation.
   /// </summary>
-  public sealed class QueryTranslationResult
+  public readonly struct QueryTranslationResult
   {
     /// <summary>
     /// Gets or sets SQL DOM query.
     /// </summary>
-    public ISqlCompileUnit Query { get; set; }
+    public SqlSelect Query { get; }
 
     /// <summary>
     /// Gets or sets parameter bindings for translated query.
     /// </summary>
-    public IList<QueryParameterBinding> ParameterBindings { get; set; }
+    public IReadOnlyList<QueryParameterBinding> ParameterBindings { get; }
 
     // Constructors
 
-    internal QueryTranslationResult(ISqlCompileUnit query, IEnumerable<QueryParameterBinding> bindings)
+    internal QueryTranslationResult(SqlSelect query, IEnumerable<QueryParameterBinding> bindings)
     {
       Query = query;
       ParameterBindings = bindings.ToList();

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryTranslationResult.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryTranslationResult.cs
@@ -17,12 +17,12 @@ namespace Xtensive.Orm.Services
   public readonly struct QueryTranslationResult
   {
     /// <summary>
-    /// Gets or sets SQL DOM query.
+    /// Gets <see cref="SqlSelect"/> query.
     /// </summary>
     public SqlSelect Query { get; }
 
     /// <summary>
-    /// Gets or sets parameter bindings for translated query.
+    /// Gets parameter bindings for translated query.
     /// </summary>
     public IReadOnlyList<QueryParameterBinding> ParameterBindings { get; }
 

--- a/Orm/Xtensive.Orm/Orm/Services/TransactionMonitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/TransactionMonitor.cs
@@ -30,8 +30,7 @@ namespace Xtensive.Orm.Services
 
     private void EndTransaction(object sender, TransactionEventArgs e)
     {
-      if (registry.TryGetValue(Session.Transaction, out var set)) {
-        registry.Remove(Session.Transaction);
+      if (registry.Remove(Session.Transaction, out var set)) {
         foreach (var disposable in set) {
           disposable.DisposeSafely();
         }

--- a/Orm/Xtensive.Orm/Orm/TypeReference.cs
+++ b/Orm/Xtensive.Orm/Orm/TypeReference.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2009.10.09
 
@@ -14,17 +14,17 @@ namespace Xtensive.Orm
   /// Reference to <see cref="TypeInfo"/> with the specified degree of accuracy.
   /// </summary>
   [Serializable]
-  public struct TypeReference
+  public readonly struct TypeReference
   {
     /// <summary>
     /// Gets or sets the referenced type.
     /// </summary>
-    public TypeInfo Type { get; private set; }
+    public TypeInfo Type { get; }
 
     /// <summary>
     /// Gets or sets the type reference accuracy.
     /// </summary>
-    public TypeReferenceAccuracy Accuracy { get; private set; }
+    public TypeReferenceAccuracy Accuracy { get; }
 
 
     // Constructor
@@ -35,7 +35,6 @@ namespace Xtensive.Orm
     /// <param name="type">The referenced type.</param>
     /// <param name="accuracy">The type reference accuracy.</param>
     public TypeReference(TypeInfo type, TypeReferenceAccuracy accuracy)
-      : this()
     {
       Type = type;
       Accuracy = accuracy;

--- a/Orm/Xtensive.Orm/Orm/TypeReference.cs
+++ b/Orm/Xtensive.Orm/Orm/TypeReference.cs
@@ -17,12 +17,12 @@ namespace Xtensive.Orm
   public readonly struct TypeReference
   {
     /// <summary>
-    /// Gets or sets the referenced type.
+    /// Gets the referenced type.
     /// </summary>
     public TypeInfo Type { get; }
 
     /// <summary>
-    /// Gets or sets the type reference accuracy.
+    /// Gets the type reference accuracy.
     /// </summary>
     public TypeReferenceAccuracy Accuracy { get; }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
@@ -955,8 +955,7 @@ namespace Xtensive.Orm.Upgrade
         tasks.Enqueue(task);
       }
 
-      while (tasks.Count > 0) {
-        var task = tasks.Dequeue();
+      while (tasks.TryDequeue(out var task)) {
         var source = task.First;
         var target = task.Second;
         // both fields are primitive -> put to result is types match

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlActionTranslator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlActionTranslator.cs
@@ -116,9 +116,10 @@ namespace Xtensive.Orm.Upgrade
 
     private void VisitAction(NodeAction action)
     {
-      if (action is GroupingNodeAction)
-        foreach (var nodeAction in ((GroupingNodeAction) action).Actions)
+      if (action is GroupingNodeAction groupingNodeAction) {
+        foreach (var nodeAction in groupingNodeAction.Actions)
           VisitAction(nodeAction);
+      }
       else if (action is CreateNodeAction createNodeAction)
         VisitCreateAction(createNodeAction);
       else if (action is RemoveNodeAction removeNodeAction)

--- a/Orm/Xtensive.Orm/Orm/VersionSet.cs
+++ b/Orm/Xtensive.Orm/Orm/VersionSet.cs
@@ -240,11 +240,7 @@ namespace Xtensive.Orm
     public bool Remove(Key key)
     {
       ArgumentValidator.EnsureArgumentNotNull(key, "key");
-      if (Contains(key)) {
-        versions.Remove(key);
-        return true;
-      }
-      return false;
+      return versions.Remove(key);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
@@ -23,10 +23,10 @@ namespace Xtensive.Sql.Compiler
   {
     protected readonly SqlValueType decimalType;
     protected readonly SqlTranslator translator;
-    
+
     protected SqlCompilerConfiguration configuration;
     protected SqlCompilerContext context;
-    
+
     public SqlCompilationResult Compile(ISqlCompileUnit unit, SqlCompilerConfiguration compilerConfiguration)
     {
       ArgumentValidator.EnsureArgumentNotNull(unit, "unit");
@@ -46,7 +46,7 @@ namespace Xtensive.Sql.Compiler
         context.Output.AppendText(translator.Translate(context, node, NodeSection.Exit));
       }
     }
-    
+
     public virtual void Visit(SqlAlterDomain node)
     {
       using (context.EnterScope(node)) {
@@ -571,7 +571,7 @@ namespace Xtensive.Sql.Compiler
         context.Output.AppendText(translator.Translate(context, node, NodeSection.Exit));
       }
     }
-    
+
     public virtual void Visit(SqlCreateSequence node)
     {
       ArgumentValidator.EnsureArgumentNotNull(node.Sequence.SequenceDescriptor, "SequenceDescriptor");
@@ -1211,7 +1211,7 @@ namespace Xtensive.Sql.Compiler
           var cr = item as SqlColumnRef;
           if (!cr.IsNullReference() && cr.SqlColumn is SqlColumnStub)
             continue;
-            
+
           if (!context.IsEmpty)
             context.Output.AppendDelimiter(translator.ColumnDelimiter);
           if (!cr.IsNullReference()) {
@@ -1558,7 +1558,7 @@ namespace Xtensive.Sql.Compiler
         context.Output.AppendText(translator.Translate(context, column, TableColumnSection.NotNull));
       context.Output.AppendText(translator.Translate(context, column, TableColumnSection.Exit));
     }
-    
+
     private void Visit(TableConstraint constraint)
     {
       using (context.EnterScope(context.NamingOptions & ~SqlCompilerNamingOptions.TableQualifiedColumns)) {

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
@@ -3,6 +3,7 @@
 // See the License.txt file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -34,7 +35,7 @@ namespace Xtensive.Sql.Compiler
     public virtual string BatchBegin { get { return string.Empty; } }
     public virtual string BatchEnd { get { return string.Empty; } }
     public virtual string BatchItemDelimiter { get { return ";"; } }
-    
+
     public virtual string RowBegin { get { return "("; } }
     public virtual string RowEnd { get { return ")"; } }
     public virtual string RowItemDelimiter { get { return ","; } }
@@ -50,7 +51,7 @@ namespace Xtensive.Sql.Compiler
     /// See <see cref="double.ToString(string)"/> for details.
     /// </summary>
     public virtual string FloatFormatString { get { return "0.0######"; } }
-    
+
     /// <summary>
     /// Gets the double format string.
     /// See <see cref="double.ToString(string)"/> for details.
@@ -68,7 +69,7 @@ namespace Xtensive.Sql.Compiler
     /// See <see cref="SqlHelper.TimeSpanToString"/> for details.
     /// </summary>
     public abstract string TimeSpanFormatString { get; }
-    
+
     /// <summary>
     /// Gets the parameter prefix.
     /// </summary>
@@ -838,7 +839,7 @@ namespace Xtensive.Sql.Compiler
     {
       if (!node.Index.IsFullText)
         return "DROP INDEX " + QuoteIdentifier(node.Index.DbName) + " ON " + Translate(context, node.Index.DataTable);
-      else 
+      else
         return "DROP FULLTEXT INDEX ON " + Translate(context, node.Index.DataTable);
     }
 
@@ -1027,7 +1028,7 @@ namespace Xtensive.Sql.Compiler
         return string.Empty;
       }
     }
-    
+
     public virtual string Translate(SqlCompilerContext context, object literalValue)
     {
       var literalType = literalValue.GetType();
@@ -1059,7 +1060,7 @@ namespace Xtensive.Sql.Compiler
           Strings.ExTranslationOfLiteralOfTypeXIsNotSupported, literalType.GetShortName()));
       return literalValue.ToString();
     }
-    
+
     public virtual string Translate(SqlCompilerContext context, SqlMatch node, MatchSection section)
     {
       switch (section) {
@@ -1801,7 +1802,7 @@ namespace Xtensive.Sql.Compiler
     {
       if (comment?.Text == null)
         return string.Empty;
-      
+
       if (comment.Text.IndexOfAny(new char[] { '*', '/' }) != -1)
         throw new ArgumentException(string.Format(Strings.ExArgumentContainsInvalidCharacters, nameof(comment), "*/"));
 
@@ -1833,9 +1834,9 @@ namespace Xtensive.Sql.Compiler
     /// </summary>
     /// <param name="statements">The statements.</param>
     /// <returns>String containing the whole batch.</returns>
-    public virtual string BuildBatch(string[] statements)
+    public virtual string BuildBatch(IReadOnlyList<string> statements)
     {
-      if (statements.Length==0)
+      if (statements.Count == 0)
         return string.Empty;
       var expectedLength = BatchBegin.Length + BatchEnd.Length +
         statements.Sum(statement => statement.Length + BatchItemDelimiter.Length + NewLine.Length);


### PR DESCRIPTION
* Make QueryTranslationResult readonly struct

* Make QueryRequest readonly struct

* Don't load string resource until necessary

* improve is/as usages

* Optimize PrefetchHelper && make Fetcher readonluy struct

* Optimize BatchingCommandProcessor.PutTasksForExecution

* Refactor PrefetchManager.GetGraphContainer() to avoid unnecessary allocation

* Avoid double HashSet-search in TypeRegistry.Register()

* Improving refactoring of TypeDefCollection

* Use Queue.TryDequeue()

* Avoid ReadOnly-wrapping of Empty arrays. They are always immutable

* Avoid double dictionary search when removing

* Make BuildBatch() to accept IReadOnlyList<string> arg to avoid conversions

* Make ColumnInfoRef readonly struct

* Refactor ColumnCollection

* Make TypeReference readonly struct

* Make ColumnGroup readonly struct

* Make TypeInfoRef readonly struct