### PR TITLE
Revert "Add GenerateAssemblyInfo/GenerateTargetFrameworkAttribute to Xtensive.Orm.Web.Tests.csproj necessary for build"

### DIFF
--- a/Extensions/Xtensive.Orm.Web.Tests/Xtensive.Orm.Web.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Web.Tests/Xtensive.Orm.Web.Tests.csproj
@@ -4,8 +4,6 @@
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(ExtensionsKeyFile)</AssemblyOriginatorKeyFile>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <Import Project="$(SolutionDir)MSBuild\DataObjects.Net.InternalBuild.targets" />
   <ItemGroup>


### PR DESCRIPTION
This reverts commit f8bcda673b7f3f97b44046428a2f6b23ecc4714b.

Cannot reproduce the build issue with SDK versions: 5.0.404, 6.0.101