### PR TITLE
Optimizing refactoring: use ArraySegment instead of allocating subarrays

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Internals/GenericKeyFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/GenericKeyFactory.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
 // Created:    2009.07.27
 
 using System;
+using System.Collections.Generic;
 using Xtensive.Orm.Model;
 using Tuple = Xtensive.Tuples.Tuple;
 
@@ -15,14 +16,14 @@ namespace Xtensive.Orm.Internals
   {
     public readonly Type Type;
     public readonly Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, Key> DefaultConstructor;
-    public readonly Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, int[], Key> KeyIndexBasedConstructor;
+    public readonly Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<int>, Key> KeyIndexBasedConstructor;
 
 
     // Constructors
 
     public GenericKeyFactory(Type type,
       Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, Key> defaultConstructor,
-      Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, int[], Key> keyIndexBasedConstructor)
+      Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<int>, Key> keyIndexBasedConstructor)
     {
       Type = type;
       DefaultConstructor = defaultConstructor;

--- a/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Internals
     }
 
     public static Key Materialize(Domain domain, string nodeId,
-      TypeInfo type, Tuple value, TypeReferenceAccuracy accuracy, bool canCache, int[] keyIndexes)
+      TypeInfo type, Tuple value, TypeReferenceAccuracy accuracy, bool canCache, IReadOnlyList<int> keyIndexes)
     {
       var hierarchy = type.Hierarchy;
       var keyInfo = type.Key;
@@ -131,18 +131,18 @@ namespace Xtensive.Orm.Internals
       return true;
     }
 
-    public static bool IsValidKeyTuple(Tuple tuple, int[] keyIndexes)
+    public static bool IsValidKeyTuple(Tuple tuple, IReadOnlyList<int> keyIndexes)
     {
       if (keyIndexes==null)
         return IsValidKeyTuple(tuple);
-      var limit = keyIndexes.Length;
+      var limit = keyIndexes.Count;
       for (int i = 0; i < limit; i++)
         if (tuple.GetFieldState(keyIndexes[i]).IsNull())
           return false;
       return true;
     }
 
-    private static Key CreateGenericKey(Domain domain, string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, Tuple tuple, int[] keyIndexes)
+    private static Key CreateGenericKey(Domain domain, string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, Tuple tuple, IReadOnlyList<int> keyIndexes)
     {
       var keyTypeInfo = domain.GenericKeyFactories.GetOrAdd(type, BuildGenericKeyFactory);
       if (keyIndexes==null)
@@ -158,7 +158,7 @@ namespace Xtensive.Orm.Internals
       keyType = keyType.MakeGenericType(descriptor.ToArray(descriptor.Count));
       var defaultConstructor = DelegateHelper.CreateDelegate<Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, Key>>(
         null, keyType, "Create", Array.Empty<Type>());
-      var keyIndexBasedConstructor = DelegateHelper.CreateDelegate<Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, int[], Key>>(
+      var keyIndexBasedConstructor = DelegateHelper.CreateDelegate<Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<int>, Key>>(
         null, keyType, "Create", Array.Empty<Type>());
       return new GenericKeyFactory(keyType, defaultConstructor, keyIndexBasedConstructor);
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3,T4}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3,T4}.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
 // Created:    2009.07.13
 
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
@@ -16,13 +17,13 @@ namespace Xtensive.Orm.Internals
   [Serializable]
   internal sealed class Key<T1, T2, T3, T4> : Key
   {
-    private static readonly Predicate<T1, T1> equalityComparer1 = 
+    private static readonly Predicate<T1, T1> EqualityComparer1 =
       ComparerProvider.Default.GetComparer<T1>().Equals;
-    private static readonly Predicate<T2, T2> equalityComparer2 = 
+    private static readonly Predicate<T2, T2> EqualityComparer2 =
       ComparerProvider.Default.GetComparer<T2>().Equals;
-    private static readonly Predicate<T3, T3> equalityComparer3 = 
+    private static readonly Predicate<T3, T3> EqualityComparer3 =
       ComparerProvider.Default.GetComparer<T3>().Equals;
-    private static readonly Predicate<T4, T4> equalityComparer4 = 
+    private static readonly Predicate<T4, T4> EqualityComparer4 =
       ComparerProvider.Default.GetComparer<T4>().Equals;
 
     private readonly T1 value1;
@@ -46,10 +47,10 @@ namespace Xtensive.Orm.Internals
       if (otherKey == null)
         return false;
       return
-        equalityComparer4.Invoke(value4, otherKey.value4) && 
-        equalityComparer3.Invoke(value3, otherKey.value3) && 
-        equalityComparer2.Invoke(value2, otherKey.value2) && 
-        equalityComparer1.Invoke(value1, otherKey.value1);
+        EqualityComparer4.Invoke(value4, otherKey.value4) &&
+        EqualityComparer3.Invoke(value3, otherKey.value3) &&
+        EqualityComparer2.Invoke(value2, otherKey.value2) &&
+        EqualityComparer1.Invoke(value1, otherKey.value1);
     }
 
     protected override int CalculateHashCode()
@@ -62,7 +63,7 @@ namespace Xtensive.Orm.Internals
     }
 
     [UsedImplicitly]
-    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, int[] keyIndexes)
+    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<int> keyIndexes)
     {
       return new Key<T1, T2, T3, T4>(nodeId, type, accuracy,
         tuple.GetValueOrDefault<T1>(keyIndexes[0]),
@@ -81,7 +82,7 @@ namespace Xtensive.Orm.Internals
         tuple.GetValueOrDefault<T4>(3));
     }
 
-    
+
     // Constructors
 
     private Key(string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, T1 value1, T2 value2, T3 value3, T4 value4)

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3}.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
 // Created:    2009.07.13
 
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
@@ -16,11 +17,11 @@ namespace Xtensive.Orm.Internals
   [Serializable]
   internal sealed class Key<T1, T2, T3> : Key
   {
-    private static readonly Predicate<T1, T1> equalityComparer1 = 
+    private static readonly Predicate<T1, T1> EqualityComparer1 =
       ComparerProvider.Default.GetComparer<T1>().Equals;
-    private static readonly Predicate<T2, T2> equalityComparer2 = 
+    private static readonly Predicate<T2, T2> EqualityComparer2 =
       ComparerProvider.Default.GetComparer<T2>().Equals;
-    private static readonly Predicate<T3, T3> equalityComparer3 = 
+    private static readonly Predicate<T3, T3> EqualityComparer3 =
       ComparerProvider.Default.GetComparer<T3>().Equals;
 
     private readonly T1 value1;
@@ -42,9 +43,9 @@ namespace Xtensive.Orm.Internals
       if (otherKey == null)
         return false;
       return
-        equalityComparer3.Invoke(value3, otherKey.value3) && 
-        equalityComparer2.Invoke(value2, otherKey.value2) && 
-        equalityComparer1.Invoke(value1, otherKey.value1);
+        EqualityComparer3.Invoke(value3, otherKey.value3) &&
+        EqualityComparer2.Invoke(value2, otherKey.value2) &&
+        EqualityComparer1.Invoke(value1, otherKey.value1);
     }
 
     protected override int CalculateHashCode()
@@ -56,7 +57,7 @@ namespace Xtensive.Orm.Internals
     }
 
     [UsedImplicitly]
-    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, int[] keyIndexes)
+    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<int> keyIndexes)
     {
       return new Key<T1, T2, T3>(nodeId, type, accuracy,
         tuple.GetValueOrDefault<T1>(keyIndexes[0]),
@@ -73,7 +74,7 @@ namespace Xtensive.Orm.Internals
         tuple.GetValueOrDefault<T3>(2));
     }
 
-    
+
     // Constructors
 
     private Key(string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, T1 value1, T2 value2, T3 value3)

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2}.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
 // Created:    2009.07.13
 
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
@@ -16,9 +17,9 @@ namespace Xtensive.Orm.Internals
   [Serializable]
   internal sealed class Key<T1, T2> : Key
   {
-    private static readonly Predicate<T1, T1> equalityComparer1 = 
+    private static readonly Predicate<T1, T1> EqualityComparer1 =
       ComparerProvider.Default.GetComparer<T1>().Equals;
-    private static readonly Predicate<T2, T2> equalityComparer2 = 
+    private static readonly Predicate<T2, T2> EqualityComparer2 =
       ComparerProvider.Default.GetComparer<T2>().Equals;
 
     private readonly T1 value1;
@@ -38,8 +39,8 @@ namespace Xtensive.Orm.Internals
       if (otherKey == null)
         return false;
       return
-        equalityComparer2.Invoke(value2, otherKey.value2) && 
-        equalityComparer1.Invoke(value1, otherKey.value1);
+        EqualityComparer2.Invoke(value2, otherKey.value2) &&
+        EqualityComparer1.Invoke(value1, otherKey.value1);
     }
 
     protected override int CalculateHashCode()
@@ -48,7 +49,7 @@ namespace Xtensive.Orm.Internals
     }
 
     [UsedImplicitly]
-    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, int[] keyIndexes)
+    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<int> keyIndexes)
     {
       return new Key<T1, T2>(nodeId, type, accuracy,
         tuple.GetValueOrDefault<T1>(keyIndexes[0]),
@@ -63,7 +64,7 @@ namespace Xtensive.Orm.Internals
         tuple.GetValueOrDefault<T2>(1));
     }
 
-    
+
     // Constructors
 
     private Key(string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, T1 value1, T2 value2)

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T}.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
 // Created:    2009.07.13
 
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
@@ -16,7 +17,7 @@ namespace Xtensive.Orm.Internals
   [Serializable]
   internal sealed class Key<T> : Key
   {
-    private static readonly Predicate<T, T> equalityComparer1 = 
+    private static readonly Predicate<T, T> EqualityComparer1 =
       ComparerProvider.Default.GetComparer<T>().Equals;
 
     private readonly T value1;
@@ -34,7 +35,7 @@ namespace Xtensive.Orm.Internals
       if (otherKey == null)
         return false;
       return
-        equalityComparer1.Invoke(value1, otherKey.value1);
+        EqualityComparer1.Invoke(value1, otherKey.value1);
     }
 
     protected override int CalculateHashCode()
@@ -43,7 +44,7 @@ namespace Xtensive.Orm.Internals
     }
 
     [UsedImplicitly]
-    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, int[] keyIndexes)
+    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<int> keyIndexes)
     {
       return new Key<T>(nodeId, type, accuracy, tuple.GetValueOrDefault<T>(keyIndexes[0]));
     }
@@ -54,7 +55,7 @@ namespace Xtensive.Orm.Internals
       return new Key<T>(nodeId, type, accuracy, tuple.GetValueOrDefault<T>(0));
     }
 
-    
+
     // Constructors
 
     private Key(string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, T value)

--- a/Orm/Xtensive.Orm/Orm/Internals/TypeMapping.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/TypeMapping.cs
@@ -1,9 +1,10 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2008.08.08
 
+using System.Collections.Generic;
 using Xtensive.Tuples.Transform;
 using Xtensive.Orm.Model;
 
@@ -13,13 +14,13 @@ namespace Xtensive.Orm.Internals
   {
     public readonly TypeInfo Type;
     public readonly MapTransform KeyTransform;
-    public readonly int[] KeyIndexes;
+    public readonly IReadOnlyList<int> KeyIndexes;
     public readonly MapTransform Transform;
 
 
     // Constructors
 
-    public TypeMapping(TypeInfo type, MapTransform keyTransform, MapTransform transform, int[] keyIndexes)
+    public TypeMapping(TypeInfo type, MapTransform keyTransform, MapTransform transform, IReadOnlyList<int> keyIndexes)
     {
       Type = type;
       KeyTransform = keyTransform;

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
@@ -47,7 +47,7 @@ namespace Xtensive.Orm.Linq.Materialization
       var keyIndexes = materializationInfo.KeyIndexes;
       if (!KeyFactory.IsValidKeyTuple(tuple, keyIndexes))
         return null;
-      if (keyIndexes.Length <= WellKnown.MaxGenericKeyLength)
+      if (keyIndexes.Count <= WellKnown.MaxGenericKeyLength)
         key = KeyFactory.Materialize(Session.Domain, Session.StorageNodeId, materializationInfo.Type, tuple, accuracy, canCache, keyIndexes);
       else {
         var keyTuple = materializationInfo.KeyTransform.Apply(TupleTransformType.TransformedTuple, tuple);

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
@@ -90,8 +90,8 @@ namespace Xtensive.Orm.Linq.Materialization
         typeColumnMap = newColumns;
       }
 
-      int[] allIndexes = MaterializationHelper.CreateSingleSourceMap(descriptor.Count, typeColumnMap);
-      int[] keyIndexes = allIndexes.Take(keyInfo.TupleDescriptor.Count).ToArray();
+      ArraySegment<int> allIndexes = MaterializationHelper.CreateSingleSourceMap(descriptor.Count, typeColumnMap);
+      ArraySegment<int> keyIndexes = allIndexes.Slice(0, keyInfo.TupleDescriptor.Count);
 
       var transform    = new MapTransform(true, descriptor, allIndexes);
       var keyTransform = new MapTransform(true, keyInfo.TupleDescriptor, keyIndexes);

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
@@ -46,9 +46,7 @@ namespace Xtensive.Orm.Linq.Materialization
     public static int[] CreateSingleSourceMap(int targetLength, IReadOnlyList<Pair<int>> remappedColumns)
     {
       var map = new int[targetLength];
-      for (var i = 0; i < map.Length; i++) {
-        map[i] = MapTransform.NoMapping;
-      }
+      Array.Fill(map, MapTransform.NoMapping);
 
       for (var i = 0; i < remappedColumns.Count; i++) {
         var remappedColumn = remappedColumns[i];


### PR DESCRIPTION
The optimization is here:
https://github.com/DataObjects-NET/dataobjects-net/pull/208/files#diff-03168b160ac9646b7cc14af6934909caecdf6213f68d91386277c3ace0a29ab9L94

We avoiding `.ToArray()` call by using `IReadOnlyList` in `TypeMapping`