### PR TITLE
Schema extraction improvements for MS SQL Server

### DIFF
--- a/ChangeLog/6.0.9_dev.txt
+++ b/ChangeLog/6.0.9_dev.txt
@@ -1,0 +1,2 @@
+[sqlserver] Fixed Full-text indexes extraction for Azure SQL provider
+[sqlserver] Correct extraction of custom sequences based on types other than BIGINT

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/Azure/Extractor.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/Azure/Extractor.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2010-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2010.03.02
 
@@ -8,11 +8,6 @@ namespace Xtensive.Sql.Drivers.SqlServer.Azure
 {
   internal class Extractor : v12.Extractor
   {
-    protected override void ExtractFulltextIndexes()
-    {
-    }
-
-
     // Constructors
 
     public Extractor(SqlDriver driver)

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Extractor.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Extractor.cs
@@ -50,8 +50,9 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
           var sequence = currentSchema.CreateSequence(reader.GetString(1));
           var descriptor = sequence.SequenceDescriptor;
 
-          if (!valueReaders.TryGetValue(reader.GetInt32(2), out var valueReader))
-            throw new ArgumentOutOfRangeException($"Type of sequence '{reader.GetString(1)}' is not supported");
+          if (!valueReaders.TryGetValue(reader.GetInt32(2), out var valueReader)) {
+            throw new ArgumentOutOfRangeException($"Type of sequence '{reader.GetString(1)}' is not supported.");
+          }
 
           descriptor.StartValue = valueReader(reader, 3);
           descriptor.Increment = valueReader(reader, 4);

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Extractor.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Extractor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
+// Copyright (C) 2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -12,6 +12,8 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
 {
   internal class Extractor : v10.Extractor
   {
+    private readonly Dictionary<int, Func<DbDataReader, int, long>> valueReaders;
+
     protected override void ExtractCatalogContents()
     {
       base.ExtractCatalogContents();
@@ -24,6 +26,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
   SELECT
     schema_id,
     name,
+    user_type_id,
     start_value,
     increment,
     minimum_value,
@@ -46,12 +49,16 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
           var currentSchema = GetSchema(reader.GetInt32(0));
           var sequence = currentSchema.CreateSequence(reader.GetString(1));
           var descriptor = sequence.SequenceDescriptor;
-          descriptor.StartValue = reader.GetInt64(2);
-          descriptor.Increment = reader.GetInt64(3);
-          descriptor.MinValue = reader.GetInt64(4);
-          descriptor.MaxValue = reader.GetInt64(5);
-          descriptor.IsCyclic = reader.GetBoolean(6);
-          descriptor.LastValue = reader.GetInt64(7);
+
+          if (!valueReaders.TryGetValue(reader.GetInt32(2), out var valueReader))
+            throw new ArgumentOutOfRangeException($"Type of sequence '{reader.GetString(1)}' is not supported");
+
+          descriptor.StartValue = valueReader(reader, 3);
+          descriptor.Increment = valueReader(reader, 4);
+          descriptor.MinValue = valueReader(reader, 5);
+          descriptor.MaxValue = valueReader(reader, 6);
+          descriptor.IsCyclic = reader.GetBoolean(7);
+          descriptor.LastValue = valueReader(reader, 8);
         }
     }
 
@@ -64,6 +71,11 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
     public Extractor(SqlDriver driver)
       : base(driver)
     {
+      valueReaders = new Dictionary<int, Func<DbDataReader, int, long>>(4);
+      valueReaders[48] = (DbDataReader reader, int index) => reader.GetByte(index);
+      valueReaders[52] = (DbDataReader reader, int index) => reader.GetInt16(index);
+      valueReaders[56] = (DbDataReader reader, int index) => reader.GetInt32(index);
+      valueReaders[127] = (DbDataReader reader, int index) => reader.GetInt64(index);
     }
   }
 }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Extractor.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Extractor.cs
@@ -47,11 +47,12 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
       using (var reader = cmd.ExecuteReader())
         while (reader.Read()) {
           var currentSchema = GetSchema(reader.GetInt32(0));
-          var sequence = currentSchema.CreateSequence(reader.GetString(1));
+          var sequenceName = reader.GetString(1);
+          var sequence = currentSchema.CreateSequence(sequenceName);
           var descriptor = sequence.SequenceDescriptor;
 
           if (!valueReaders.TryGetValue(reader.GetInt32(2), out var valueReader)) {
-            throw new ArgumentOutOfRangeException($"Type of sequence '{reader.GetString(1)}' is not supported.");
+            throw new ArgumentOutOfRangeException($"Type of sequence '{sequenceName}' is not supported.");
           }
 
           descriptor.StartValue = valueReader(reader, 3);

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlServer/ExtractorTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlServer/ExtractorTest.cs
@@ -19,13 +19,13 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
   [TestFixture]
   public class ExtractorTest : SqlTest
   {
-    private List<string> dropOperations = new List<string>();
+    private readonly List<string> dropOperations = new List<string>();
 
     protected override void TestFixtureTearDown()
     {
       foreach (var dropOperation in dropOperations) {
         try {
-          ExecuteNonQuery(dropOperation);
+          _ = ExecuteNonQuery(dropOperation);
         }
         catch (Exception exception) {
           Console.Write("Operation '{0}' wasn't performed correctly", dropOperation);
@@ -62,8 +62,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       var dropScript = "IF OBJECT_ID('Table1') IS NOT NULL DROP TABLE [Table1]";
 
       RegisterDropForLater(dropScript);
-      ExecuteNonQuery(dropScript);
-      ExecuteNonQuery(createScript);
+      _ = ExecuteNonQuery(dropScript);
+      _ = ExecuteNonQuery(createScript);
 
       #endregion
 
@@ -112,8 +112,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       var dropScript = @"IF OBJECT_ID('Table1') IS NOT NULL DROP TABLE [Table1]";
 
       RegisterDropForLater(dropScript);
-      ExecuteNonQuery(dropScript);
-      ExecuteNonQuery(createScript);
+      _ = ExecuteNonQuery(dropScript);
+      _ = ExecuteNonQuery(createScript);
 
       #endregion
 
@@ -187,8 +187,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
         IF OBJECT_ID('Table2') IS NOT NULL DROP TABLE [Table2];";
 
       RegisterDropForLater(dropScript);
-      ExecuteNonQuery(dropScript);
-      ExecuteNonQuery(createScript);
+      _ = ExecuteNonQuery(dropScript);
+      _ = ExecuteNonQuery(createScript);
 
       #endregion
 
@@ -268,8 +268,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
         IF OBJECT_ID('Table2') IS NOT NULL DROP TABLE [Table2];";
 
       RegisterDropForLater(dropScript);
-      ExecuteNonQuery(dropScript);
-      ExecuteNonQuery(createScript);
+      _ = ExecuteNonQuery(dropScript);
+      _ = ExecuteNonQuery(createScript);
 
       #endregion
 
@@ -333,8 +333,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
         IF OBJECT_ID('Table2') IS NOT NULL DROP TABLE [Table2];";
 
       RegisterDropForLater(dropScript);
-      ExecuteNonQuery(dropScript);
-      ExecuteNonQuery(createScript);
+      _ =ExecuteNonQuery(dropScript);
+      _ = ExecuteNonQuery(createScript);
 
       #endregion
 
@@ -381,15 +381,15 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
     [Test]
     public void ExtractDomainsTest()
     {
-      string createTable =
+      var createTable =
         "create table table_with_domained_columns (id int primary key, value test_type)";
-      string dropTable =
+      var dropTable =
         "if object_id('table_with_domained_columns') is not null drop table table_with_domained_columns";
 
-      ExecuteNonQuery(dropTable);
+      _ = ExecuteNonQuery(dropTable);
       DropDomain();
       CreateDomain();
-      ExecuteNonQuery(createTable);
+      _ = ExecuteNonQuery(createTable);
 
       var schema = ExtractCatalog().DefaultSchema;
       var definedDomain = schema.Domains.Single(domain => domain.Name=="test_type");
@@ -403,13 +403,13 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
     [Test]
     public void ExtractDefaultConstraintTest()
     {
-      string createTable =
+      var createTable =
         "create table table_with_default_constraint (id int default 0)";
-      string dropTable =
+      var dropTable =
         "if object_id('table_with_default_constraint') is not null drop table table_with_default_constraint";
 
-      ExecuteNonQuery(dropTable);
-      ExecuteNonQuery(createTable);
+      _ = ExecuteNonQuery(dropTable);
+      _ = ExecuteNonQuery(createTable);
 
       var schema = ExtractCatalog().DefaultSchema;
       var table = schema.Tables["table_with_default_constraint"];
@@ -420,35 +420,35 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
     [Test]
     public void ExtractComputedColumnTest()
     {
-      string createTable = @"
+      var createTable = @"
         CREATE TABLE Tmp ( [Value] [int] NOT NULL, [Sum]  AS ([Value]+(1)) PERSISTED ) ON [PRIMARY]
         CREATE NONCLUSTERED INDEX [IX_Sum] ON Tmp ( [Sum] ASC ) ON [PRIMARY]";
-      string createView = @"
+      var createView = @"
         CREATE VIEW Tmp_View WITH SCHEMABINDING AS SELECT Value, Sum FROM dbo.Tmp";
-      string createIndex = @"
+      var createIndex = @"
         CREATE UNIQUE CLUSTERED INDEX [x] ON Tmp_View (	[Value] ASC )";
-      string drop = @"
+      var drop = @"
         if object_id('Tmp_View') is not null drop view Tmp_View
         if object_id('Tmp') is not null drop table Tmp";
 
-      ExecuteNonQuery(drop);
-      ExecuteNonQuery(createTable);
-      ExecuteNonQuery(createView);
+      _ = ExecuteNonQuery(drop);
+      _ = ExecuteNonQuery(createTable);
+      _ = ExecuteNonQuery(createView);
 
-      ExtractDefaultSchema();
-      ExecuteNonQuery(drop);
+      _ = ExtractDefaultSchema();
+      _ = ExecuteNonQuery(drop);
     }
     
     [Test]
     public void ExtractUDTTest()
     {
       Require.ProviderVersionAtLeast(StorageProviderVersion.SqlServer2008);
-      string create = "CREATE TYPE GuidList AS TABLE ( Id UNIQUEIDENTIFIER NULL )";
-      string drop = "if type_id('GuidList') is not null drop type GuidList";
+      var create = "CREATE TYPE GuidList AS TABLE ( Id UNIQUEIDENTIFIER NULL )";
+      var drop = "if type_id('GuidList') is not null drop type GuidList";
 
-      ExecuteNonQuery(drop);
-      ExecuteNonQuery(create);
-      ExtractDefaultSchema();
+      _ = ExecuteNonQuery(drop);
+      _ = ExecuteNonQuery(create);
+      _ = ExtractDefaultSchema();
     }
 
     [Test]
@@ -479,36 +479,141 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       cases[3] = new Pair<string, ChangeTrackingMode>(createOffNoPopulationIndex, ChangeTrackingMode.OffWithNoPopulation);
 
       foreach (var @case in cases) {
-        ExecuteNonQuery(dropTable);
-        ExecuteNonQuery(createTable);
-        ExecuteNonQuery(@case.First);
+        _ = ExecuteNonQuery(dropTable);
+        _ = ExecuteNonQuery(createTable);
+        _ = ExecuteNonQuery(@case.First);
         var schema = ExtractDefaultSchema();
         var table = schema.Tables["FullTextTestTable"];
         var ftIndex = table.Indexes.OfType<FullTextIndex>().FirstOrDefault();
         Assert.That(ftIndex, Is.Not.Null);
         Assert.That(ftIndex.ChangeTrackingMode, Is.EqualTo(@case.Second));
       }
-      ExecuteNonQuery(dropTable);
+      _ = ExecuteNonQuery(dropTable);
     }
 
-#region Helpers
+    [Test]
+    public void ExtractInt64SequenceTest()
+    {
+      var createSequence = @"CREATE SEQUENCE dbo.BigIntSeq
+                                AS bigint
+                                START WITH 12 INCREMENT BY 3
+                                MINVALUE 10 MAXVALUE 200
+                                CYCLE CACHE 3;";
+
+      var dropSequence = @"IF OBJECT_ID('dbo.BigIntSeq', 'SO') IS NOT NULL 
+                              DROP SEQUENCE dbo.BigIntSeq;";
+
+      _ = ExecuteNonQuery(dropSequence);
+      _ = ExecuteNonQuery(createSequence);
+      var schema = ExtractDefaultSchema();
+      var sequence = schema.Sequences.FirstOrDefault(s => s.Name == "BigIntSeq");
+      Assert.That(sequence, Is.Not.Null);
+      var descriptor = sequence.SequenceDescriptor;
+      Assert.That(descriptor.StartValue, Is.EqualTo(12));
+      Assert.That(descriptor.Increment, Is.EqualTo(3));
+      Assert.That(descriptor.MinValue, Is.EqualTo(10));
+      Assert.That(descriptor.MaxValue, Is.EqualTo(200));
+
+      _ = ExecuteNonQuery(dropSequence);
+    }
+
+    [Test]
+    public void ExtractInt32SequenceTest()
+    {
+      var createSequence = @"CREATE SEQUENCE dbo.IntSeq
+                                AS int
+                                START WITH 12 INCREMENT BY 3
+                                MINVALUE 10 MAXVALUE 200
+                                CYCLE CACHE 3;";
+
+      var dropSequence = @"IF OBJECT_ID('dbo.IntSeq', 'SO') IS NOT NULL 
+                              DROP SEQUENCE dbo.IntSeq;";
+
+      _ = ExecuteNonQuery(dropSequence);
+      _ = ExecuteNonQuery(createSequence);
+      var schema = ExtractDefaultSchema();
+      var sequence = schema.Sequences.FirstOrDefault(s => s.Name == "IntSeq");
+      Assert.That(sequence, Is.Not.Null);
+      var descriptor = sequence.SequenceDescriptor;
+      Assert.That(descriptor.StartValue, Is.EqualTo(12));
+      Assert.That(descriptor.Increment, Is.EqualTo(3));
+      Assert.That(descriptor.MinValue, Is.EqualTo(10));
+      Assert.That(descriptor.MaxValue, Is.EqualTo(200));
+
+      _ = ExecuteNonQuery(dropSequence);
+    }
+
+    [Test]
+    public void ExtractInt16SequenceTest()
+    {
+      var createSequence = @"CREATE SEQUENCE dbo.SmallIntSeq
+                                AS smallint
+                                START WITH 12 INCREMENT BY 3
+                                MINVALUE 10 MAXVALUE 200
+                                CYCLE CACHE 3;";
+
+      var dropSequence = @"IF OBJECT_ID('dbo.SmallIntSeq', 'SO') IS NOT NULL 
+                              DROP SEQUENCE dbo.SmallIntSeq;";
+
+      _ = ExecuteNonQuery(dropSequence);
+      _ = ExecuteNonQuery(createSequence);
+      var schema = ExtractDefaultSchema();
+      var sequence = schema.Sequences.FirstOrDefault(s => s.Name == "SmallIntSeq");
+      Assert.That(sequence, Is.Not.Null);
+      var descriptor = sequence.SequenceDescriptor;
+      Assert.That(descriptor.StartValue, Is.EqualTo(12));
+      Assert.That(descriptor.Increment, Is.EqualTo(3));
+      Assert.That(descriptor.MinValue, Is.EqualTo(10));
+      Assert.That(descriptor.MaxValue, Is.EqualTo(200));
+
+      _ = ExecuteNonQuery(dropSequence);
+    }
+
+    [Test]
+    public void ExtractByteSequenceTest()
+    {
+      var createSequence = @"CREATE SEQUENCE dbo.TinyIntSeq
+                                AS tinyint
+                                START WITH 12 INCREMENT BY 3
+                                MINVALUE 10 MAXVALUE 200
+                                CYCLE CACHE 3;";
+
+      var dropSequence = @"IF OBJECT_ID('dbo.TinyIntSeq', 'SO') IS NOT NULL 
+                              DROP SEQUENCE dbo.TinyIntSeq;";
+
+      _ = ExecuteNonQuery(dropSequence);
+      _ = ExecuteNonQuery(createSequence);
+      var schema = ExtractDefaultSchema();
+      var sequence = schema.Sequences.FirstOrDefault(s => s.Name == "TinyIntSeq");
+      Assert.That(sequence, Is.Not.Null);
+      var descriptor = sequence.SequenceDescriptor;
+      Assert.That(descriptor.StartValue, Is.EqualTo(12));
+      Assert.That(descriptor.Increment, Is.EqualTo(3));
+      Assert.That(descriptor.MinValue, Is.EqualTo(10));
+      Assert.That(descriptor.MaxValue, Is.EqualTo(200));
+
+      _ = ExecuteNonQuery(dropSequence);
+    }
+
+
+    #region Helpers
 
     private void CreateDomain()
     {
       var schema = ExtractCatalog().DefaultSchema;
       var domain = schema.CreateDomain("test_type", new SqlValueType(SqlType.Int64));
       var commandText = Driver.Compile(SqlDdl.Create(domain)).GetCommandText();
-      ExecuteNonQuery(commandText);
+      _ = ExecuteNonQuery(commandText);
     }
 
     private void DropDomain()
     {
       var schema = ExtractCatalog().DefaultSchema;
       var domain = schema.Domains["test_type"];
-      if (domain==null)
+      if (domain == null)
         return;
       var commandText = Driver.Compile(SqlDdl.Drop(domain)).GetCommandText();
-      ExecuteNonQuery(commandText);
+      _ =ExecuteNonQuery(commandText);
     }
 
     private void RegisterDropForLater(string dropScript)

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlServer/ExtractorTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlServer/ExtractorTest.cs
@@ -520,6 +520,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
     [Test]
     public void ExtractInt32SequenceTest()
     {
+      Require.ProviderVersionAtLeast(StorageProviderVersion.SqlServer2012);
+
       var createSequence = @"CREATE SEQUENCE dbo.IntSeq
                                 AS int
                                 START WITH 12 INCREMENT BY 3
@@ -546,6 +548,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
     [Test]
     public void ExtractInt16SequenceTest()
     {
+      Require.ProviderVersionAtLeast(StorageProviderVersion.SqlServer2012);
+
       var createSequence = @"CREATE SEQUENCE dbo.SmallIntSeq
                                 AS smallint
                                 START WITH 12 INCREMENT BY 3
@@ -572,6 +576,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
     [Test]
     public void ExtractByteSequenceTest()
     {
+      Require.ProviderVersionAtLeast(StorageProviderVersion.SqlServer2012);
+
       var createSequence = @"CREATE SEQUENCE dbo.TinyIntSeq
                                 AS tinyint
                                 START WITH 12 INCREMENT BY 3

--- a/Orm/Xtensive.Orm.Tests/Upgrade/UpgradeSchemaWithNonDOSequences.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/UpgradeSchemaWithNonDOSequences.cs
@@ -1,0 +1,165 @@
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Services;
+
+namespace Xtensive.Orm.Tests.Upgrade
+{
+  [TestFixture]
+  public class UpgradeSchemaWithNonDOSequences
+  {
+    public class DummyEntity : Entity
+    {
+      [Field, Key]
+      public int Id { get; private set; }
+    }
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+      Require.ProviderIs(StorageProvider.SqlServer);
+      Require.AllFeaturesSupported(Providers.ProviderFeatures.Sequences);
+    }
+
+    [Test]
+    [TestCase(typeof(byte), DomainUpgradeMode.Recreate, TestName = "TinyIntRecreateTest")]
+    [TestCase(typeof(byte), DomainUpgradeMode.Perform, TestName = "TinyIntPerformTest")]
+    [TestCase(typeof(byte), DomainUpgradeMode.PerformSafely, TestName = "TinyIntPerformSafelyTest")]
+    [TestCase(typeof(byte), DomainUpgradeMode.Validate, TestName = "TinyIntValidateTest")]
+    [TestCase(typeof(byte), DomainUpgradeMode.Skip, TestName = "TinyIntSkipTest")]
+    [TestCase(typeof(byte), DomainUpgradeMode.LegacyValidate, TestName = "TinyIntLegacyValidateTest")]
+    [TestCase(typeof(byte), DomainUpgradeMode.LegacySkip, TestName = "TinyIntLegacySkipTest")]
+
+    [TestCase(typeof(short), DomainUpgradeMode.Recreate, TestName = "SmallIntRecreateTest")]
+    [TestCase(typeof(short), DomainUpgradeMode.Perform, TestName = "SmallIntPerformTest")]
+    [TestCase(typeof(short), DomainUpgradeMode.PerformSafely, TestName = "SmallIntPerformSafelyTest")]
+    [TestCase(typeof(short), DomainUpgradeMode.Validate, TestName = "SmallIntValidateTest")]
+    [TestCase(typeof(short), DomainUpgradeMode.Skip, TestName = "SmallIntSkipTest")]
+    [TestCase(typeof(short), DomainUpgradeMode.LegacyValidate, TestName = "SmallIntLegacyValidateTest")]
+    [TestCase(typeof(short), DomainUpgradeMode.LegacySkip, TestName = "SmallIntLegacySkipTest")]
+
+    [TestCase(typeof(int), DomainUpgradeMode.Recreate, TestName = "IntRecreateTest")]
+    [TestCase(typeof(int), DomainUpgradeMode.Perform, TestName = "IntPerformTest")]
+    [TestCase(typeof(int), DomainUpgradeMode.PerformSafely, TestName = "IntPerformSafelyTest")]
+    [TestCase(typeof(int), DomainUpgradeMode.Validate, TestName = "IntValidateTest")]
+    [TestCase(typeof(int), DomainUpgradeMode.Skip, TestName = "IntSkipTest")]
+    [TestCase(typeof(int), DomainUpgradeMode.LegacyValidate, TestName = "IntLegacyValidateTest")]
+    [TestCase(typeof(int), DomainUpgradeMode.LegacySkip, TestName = "IntLegacySkipTest")]
+
+    [TestCase(typeof(long), DomainUpgradeMode.Recreate, TestName = "BigIntRecreateTest")]
+    [TestCase(typeof(long), DomainUpgradeMode.Perform, TestName = "BigIntPerformTest")]
+    [TestCase(typeof(long), DomainUpgradeMode.PerformSafely, TestName = "BigIntPerformSafelyTest")]
+    [TestCase(typeof(long), DomainUpgradeMode.Validate, TestName = "BigIntValidateTest")]
+    [TestCase(typeof(long), DomainUpgradeMode.Skip, TestName = "BigIntSkipTest")]
+    [TestCase(typeof(long), DomainUpgradeMode.LegacyValidate, TestName = "BigIntLegacyValidateTest")]
+    [TestCase(typeof(long), DomainUpgradeMode.LegacySkip, TestName = "BigIntLegacySkipTest")]
+    public void MainTest(Type seqBaseType, DomainUpgradeMode upgradeMode)
+    {
+      var initConfig = GetDomainConfig(DomainUpgradeMode.Recreate);
+      using (var initialDomain = Domain.Build(initConfig))
+      using (var session = initialDomain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        var service = session.Services.Get<DirectSqlAccessor>();
+        var command = service.CreateCommand();
+        command.CommandText = GetSequenceCreatorQuery(seqBaseType);
+        using (command) {
+          _ = command.ExecuteNonQuery();
+        }
+        tx.Complete();
+      }
+
+      var upgradeConfig = GetDomainConfig(upgradeMode);
+      using ( var initialDomain = Domain.Build(upgradeConfig))
+      using (var session = initialDomain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        var service = session.Services.Get<DirectSqlAccessor>();
+        var command = service.CreateCommand();
+        command.CommandText = GetSequenceValidatorQuery(seqBaseType, upgradeMode);
+        using (command) {
+          Assert.IsTrue((bool)command.ExecuteScalar());
+        }
+      }
+    }
+
+    private DomainConfiguration GetDomainConfig(DomainUpgradeMode upgradeMode)
+    {
+      var config = DomainConfigurationFactory.Create();
+      config.Types.Register(typeof (DummyEntity));
+      config.UpgradeMode = upgradeMode;
+      return config;
+    }
+
+    private string GetSequenceCreatorQuery(Type baseType)
+    {
+      var sequenceName = GetSequenceName(baseType);
+      if (baseType == typeof(byte)) {
+        return $"CREATE SEQUENCE dbo.{sequenceName} AS tinyint START WITH 12 INCREMENT BY 3 MINVALUE 10 MAXVALUE 200 CYCLE CACHE 3;";
+      }
+      else if(baseType == typeof(short)) {
+        return $"CREATE SEQUENCE dbo.{sequenceName} AS smallint START WITH 12 INCREMENT BY 3 MINVALUE 10 MAXVALUE 200 CYCLE CACHE 3;";
+      }
+      else if (baseType == typeof(int)) {
+        return $"CREATE SEQUENCE dbo.{sequenceName} AS int START WITH 12 INCREMENT BY 3 MINVALUE 10 MAXVALUE 200 CYCLE CACHE 3;";
+      }
+      else if(baseType == typeof(long)) {
+        return $"CREATE SEQUENCE dbo.{sequenceName} AS bigint START WITH 12 INCREMENT BY 3 MINVALUE 10 MAXVALUE 200 CYCLE CACHE 3;";
+      }
+      throw new ArgumentOutOfRangeException();
+    }
+
+    private string GetSequenceValidatorQuery(Type baseType, DomainUpgradeMode upgradeMode)
+    {
+      var sequenceName = GetSequenceName(baseType);
+      if (upgradeMode == DomainUpgradeMode.Recreate) {
+        // no sequence
+        return $"SELECT CASE WHEN Count([name]) = 0 THEN Cast(1 as bit) ELSE CAST(0 as bit) END AS r FROM [DO-Tests].[sys].[sequences] WHERE[name] = N'{sequenceName}'";
+      }
+      else if (upgradeMode == DomainUpgradeMode.Perform) {
+        // no sequence
+        return $"SELECT CASE WHEN Count([name]) = 0 THEN Cast(1 as bit) ELSE CAST(0 as bit) END AS r FROM [DO-Tests].[sys].[sequences] WHERE[name] = N'{sequenceName}'";
+      }
+      else if (upgradeMode == DomainUpgradeMode.PerformSafely) {
+        // no sequence
+        return $"SELECT CASE WHEN Count([name]) = 0 THEN Cast(1 as bit) ELSE CAST(0 as bit) END AS r FROM [DO-Tests].[sys].[sequences] WHERE[name] = N'{sequenceName}'";
+      }
+      else if (upgradeMode == DomainUpgradeMode.Skip) {
+        // sequence
+        return $"SELECT CASE WHEN Count([name]) = 1 THEN Cast(1 as bit) ELSE CAST(0 as bit) END AS r FROM [DO-Tests].[sys].[sequences] WHERE[name] = N'{sequenceName}'";
+      }
+      else if (upgradeMode == DomainUpgradeMode.Validate) {
+        // sequence
+        return $"SELECT CASE WHEN Count([name]) = 1 THEN Cast(1 as bit) ELSE CAST(0 as bit) END AS r FROM [DO-Tests].[sys].[sequences] WHERE[name] = N'{sequenceName}'";
+      }
+      else if (upgradeMode == DomainUpgradeMode.LegacySkip) {
+        // sequence
+        return $"SELECT CASE WHEN Count([name]) = 1 THEN Cast(1 as bit) ELSE CAST(0 as bit) END AS r FROM [DO-Tests].[sys].[sequences] WHERE[name] = N'{sequenceName}'";
+      }
+      else if (upgradeMode == DomainUpgradeMode.LegacyValidate) {
+        // sequence
+        return $"SELECT CASE WHEN Count([name]) = 1 THEN Cast(1 as bit) ELSE CAST(0 as bit) END AS r FROM [DO-Tests].[sys].[sequences] WHERE[name] = N'{sequenceName}'";
+      }
+      throw new ArgumentOutOfRangeException();
+    }
+
+    private string GetSequenceName(Type baseType)
+    {
+      if (baseType == typeof(byte)) {
+        return "TinyIntSeq";
+      }
+      else if (baseType == typeof(short)) {
+        return "SmallIntSeq";
+      }
+      else if (baseType == typeof(int)) {
+        return "IntSeq";
+      }
+      else if (baseType==typeof(long)) {
+        return "BigIntSeq";
+      }
+      throw new ArgumentOutOfRangeException();
+    }
+  }
+}


### PR DESCRIPTION
Addresses #203 and #205

- Sequence extraction can extract other types of sequences from ```tinyint``` to ```bigint``` (decimal and numeric are not supported by DO sequence descriptor).
- Full-text indexes are correctly extracted by Azure SQL provider.
