### PR TITLE
A bunch of small changes

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
+++ b/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AssemblySearchPaths>$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
@@ -29,20 +29,8 @@
     <ProjectReference Include="..\Xtensive.Orm\Xtensive.Orm.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="Model\InterfaceAssociationsModelGenerator.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
     <None Update="Northwind.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="Upgrade\HugeModelUpgrade\Models\ModelWithMappedTypes.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
-    <None Update="Upgrade\HugeModelUpgrade\Models\RegularModel.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
-    <None Update="Upgrade\HugeModelUpgrade\Models\TwoPartsModel.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
     </None>
     <None Update="Chinook.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Orm.Providers
   internal sealed class BatchingCommandProcessor : CommandProcessor, ISqlTaskProcessor
   {
     private readonly int batchSize;
-    private Queue<SqlTask> tasks = new Queue<SqlTask>();
+    private Queue<SqlTask> tasks;
 
     void ISqlTaskProcessor.ProcessTask(SqlLoadTask task, CommandProcessorContext context)
     {
@@ -290,7 +290,7 @@ namespace Xtensive.Orm.Providers
       }
       else {
         context.ProcessingTasks = tasks;
-        tasks = new Queue<SqlTask>();
+        tasks = new Queue<SqlTask>(batchSize);
       }
     }
 
@@ -328,6 +328,7 @@ namespace Xtensive.Orm.Providers
     {
       ArgumentValidator.EnsureArgumentIsGreaterThan(batchSize, 1, nameof(batchSize));
       this.batchSize = batchSize;
+      this.tasks = new Queue<SqlTask>(batchSize);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
@@ -14,7 +14,7 @@ namespace Xtensive.Orm.Providers
 {
   internal sealed class SimpleCommandProcessor : CommandProcessor, ISqlTaskProcessor
   {
-    private readonly Queue<SqlTask> tasks;
+    private Queue<SqlTask> tasks = new();
 
     void ISqlTaskProcessor.ProcessTask(SqlLoadTask task, CommandProcessorContext context)
     {
@@ -51,8 +51,8 @@ namespace Xtensive.Orm.Providers
 
     public override void ExecuteTasks(CommandProcessorContext context)
     {
-      context.ProcessingTasks = new Queue<SqlTask>(tasks);
-      tasks.Clear();
+      context.ProcessingTasks = tasks;
+      tasks = new Queue<SqlTask>();
 
       while (context.ProcessingTasks.Count > 0) {
         AllocateCommand(context);
@@ -79,8 +79,8 @@ namespace Xtensive.Orm.Providers
 
     public override async Task ExecuteTasksAsync(CommandProcessorContext context, CancellationToken token)
     {
-      context.ProcessingTasks = new Queue<SqlTask>(tasks);
-      tasks.Clear();
+      context.ProcessingTasks = tasks;
+      tasks = new Queue<SqlTask>();
 
       while (context.ProcessingTasks.Count > 0) {
         AllocateCommand(context);
@@ -152,7 +152,6 @@ namespace Xtensive.Orm.Providers
     public SimpleCommandProcessor(CommandFactory factory, int maxQueryParameterCount)
       : base(factory, maxQueryParameterCount)
     {
-      tasks = new Queue<SqlTask>();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
@@ -14,7 +14,11 @@ namespace Xtensive.Orm.Providers
 {
   internal sealed class SimpleCommandProcessor : CommandProcessor, ISqlTaskProcessor
   {
-    private Queue<SqlTask> tasks = new();
+    // equals to default batch size from SessionConfiguration
+    // hard to choose particular value so let it be some known number :)
+    private const int DefaultTaskQueueCapacity = 25;
+
+    private Queue<SqlTask> tasks = new(DefaultTaskQueueCapacity);
 
     void ISqlTaskProcessor.ProcessTask(SqlLoadTask task, CommandProcessorContext context)
     {
@@ -52,7 +56,7 @@ namespace Xtensive.Orm.Providers
     public override void ExecuteTasks(CommandProcessorContext context)
     {
       context.ProcessingTasks = tasks;
-      tasks = new Queue<SqlTask>();
+      tasks = new Queue<SqlTask>(DefaultTaskQueueCapacity);
 
       while (context.ProcessingTasks.Count > 0) {
         AllocateCommand(context);
@@ -80,7 +84,7 @@ namespace Xtensive.Orm.Providers
     public override async Task ExecuteTasksAsync(CommandProcessorContext context, CancellationToken token)
     {
       context.ProcessingTasks = tasks;
-      tasks = new Queue<SqlTask>();
+      tasks = new Queue<SqlTask>(DefaultTaskQueueCapacity);
 
       while (context.ProcessingTasks.Count > 0) {
         AllocateCommand(context);

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -42,7 +42,7 @@ namespace Xtensive.Orm
 
       var providerType = source.Provider.GetType();
       if (providerType != WellKnownOrmTypes.QueryProvider) {
-        var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
+        var errorMessage = Strings.ExTagDoesNotSupportQueryProviderOfTypeX;
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
@@ -66,7 +66,7 @@ namespace Xtensive.Orm
 
       var providerType = source.Provider.GetType();
       if (providerType != WellKnownOrmTypes.QueryProvider) {
-        var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
+        var errorMessage = Strings.ExTagDoesNotSupportQueryProviderOfTypeX;
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -122,8 +122,16 @@ namespace Xtensive.Orm.Rse
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="columns">Collection of items to add.</param>
+    /// <remarks>
+    /// <paramref name="columns"/> is used to initialize inner field directly
+    /// to save time on avoiding collection copy. If you pass an <see cref="IReadOnlyList{Column}"/>
+    /// implementor that, in fact, can be changed, make sure the passed collection doesn't change afterwards.
+    /// Ideally, use arrays instead of <see cref="List{T}"/> or similar collections.
+    /// Changing the passed collection afterwards will lead to unpredictable results.
+    /// </remarks>
     public ColumnCollection(IReadOnlyList<Column> columns)
     {
+      //!!! Direct initialization by parameter is unsafe performance optimization: See remarks in ctor summary!
       this.columns = columns;
       var count = this.columns.Count;
       nameIndex = new Dictionary<string, int>(count);

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnGroupCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnGroupCollection.cs
@@ -55,8 +55,16 @@ namespace Xtensive.Orm.Rse
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="items">The collection items.</param>
+    /// <remarks>
+    /// <paramref name="items"/> is used to initialize inner field directly
+    /// to save time on avoiding collection copy. If you pass an <see cref="IReadOnlyList{ColumnGroup}"/>
+    /// implementor that, in fact, can be changed, make sure the passed collection doesn't change afterwards.
+    /// Ideally, use arrays instead of <see cref="List{T}"/> or similar collections.
+    /// Changing the passed collection afterwards will lead to unpredictable results.
+    /// </remarks>
     public ColumnGroupCollection(IReadOnlyList<ColumnGroup> items)
     {
+      //!!! Direct initialization by parameter is unsafe performance optimization: See remark in ctor summary!
       this.items = items;
     }
   }

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -6096,6 +6096,15 @@ namespace Xtensive {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;Tag&apos; does not support query provider of type &apos;{0}&apos;..
+        /// </summary>
+        internal static string ExTagDoesNotSupportQueryProviderOfTypeX {
+            get {
+                return ResourceManager.GetString("ExTagDoesNotSupportQueryProviderOfTypeX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;Take&apos; does not support query provider of type &apos;{0}&apos;..
         /// </summary>
         internal static string ExTakeDoesNotSupportQueryProviderOfTypeX {

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -106,70 +106,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Applying [{0}] to property &apos;{1}&apos; failed. {2}.
-        /// </summary>
-        internal static string AspectExApplyingXToPropertyYFailedZ {
-            get {
-                return ResourceManager.GetString("AspectExApplyingXToPropertyYFailedZ", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Both localizable message resource and not localizable message can not be specified at once (location: {0})..
-        /// </summary>
-        internal static string AspectExBothLocalizableMessageResourceAndNotLocalizableMessageCanNotBeSpecifiedAtOnceLocationX {
-            get {
-                return ResourceManager.GetString("AspectExBothLocalizableMessageResourceAndNotLocalizableMessageCanNotBeSpecifiedAt" +
-                        "OnceLocationX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Field constraint can not be applied to read only property {0}..
-        /// </summary>
-        internal static string AspectExFieldConstraintCanNotBeAppliedToReadOnlyPropertyX {
-            get {
-                return ResourceManager.GetString("AspectExFieldConstraintCanNotBeAppliedToReadOnlyPropertyX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0}: multiple attributes of type &apos;{1}&apos; are not allowed here..
-        /// </summary>
-        internal static string AspectExMultipleAttributesOfTypeXAreNotAllowedHere {
-            get {
-                return ResourceManager.GetString("AspectExMultipleAttributesOfTypeXAreNotAllowedHere", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to [{0}] attribute on &apos;{1}&apos; requires a comparer for type &apos;{2}&apos;..
-        /// </summary>
-        internal static string AspectExNoComparer {
-            get {
-                return ResourceManager.GetString("AspectExNoComparer", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; and &apos;{1}&apos; properties must be used together (location: {2})..
-        /// </summary>
-        internal static string AspectExXAndYPropertiesMustBeUsedTogetherLocationZ {
-            get {
-                return ResourceManager.GetString("AspectExXAndYPropertiesMustBeUsedTogetherLocationZ", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; does not support &apos;{1}&apos; value type (location: {2})..
-        /// </summary>
-        internal static string AspectExXDoesNotSupportYValueTypeLocationZ {
-            get {
-                return ResourceManager.GetString("AspectExXDoesNotSupportYValueTypeLocationZ", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Associations.
         /// </summary>
         internal static string Associations {
@@ -193,51 +129,6 @@ namespace Xtensive {
         internal static string CachedFormat {
             get {
                 return ResourceManager.GetString("CachedFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t access member &apos;{0}&apos;.
-        /// </summary>
-        internal static string CantAccessMemberX {
-            get {
-                return ResourceManager.GetString("CantAccessMemberX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to  (can&apos;t change type of column &apos;{0}&apos;).
-        /// </summary>
-        internal static string CantChangeTypeOfColumnX {
-            get {
-                return ResourceManager.GetString("CantChangeTypeOfColumnX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to  (can&apos;t remove column &apos;{0}&apos;).
-        /// </summary>
-        internal static string CantRemoveColumnX {
-            get {
-                return ResourceManager.GetString("CantRemoveColumnX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to  (can&apos;t remove table &apos;{0}&apos;).
-        /// </summary>
-        internal static string CantRemoveTableX {
-            get {
-                return ResourceManager.GetString("CantRemoveTableX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Columns.
-        /// </summary>
-        internal static string Columns {
-            get {
-                return ResourceManager.GetString("Columns", resourceCulture);
             }
         }
         
@@ -314,15 +205,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Date must be in the past..
-        /// </summary>
-        internal static string DateMustBeInThePast {
-            get {
-                return ResourceManager.GetString("DateMustBeInThePast", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Difference.
         /// </summary>
         internal static string Difference {
@@ -395,33 +277,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The accessed member is not a property..
-        /// </summary>
-        internal static string ExAccessedMemberIsNotProperty {
-            get {
-                return ResourceManager.GetString("ExAccessedMemberIsNotProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The access to a type&apos;s member can not be extracted from the specified expression..
-        /// </summary>
-        internal static string ExAccessToTypeMemberCanNotBeExtractedFromSpecifiedExpression {
-            get {
-                return ResourceManager.GetString("ExAccessToTypeMemberCanNotBeExtractedFromSpecifiedExpression", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Active serialization context is not found..
-        /// </summary>
-        internal static string ExActiveSerializationContextIsNotFound {
-            get {
-                return ResourceManager.GetString("ExActiveSerializationContextIsNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Active Session is required for this operation. Use Session.Open(...) to open it..
         /// </summary>
         internal static string ExActiveSessionIsRequiredForThisOperation {
@@ -445,24 +300,6 @@ namespace Xtensive {
         internal static string ExActiveTransactionIsRequiredForThisOperationUseSessionOpenTransactionToOpenIt {
             get {
                 return ResourceManager.GetString("ExActiveTransactionIsRequiredForThisOperationUseSessionOpenTransactionToOpenIt", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Actual conjunction operand count greater than MaxConjunctionOperandCount..
-        /// </summary>
-        internal static string ExActualConjunctionOperandCountGreaterThanExpected {
-            get {
-                return ResourceManager.GetString("ExActualConjunctionOperandCountGreaterThanExpected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Actual schema version of assembly &apos;{0}&apos; is expected to be &apos;{1}&apos;, but currently it is &apos;{2}&apos;..
-        /// </summary>
-        internal static string ExActualSchemaVersionOfAssemblyXIsExpectedToBeYButCurrentlyItIsZ {
-            get {
-                return ResourceManager.GetString("ExActualSchemaVersionOfAssemblyXIsExpectedToBeYButCurrentlyItIsZ", resourceCulture);
             }
         }
         
@@ -499,15 +336,6 @@ namespace Xtensive {
         internal static string ExAllMethodIsOnlySupportedForRootExpressionsOrSubqueries {
             get {
                 return ResourceManager.GetString("ExAllMethodIsOnlySupportedForRootExpressionsOrSubqueries", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to UndoDescriptor is already completed..
-        /// </summary>
-        internal static string ExAlreadyCompleted {
-            get {
-                return ResourceManager.GetString("ExAlreadyCompleted", resourceCulture);
             }
         }
         
@@ -701,15 +529,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Association multiplicity &apos;{0}&apos; is not valid for field &apos;{1}&apos;..
-        /// </summary>
-        internal static string ExAssociationMultiplicityIsNotValidForField {
-            get {
-                return ResourceManager.GetString("ExAssociationMultiplicityIsNotValidForField", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to At least one column index pair must be specified..
         /// </summary>
         internal static string ExAtLeastOneColumnIndexPairMustBeSpecified {
@@ -728,15 +547,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to AtomicContext is suspended..
-        /// </summary>
-        internal static string ExAtomicContextIsSuspended {
-            get {
-                return ResourceManager.GetString("ExAtomicContextIsSuspended", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to An attempt to automatically activate Session &apos;{0}&apos; inside Session &apos;{1}&apos; (Session switching) is blocked. 
         ///Most likely, mixed usage of objects from different Sessions is a result of a bug in your code. 
         ///Use manual Session activation (Session.Deactivate(), Session.Activate()) or 
@@ -745,15 +555,6 @@ namespace Xtensive {
         internal static string ExAttemptToAutomaticallyActivateSessionXInsideSessionYIsBlocked {
             get {
                 return ResourceManager.GetString("ExAttemptToAutomaticallyActivateSessionXInsideSessionYIsBlocked", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to BatchingCommandProcessor does not support validation of number of affected rows..
-        /// </summary>
-        internal static string ExBatchingCommandProcessorDoesNotSupportValidationOfNumberOfAffectedRows {
-            get {
-                return ResourceManager.GetString("ExBatchingCommandProcessorDoesNotSupportValidationOfNumberOfAffectedRows", resourceCulture);
             }
         }
         
@@ -809,15 +610,6 @@ namespace Xtensive {
         internal static string ExBothLeftAndRightPartOfBinaryExpressionXAreNULLOrNotStructureExpression {
             get {
                 return ResourceManager.GetString("ExBothLeftAndRightPartOfBinaryExpressionXAreNULLOrNotStructureExpression", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Both measurements have no value..
-        /// </summary>
-        internal static string ExBothMeasurementsHaveNoValue {
-            get {
-                return ResourceManager.GetString("ExBothMeasurementsHaveNoValue", resourceCulture);
             }
         }
         
@@ -885,38 +677,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Can not commit a transaction: ValidationContext is in inconsistent state..
-        /// </summary>
-        internal static string ExCanNotCommitATransactionValidationContextIsInInconsistentState {
-            get {
-                return ResourceManager.GetString("ExCanNotCommitATransactionValidationContextIsInInconsistentState", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can not commit a transaction. Validation context is in invalid state..
-        /// </summary>
-        internal static string ExCanNotCommitATransactionValidationContextIsInInvalidState {
-            get {
-                return ResourceManager.GetString("ExCanNotCommitATransactionValidationContextIsInInvalidState", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Can&apos;t compile - active CompilationContext has no Compiler (Compiler is null)..
         /// </summary>
         internal static string ExCanNotCompileNoCompiler {
             get {
                 return ResourceManager.GetString("ExCanNotCompileNoCompiler", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t compile - no active EnumerationContext exists..
-        /// </summary>
-        internal static string ExCanNotCompileNoEnumerationContext {
-            get {
-                return ResourceManager.GetString("ExCanNotCompileNoEnumerationContext", resourceCulture);
             }
         }
         
@@ -957,74 +722,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Can not find reference to column &quot;{0}&quot;..
-        /// </summary>
-        internal static string ExCanNotFindReferenceToColumnX {
-            get {
-                return ResourceManager.GetString("ExCanNotFindReferenceToColumnX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Can&apos;t generate next version value of type &apos;{0}&apos;..
         /// </summary>
         internal static string ExCannotGenerateNextVersionValueOfTypeX {
             get {
                 return ResourceManager.GetString("ExCannotGenerateNextVersionValueOfTypeX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can not get validation context: there is no active transaction..
-        /// </summary>
-        internal static string ExCanNotGetValidationContextThereIsNoActiveTransaction {
-            get {
-                return ResourceManager.GetString("ExCanNotGetValidationContextThereIsNoActiveTransaction", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can not mark state as modified: it is not valid in current transaction..
-        /// </summary>
-        internal static string ExCanNotMarkStateAsModifiedItIsNotValidInCurrentTransaction {
-            get {
-                return ResourceManager.GetString("ExCanNotMarkStateAsModifiedItIsNotValidInCurrentTransaction", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t merge the state..
-        /// </summary>
-        internal static string ExCanNotMergeTheState {
-            get {
-                return ResourceManager.GetString("ExCanNotMergeTheState", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can not open more than one inner transaction..
-        /// </summary>
-        internal static string ExCanNotOpenMoreThanOneInnerTransaction {
-            get {
-                return ResourceManager.GetString("ExCanNotOpenMoreThanOneInnerTransaction", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can not open a transaction: there is no current Session..
-        /// </summary>
-        internal static string ExCanNotOpenTransactionNoCurrentSession {
-            get {
-                return ResourceManager.GetString("ExCanNotOpenTransactionNoCurrentSession", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t parse the call to the comparison method..
-        /// </summary>
-        internal static string ExCannotParseCallToComparisonMethod {
-            get {
-                return ResourceManager.GetString("ExCannotParseCallToComparisonMethod", resourceCulture);
             }
         }
         
@@ -1061,34 +763,6 @@ namespace Xtensive {
         internal static string ExCanNotReuseOpenedTransactionRequestedIsolationLevelIsDifferent {
             get {
                 return ResourceManager.GetString("ExCanNotReuseOpenedTransactionRequestedIsolationLevelIsDifferent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot upgrade schema safely. Details:
-        ///{0}.
-        /// </summary>
-        internal static string ExCanNotUpgradeSchemaSafely_DetailsX {
-            get {
-                return ResourceManager.GetString("ExCanNotUpgradeSchemaSafely_DetailsX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot use default generator for complex (multicolumn) Keys..
-        /// </summary>
-        internal static string ExCannotUseDefaultGeneratorForComplexKeys {
-            get {
-                return ResourceManager.GetString("ExCannotUseDefaultGeneratorForComplexKeys", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t access member of type &apos;EntitySet&lt;&gt;&apos;..
-        /// </summary>
-        internal static string ExCantAccessMemberOfTypeEntitySet {
-            get {
-                return ResourceManager.GetString("ExCantAccessMemberOfTypeEntitySet", resourceCulture);
             }
         }
         
@@ -1138,47 +812,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Blocking descriptor can&apos;t be invoked..
-        /// </summary>
-        internal static string ExCantInvokeBlockingDescriptor {
-            get {
-                return ResourceManager.GetString("ExCantInvokeBlockingDescriptor", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t merge state..
-        /// </summary>
-        internal static string ExCantMergeState {
-            get {
-                return ResourceManager.GetString("ExCantMergeState", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Can&apos;t modify Active or Disposed scope..
         /// </summary>
         internal static string ExCantModifyActiveOrDisposedScope {
             get {
                 return ResourceManager.GetString("ExCantModifyActiveOrDisposedScope", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t open EnumerationScope, since there is no current CompilationContext..
-        /// </summary>
-        internal static string ExCantOpenEnumerationScopeSinceThereIsNoCurrentCompilationContext {
-            get {
-                return ResourceManager.GetString("ExCantOpenEnumerationScopeSinceThereIsNoCurrentCompilationContext", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to InfinityType.None can&apos;t be passed to this constructor..
-        /// </summary>
-        internal static string ExCantPassNoInfinityToThisConstructor {
-            get {
-                return ResourceManager.GetString("ExCantPassNoInfinityToThisConstructor", resourceCulture);
             }
         }
         
@@ -1282,24 +920,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Item should be either an ICollection or ICountable..
-        /// </summary>
-        internal static string ExCollectionOrCoutableExcpected {
-            get {
-                return ResourceManager.GetString("ExCollectionOrCoutableExcpected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The collection property {0} is bound to the property {1} that isn&apos;t collection..
-        /// </summary>
-        internal static string ExCollectionPropertyXIsBoundToPropertyYThatIsNotCollection {
-            get {
-                return ResourceManager.GetString("ExCollectionPropertyXIsBoundToPropertyYThatIsNotCollection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Collection should contain at least {0} elements..
         /// </summary>
         internal static string ExCollectionShouldContainAtLeastXElements {
@@ -1323,15 +943,6 @@ namespace Xtensive {
         internal static string ExColumnBelongsToOtherTable {
             get {
                 return ResourceManager.GetString("ExColumnBelongsToOtherTable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Column group could not be found..
-        /// </summary>
-        internal static string ExColumnGroupCouldNotBeFound {
-            get {
-                return ResourceManager.GetString("ExColumnGroupCouldNotBeFound", resourceCulture);
             }
         }
         
@@ -1435,15 +1046,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Compiler {0} has invalid target member..
-        /// </summary>
-        internal static string ExCompilerXHasInvalidTargetMember {
-            get {
-                return ResourceManager.GetString("ExCompilerXHasInvalidTargetMember", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Compiler {0} has invalid target type: target type should be either non-generic or generic type definition..
         /// </summary>
         internal static string ExCompilerXHasInvalidTargetType {
@@ -1498,24 +1100,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Complete method must be called just once..
-        /// </summary>
-        internal static string ExCompleteMustBeCalledJustOnce {
-            get {
-                return ResourceManager.GetString("ExCompleteMustBeCalledJustOnce", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Concurrency conflict..
-        /// </summary>
-        internal static string ExConcurrencyConflict {
-            get {
-                return ResourceManager.GetString("ExConcurrencyConflict", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Configuration for Domain with name &apos;{0}&apos; is not found in application configuration file (section &apos;{1}&apos;)..
         /// </summary>
         internal static string ExConfigurationForDomainIsNotFoundInApplicationConfigurationFile {
@@ -1552,40 +1136,12 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ConnectionInfo is wrong. You should set either  &apos;connectionUrl&apos; element or &apos;connectionString&apos; element..
-        /// </summary>
-        internal static string ExConnectionInfoIsWrongYouShouldSetEitherConnectionUrlElementOrConnectionStringElement {
-            get {
-                return ResourceManager.GetString("ExConnectionInfoIsWrongYouShouldSetEitherConnectionUrlElementOrConnectionStringEl" +
-                        "ement", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to ConnectionInfo is wrong. You should set either &apos;connectionUrl&apos; element or &apos;provider&apos; and &apos;connectionString&apos; elements..
         /// </summary>
         internal static string ExConnectionInfoIsWrongYouShouldSetEitherConnectionUrlElementOrProviderAndConnectionStringElements {
             get {
                 return ResourceManager.GetString("ExConnectionInfoIsWrongYouShouldSetEitherConnectionUrlElementOrProviderAndConnect" +
                         "ionStringElements", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Connection is not open..
-        /// </summary>
-        internal static string ExConnectionIsNotOpen {
-            get {
-                return ResourceManager.GetString("ExConnectionIsNotOpen", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Connection is required..
-        /// </summary>
-        internal static string ExConnectionIsRequired {
-            get {
-                return ResourceManager.GetString("ExConnectionIsRequired", resourceCulture);
             }
         }
         
@@ -1626,15 +1182,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Constraint violation: constraint {0} on field &apos;{1}.{2}&apos; of object &apos;{3}&apos; failed on value {4}..
-        /// </summary>
-        internal static string ExConstraintViolation {
-            get {
-                return ResourceManager.GetString("ExConstraintViolation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Container type does not provide a suitable constructor..
         /// </summary>
         internal static string ExContainerTypeDoesNotProvideASuitableConstructor {
@@ -1662,15 +1209,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Context is not activated..
-        /// </summary>
-        internal static string ExContextMustBeActivated {
-            get {
-                return ResourceManager.GetString("ExContextMustBeActivated", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0} is required. Use {1} to set it..
         /// </summary>
         internal static string ExContextRequired {
@@ -1689,65 +1227,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to copy a part of the stream to itself. Use StreamExtensions.Copy method instead..
-        /// </summary>
-        internal static string ExCopyToMustOperateWithDifferentStreams {
-            get {
-                return ResourceManager.GetString("ExCopyToMustOperateWithDifferentStreams", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Could not construct new Key instance. Type &apos;{0}&apos; is not an entity..
         /// </summary>
         internal static string ExCouldNotConstructNewKeyInstanceTypeXIsNotAnEntity {
             get {
                 return ResourceManager.GetString("ExCouldNotConstructNewKeyInstanceTypeXIsNotAnEntity", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Could not find anonymous mapping for field &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExCouldNotFindAnonymousMappingForFieldX {
-            get {
-                return ResourceManager.GetString("ExCouldNotFindAnonymousMappingForFieldX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Could not find entity mapping for field &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExCouldNotFindEntityMappingForFieldX {
-            get {
-                return ResourceManager.GetString("ExCouldNotFindEntityMappingForFieldX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Could not find field segment for field &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExCouldNotFindFieldSegmentForFieldX {
-            get {
-                return ResourceManager.GetString("ExCouldNotFindFieldSegmentForFieldX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Could not find grouping mapping for field &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExCouldNotFindGroupingMappingForFieldX {
-            get {
-                return ResourceManager.GetString("ExCouldNotFindGroupingMappingForFieldX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Could not find subquery mapping for field &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExCouldNotFindSubqueryMappingForFieldX {
-            get {
-                return ResourceManager.GetString("ExCouldNotFindSubqueryMappingForFieldX", resourceCulture);
             }
         }
         
@@ -1788,38 +1272,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Current compiler is not suitable for this operation, most likely there is no active Session..
-        /// </summary>
-        internal static string ExCurrentCompilerIsNotSuitableForThisOperationMostLikelyThereIsNoActiveSession {
-            get {
-                return ResourceManager.GetString("ExCurrentCompilerIsNotSuitableForThisOperationMostLikelyThereIsNoActiveSession", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Current provider does not support ContainsTable functionality..
         /// </summary>
         internal static string ExCurrentProviderDoesNotSupportContainsTableFunctionality {
             get {
                 return ResourceManager.GetString("ExCurrentProviderDoesNotSupportContainsTableFunctionality", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Current session getter is already assigned..
-        /// </summary>
-        internal static string ExCurrentSessionGetterIsAlreadyAssigned {
-            get {
-                return ResourceManager.GetString("ExCurrentSessionGetterIsAlreadyAssigned", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Current storage does not support changing column types.
-        /// </summary>
-        internal static string ExCurrentStorageDoesNotSupportChangingColumnTypes {
-            get {
-                return ResourceManager.GetString("ExCurrentStorageDoesNotSupportChangingColumnTypes", resourceCulture);
             }
         }
         
@@ -1968,42 +1425,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dependency operation with full name &quot;{0}&quot; is already registered..
-        /// </summary>
-        internal static string ExDependencyOperationIsAlreadyRegistered {
-            get {
-                return ResourceManager.GetString("ExDependencyOperationIsAlreadyRegistered", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Descriptor is in invalid state..
-        /// </summary>
-        internal static string ExDescriptorIsInInvalidState {
-            get {
-                return ResourceManager.GetString("ExDescriptorIsInInvalidState", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Deserialization error: some SerializationData slots were not recognized, thus the format of the serialized data differs from the supported one..
-        /// </summary>
-        internal static string ExDeserializationErrorUnrecognizedSlotsAreFound {
-            get {
-                return ResourceManager.GetString("ExDeserializationErrorUnrecognizedSlotsAreFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Stream length not enough to deserialize object of specified type..
-        /// </summary>
-        internal static string ExDeserializationStreamLengthIncorrect {
-            get {
-                return ResourceManager.GetString("ExDeserializationStreamLengthIncorrect", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Destionation array is too small..
         /// </summary>
         internal static string ExDestionationArrayIsTooSmall {
@@ -2013,29 +1434,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The detection of changes in user structure collection isn&apos;t supported..
-        /// </summary>
-        internal static string ExDetectionOfChangesInUserStructureCollectionIsNotSupported {
-            get {
-                return ResourceManager.GetString("ExDetectionOfChangesInUserStructureCollectionIsNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Difference related to {0} type is not found on the UpgradeContext stack..
         /// </summary>
         internal static string ExDifferenceRelatedToXTypeIsNotFoundOnTheUpgradeContextStack {
             get {
                 return ResourceManager.GetString("ExDifferenceRelatedToXTypeIsNotFoundOnTheUpgradeContextStack", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Different TupleDescriptors are not valid here: {0} and {1}..
-        /// </summary>
-        internal static string ExDifferentTupleDescriptors {
-            get {
-                return ResourceManager.GetString("ExDifferentTupleDescriptors", resourceCulture);
             }
         }
         
@@ -2050,38 +1453,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DisconnectedState is already attached to session..
-        /// </summary>
-        internal static string ExDisconnectedStateIsAlreadyAttachedToSession {
-            get {
-                return ResourceManager.GetString("ExDisconnectedStateIsAlreadyAttachedToSession", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to DisconnectedState is detached..
-        /// </summary>
-        internal static string ExDisconnectedStateIsDetached {
-            get {
-                return ResourceManager.GetString("ExDisconnectedStateIsDetached", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to translate &apos;{0}&apos; expression. Downcast from &apos;{1}&apos; to &apos;{2}&apos; not supported. Use &apos;OfType&apos; or &apos;as&apos; operator instead..
         /// </summary>
         internal static string ExDowncastFromXToXNotSupportedUseOfTypeOrAsOperatorInstead {
             get {
                 return ResourceManager.GetString("ExDowncastFromXToXNotSupportedUseOfTypeOrAsOperatorInstead", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Duplicate assembly name: &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExDuplicateAssemblyNameX {
-            get {
-                return ResourceManager.GetString("ExDuplicateAssemblyNameX", resourceCulture);
             }
         }
         
@@ -2140,24 +1516,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Element with name &apos;{0}&apos; is contained in this instance already..
-        /// </summary>
-        internal static string ExElementWithNameContainedInThisInstanceAlready {
-            get {
-                return ResourceManager.GetString("ExElementWithNameContainedInThisInstanceAlready", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Element with type &apos;{0}&apos; is already contained in this instance..
-        /// </summary>
-        internal static string ExElementWithTypeIsContainedInThisInstanceAlready {
-            get {
-                return ResourceManager.GetString("ExElementWithTypeIsContainedInThisInstanceAlready", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Columns collection is empty..
         /// </summary>
         internal static string ExEmptyColumnsCollection {
@@ -2172,15 +1530,6 @@ namespace Xtensive {
         internal static string ExEmptyKeyColumnsCollection {
             get {
                 return ResourceManager.GetString("ExEmptyKeyColumnsCollection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to EndPoints order of both ranges must be equal..
-        /// </summary>
-        internal static string ExEndPointOrderMustBeEqual {
-            get {
-                return ResourceManager.GetString("ExEndPointOrderMustBeEqual", resourceCulture);
             }
         }
         
@@ -2212,29 +1561,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Entity is in inconsistent state..
-        /// </summary>
-        internal static string ExEntityIsInInconsistentState {
-            get {
-                return ResourceManager.GetString("ExEntityIsInInconsistentState", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Entity is removed..
         /// </summary>
         internal static string ExEntityIsRemoved {
             get {
                 return ResourceManager.GetString("ExEntityIsRemoved", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Entity of type &apos;{0}&apos; is incompatible with this EntitySet..
-        /// </summary>
-        internal static string ExEntityOfTypeXIsIncompatibleWithThisEntitySet {
-            get {
-                return ResourceManager.GetString("ExEntityOfTypeXIsIncompatibleWithThisEntitySet", resourceCulture);
             }
         }
         
@@ -2284,51 +1615,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enumeration is already finished..
-        /// </summary>
-        internal static string ExEnumerationIsAlreadyFinished {
-            get {
-                return ResourceManager.GetString("ExEnumerationIsAlreadyFinished", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Enumeration is not started..
-        /// </summary>
-        internal static string ExEnumerationIsNotStarted {
-            get {
-                return ResourceManager.GetString("ExEnumerationIsNotStarted", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to insert instance of type &apos;{0}&apos; with specified key. Query affected {1} tables, but expected {2} tables..
-        /// </summary>
-        internal static string ExErrorOnInsert {
-            get {
-                return ResourceManager.GetString("ExErrorOnInsert", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to update instance of type {0} with specified key. Query affected {1} tables, but expecrted {2} tables..
-        /// </summary>
-        internal static string ExErrorOnUpdate {
-            get {
-                return ResourceManager.GetString("ExErrorOnUpdate", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Some errors have been occurred during storage build. See error log for details..
-        /// </summary>
-        internal static string ExErrorsDuringStorageBuild {
-            get {
-                return ResourceManager.GetString("ExErrorsDuringStorageBuild", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Escape character must differ from delimiter character..
         /// </summary>
         internal static string ExEscapeCharacterMustDifferFromDelimiterCharacter {
@@ -2352,33 +1638,6 @@ namespace Xtensive {
         internal static string ExExceptionHasBeenThrownByTheUserMemberCompiler {
             get {
                 return ResourceManager.GetString("ExExceptionHasBeenThrownByTheUserMemberCompiler", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The exception was thrown during the task&apos;s execution..
-        /// </summary>
-        internal static string ExExceptionWasThrownDuringTaskExecution {
-            get {
-                return ResourceManager.GetString("ExExceptionWasThrownDuringTaskExecution", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to ExcludeFields does not support query provider of type &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExExcludeFieldsDoesNotSupportQueryProviderOfTypeX {
-            get {
-                return ResourceManager.GetString("ExExcludeFieldsDoesNotSupportQueryProviderOfTypeX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The expected value of the parameter is already set..
-        /// </summary>
-        internal static string ExExpectedValueOfParameterIsAlreadySet {
-            get {
-                return ResourceManager.GetString("ExExpectedValueOfParameterIsAlreadySet", resourceCulture);
             }
         }
         
@@ -2410,33 +1669,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The expression having the different normal form must not be a root expression..
-        /// </summary>
-        internal static string ExExpressionHavingDifferentNormalFormMustNotBeRoot {
-            get {
-                return ResourceManager.GetString("ExExpressionHavingDifferentNormalFormMustNotBeRoot", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The expression having the equal normal form must be a root expression..
-        /// </summary>
-        internal static string ExExpressionHavingEqualNormalFormMustBeRoot {
-            get {
-                return ResourceManager.GetString("ExExpressionHavingEqualNormalFormMustBeRoot", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The expression must return a value of type &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExExpressionMustReturnValueOfTypeX {
-            get {
-                return ResourceManager.GetString("ExExpressionMustReturnValueOfTypeX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Expression &apos;{0}&apos; is not a sequence..
         /// </summary>
         internal static string ExExpressionXIsNotASequence {
@@ -2451,16 +1683,6 @@ namespace Xtensive {
         internal static string ExExtractedAndTargetSchemasAreEqualButThereAreChangesInTypeIdentifiersSet {
             get {
                 return ResourceManager.GetString("ExExtractedAndTargetSchemasAreEqualButThereAreChangesInTypeIdentifiersSet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Extracted schema is not compatible with the target schema. Details:
-        ///{0}.
-        /// </summary>
-        internal static string ExExtractedSchemaIsNotCompatibleWithTheTargetSchema_DetailsX {
-            get {
-                return ResourceManager.GetString("ExExtractedSchemaIsNotCompatibleWithTheTargetSchema_DetailsX", resourceCulture);
             }
         }
         
@@ -2489,15 +1711,6 @@ namespace Xtensive {
         internal static string ExFieldBelongsToADifferentType {
             get {
                 return ResourceManager.GetString("ExFieldBelongsToADifferentType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Field with index &apos;{0}&apos; is infinite..
-        /// </summary>
-        internal static string ExFieldIsInfinite {
-            get {
-                return ResourceManager.GetString("ExFieldIsInfinite", resourceCulture);
             }
         }
         
@@ -2583,24 +1796,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Field &apos;{0}&apos; cannot be Nullable as it is included into primary key..
-        /// </summary>
-        internal static string ExFieldXCannotBeNullableAsItIsIncludedInPrimaryKey {
-            get {
-                return ResourceManager.GetString("ExFieldXCannotBeNullableAsItIsIncludedInPrimaryKey", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Field &apos;{0}&apos; has &apos;{1}&apos; type but is marked as not nullable..
-        /// </summary>
-        internal static string ExFieldXHasYTypeButIsMarkedAsNotNullable {
-            get {
-                return ResourceManager.GetString("ExFieldXHasYTypeButIsMarkedAsNotNullable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Field &apos;{0}&apos; is already defined in type &apos;{1}&apos; or in its ancestor..
         /// </summary>
         internal static string ExFieldXIsAlreadyDefinedInTypeXOrItsAncestor {
@@ -2615,15 +1810,6 @@ namespace Xtensive {
         internal static string ExFieldXIsNotAnEntityReferenceNorEntitySet {
             get {
                 return ResourceManager.GetString("ExFieldXIsNotAnEntityReferenceNorEntitySet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Field &apos;{0}&apos; is not an entity set..
-        /// </summary>
-        internal static string ExFieldXIsNotAnEntitySet {
-            get {
-                return ResourceManager.GetString("ExFieldXIsNotAnEntitySet", resourceCulture);
             }
         }
         
@@ -2691,15 +1877,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filter tuple descriptor mistmatches with source mapping descriptor..
-        /// </summary>
-        internal static string ExFilterTupleDescriptorMistmatchesWithSourceMappingDescriptor {
-            get {
-                return ResourceManager.GetString("ExFilterTupleDescriptorMistmatchesWithSourceMappingDescriptor", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The foreign key&apos;s value have not been loaded..
         /// </summary>
         internal static string ExForeignKeyValueHaveNotBeenLoaded {
@@ -2736,15 +1913,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The given key was not present in the dictionary..
-        /// </summary>
-        internal static string ExGivenKeyNotPresent {
-            get {
-                return ResourceManager.GetString("ExGivenKeyNotPresent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to GroupBy overload &apos;{0}&apos; is not supported..
         /// </summary>
         internal static string ExGroupByOverloadXIsNotSupported {
@@ -2759,15 +1927,6 @@ namespace Xtensive {
         internal static string ExHierarchyIsNotFoundForTypeX {
             get {
                 return ResourceManager.GetString("ExHierarchyIsNotFoundForTypeX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Hierarchy root is not registered..
-        /// </summary>
-        internal static string ExHierarchyRootIsNotRegistered {
-            get {
-                return ResourceManager.GetString("ExHierarchyRootIsNotRegistered", resourceCulture);
             }
         }
         
@@ -2818,65 +1977,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Conversion from type {0} to type {1} is inadmissible..
-        /// </summary>
-        internal static string ExInadmissibleTypeConversion {
-            get {
-                return ResourceManager.GetString("ExInadmissibleTypeConversion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to IncludeFields does not support query provider of type &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExIncludeFieldsDoesNotSupportQueryProviderOfTypeX {
-            get {
-                return ResourceManager.GetString("ExIncludeFieldsDoesNotSupportQueryProviderOfTypeX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Incompatible array type..
-        /// </summary>
-        internal static string ExIncompatibleArrayType {
-            get {
-                return ResourceManager.GetString("ExIncompatibleArrayType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The two collections cannot be combined because they use different comparison operations..
-        /// </summary>
-        internal static string ExInconsistentComparisons {
-            get {
-                return ResourceManager.GetString("ExInconsistentComparisons", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Incorrect command parameters..
         /// </summary>
         internal static string ExIncorrectCommandParameters {
             get {
                 return ResourceManager.GetString("ExIncorrectCommandParameters", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Incorrect namespace synonyms..
-        /// </summary>
-        internal static string ExIncorrectNamespaceSynonyms {
-            get {
-                return ResourceManager.GetString("ExIncorrectNamespaceSynonyms", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Incorrect Stage value: &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExIncorrectStageValue {
-            get {
-                return ResourceManager.GetString("ExIncorrectStageValue", resourceCulture);
             }
         }
         
@@ -2904,33 +2009,6 @@ namespace Xtensive {
         internal static string ExIndexedPropertiesAreNotSupported {
             get {
                 return ResourceManager.GetString("ExIndexedPropertiesAreNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Indexes of columns to be loaded are not specified..
-        /// </summary>
-        internal static string ExIndexesOfColumnsToBeLoadedAreNotSpecified {
-            get {
-                return ResourceManager.GetString("ExIndexesOfColumnsToBeLoadedAreNotSpecified", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Index field &apos;{0}&apos; is incorrect..
-        /// </summary>
-        internal static string ExIndexFieldXIsIncorrect {
-            get {
-                return ResourceManager.GetString("ExIndexFieldXIsIncorrect", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Index &apos;{0}&apos; is changed..
-        /// </summary>
-        internal static string ExIndexIsChanged {
-            get {
-                return ResourceManager.GetString("ExIndexIsChanged", resourceCulture);
             }
         }
         
@@ -3034,51 +2112,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multiple instances of type &apos;{0}&apos; with specified key are found..
-        /// </summary>
-        internal static string ExInstanceMultipleResults {
-            get {
-                return ResourceManager.GetString("ExInstanceMultipleResults", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Instance must be locked before this operation..
-        /// </summary>
-        internal static string ExInstanceMustBeLockedBeforeThisOperation {
-            get {
-                return ResourceManager.GetString("ExInstanceMustBeLockedBeforeThisOperation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A instance must have non-null IHasSyncRoot.SyncRoot property value..
-        /// </summary>
-        internal static string ExInstanceMustHaveSyncRoot {
-            get {
-                return ResourceManager.GetString("ExInstanceMustHaveSyncRoot", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Instance of type &apos;{0}&apos; with specified key is not found..
-        /// </summary>
-        internal static string ExInstanceNotFound {
-            get {
-                return ResourceManager.GetString("ExInstanceNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Interface &apos;{0}&apos; does not belong to &apos;{1}&apos; hierarchy..
-        /// </summary>
-        internal static string ExInterfaceXDoesNotBelongToXHierarchy {
-            get {
-                return ResourceManager.GetString("ExInterfaceXDoesNotBelongToXHierarchy", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Interface &apos;{0}&apos; is implemented by types mapped to different databases: {1}, {2}.
         /// </summary>
         internal static string ExInterfaceXIsImplementedByTypesMappedToDifferentDatabasesYZ {
@@ -3102,24 +2135,6 @@ namespace Xtensive {
         internal static string ExInvalidActionType {
             get {
                 return ResourceManager.GetString("ExInvalidActionType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Active scope is invalid - it differs from the expected one. Probably you have forgot to dispose some nested scope..
-        /// </summary>
-        internal static string ExInvalidActiveScope {
-            get {
-                return ResourceManager.GetString("ExInvalidActiveScope", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid AfterPath property value..
-        /// </summary>
-        internal static string ExInvalidAfterPathPropertyValue {
-            get {
-                return ResourceManager.GetString("ExInvalidAfterPathPropertyValue", resourceCulture);
             }
         }
         
@@ -3250,24 +2265,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid field name &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExInvalidFieldNameX {
-            get {
-                return ResourceManager.GetString("ExInvalidFieldNameX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid field value, constraint {0} is violated..
-        /// </summary>
-        internal static string ExInvalidFieldValueConstraintXIsViolated {
-            get {
-                return ResourceManager.GetString("ExInvalidFieldValueConstraintXIsViolated", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Invalid fill factor &apos;{0}&apos;. Value must be between 0 and 1..
         /// </summary>
         internal static string ExInvalidFillFactorXValueMustBeBetween0And1 {
@@ -3286,29 +2283,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; formatter process type is invalid for the current operation..
-        /// </summary>
-        internal static string ExInvalidFormatterProcessType {
-            get {
-                return ResourceManager.GetString("ExInvalidFormatterProcessType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to IncludedColumns collection is invalid..
         /// </summary>
         internal static string ExInvalidIncludedColumnsCollection {
             get {
                 return ResourceManager.GetString("ExInvalidIncludedColumnsCollection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to create Key. Key params do not correspond to its structure..
-        /// </summary>
-        internal static string ExInvalidKeyParams {
-            get {
-                return ResourceManager.GetString("ExInvalidKeyParams", resourceCulture);
             }
         }
         
@@ -3327,15 +2306,6 @@ namespace Xtensive {
         internal static string ExInvalidLengthAttributeOnXField {
             get {
                 return ResourceManager.GetString("ExInvalidLengthAttributeOnXField", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid mapping name &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExInvalidMappingNameX {
-            get {
-                return ResourceManager.GetString("ExInvalidMappingNameX", resourceCulture);
             }
         }
         
@@ -3376,38 +2346,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Object serializer is invalid, since similar value serializer exists..
-        /// </summary>
-        internal static string ExInvalidObjectSerializerSimilarValueSerializerExists {
-            get {
-                return ResourceManager.GetString("ExInvalidObjectSerializerSimilarValueSerializerExists", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid Parent value..
-        /// </summary>
-        internal static string ExInvalidParentValue {
-            get {
-                return ResourceManager.GetString("ExInvalidParentValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Invalid Precision attribute on field &apos;{0}&apos;..
         /// </summary>
         internal static string ExInvalidPrecisionAttributeOnFieldX {
             get {
                 return ResourceManager.GetString("ExInvalidPrecisionAttributeOnFieldX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid prefetch selector &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExInvalidPrefetchSelectorX {
-            get {
-                return ResourceManager.GetString("ExInvalidPrefetchSelectorX", resourceCulture);
             }
         }
         
@@ -3430,15 +2373,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Record with invalid (possibly - unspecified) type is found..
-        /// </summary>
-        internal static string ExInvalidRecordType {
-            get {
-                return ResourceManager.GetString("ExInvalidRecordType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Invalid Scale attribute on field &apos;{0}&apos;..
         /// </summary>
         internal static string ExInvalidScaleAttributeOnFieldX {
@@ -3457,33 +2391,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; can&apos;t be an IsReferable serializer, since it serializes IReference type..
-        /// </summary>
-        internal static string ExInvalidSerializerBehaviorMustNotBeReferable {
-            get {
-                return ResourceManager.GetString("ExInvalidSerializerBehaviorMustNotBeReferable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Generic parameter T is resolved to associated &apos;{0}&apos;, although &apos;{1}&apos; is expected..
-        /// </summary>
-        internal static string ExInvalidSerializerType {
-            get {
-                return ResourceManager.GetString("ExInvalidSerializerType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The Session of specified ISessionBound object is invalid..
-        /// </summary>
-        internal static string ExInvalidSession {
-            get {
-                return ResourceManager.GetString("ExInvalidSession", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Invalid sort expression &apos;{0}&apos;.
         /// </summary>
         internal static string ExInvalidSortExpressionX {
@@ -3493,29 +2400,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid transaction state (&apos;{0}&apos;). Expected state(s) is (are) &apos;{1}&apos;..
-        /// </summary>
-        internal static string ExInvalidTransactionState {
-            get {
-                return ResourceManager.GetString("ExInvalidTransactionState", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Invalid TupleDescriptor. Expected descriptor is {0}..
         /// </summary>
         internal static string ExInvalidTupleDescriptorExpectedDescriptorIs {
             get {
                 return ResourceManager.GetString("ExInvalidTupleDescriptorExpectedDescriptorIs", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid upgrader version..
-        /// </summary>
-        internal static string ExInvalidUpgraderVersion {
-            get {
-                return ResourceManager.GetString("ExInvalidUpgraderVersion", resourceCulture);
             }
         }
         
@@ -3574,65 +2463,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The specified item cannot be cached because its type is incompatible with underlying storage format..
-        /// </summary>
-        internal static string ExItemCantBeCachedIncompatibleType {
-            get {
-                return ResourceManager.GetString("ExItemCantBeCachedIncompatibleType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The specified item cannot be cached because its type is incompatible with ITuple..
-        /// </summary>
-        internal static string ExItemCantBeComparedIncompatibleType {
-            get {
-                return ResourceManager.GetString("ExItemCantBeComparedIncompatibleType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Specified item is already in use..
-        /// </summary>
-        internal static string ExItemIsInUse {
-            get {
-                return ResourceManager.GetString("ExItemIsInUse", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Specified item is not in use..
-        /// </summary>
-        internal static string ExItemIsNotInUse {
-            get {
-                return ResourceManager.GetString("ExItemIsNotInUse", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Specified item isn&apos;t pooled..
-        /// </summary>
-        internal static string ExItemIsNotPooled {
-            get {
-                return ResourceManager.GetString("ExItemIsNotPooled", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Specified item isn&apos;t found..
         /// </summary>
         internal static string ExItemNotFound {
             get {
                 return ResourceManager.GetString("ExItemNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Item is not found in EntitySet..
-        /// </summary>
-        internal static string ExItemNotFoundInEntitySet {
-            get {
-                return ResourceManager.GetString("ExItemNotFoundInEntitySet", resourceCulture);
             }
         }
         
@@ -3709,15 +2544,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Key already exists..
-        /// </summary>
-        internal static string ExKeyAlreadyExists {
-            get {
-                return ResourceManager.GetString("ExKeyAlreadyExists", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The Key belongs to different storage node..
         /// </summary>
         internal static string ExKeyBelongsToDifferentStorageNode {
@@ -3745,15 +2571,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Key contains multiple fields with IsTypeId==true flag..
-        /// </summary>
-        internal static string ExKeyContainsMultipleFieldsWithIsTypeIdTrueFlag {
-            get {
-                return ResourceManager.GetString("ExKeyContainsMultipleFieldsWithIsTypeIdTrueFlag", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Key field can&apos;t be of &apos;{0}&apos; type..
         /// </summary>
         internal static string ExKeyFieldCantBeOfXType {
@@ -3777,15 +2594,6 @@ namespace Xtensive {
         internal static string ExKeyFieldXInTypeYShouldNotHaveSetAccessor {
             get {
                 return ResourceManager.GetString("ExKeyFieldXInTypeYShouldNotHaveSetAccessor", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Key field &apos;{0}&apos; was not found in type &apos;{1}&apos;..
-        /// </summary>
-        internal static string ExKeyFieldXWasNotFoundInTypeY {
-            get {
-                return ResourceManager.GetString("ExKeyFieldXWasNotFoundInTypeY", resourceCulture);
             }
         }
         
@@ -3835,38 +2643,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Key of specified type cannot be generated by this KeyGenerator..
-        /// </summary>
-        internal static string ExKeyOfSpecifiedTypeCannotBeGeneratedByThisKeyGenerator {
-            get {
-                return ResourceManager.GetString("ExKeyOfSpecifiedTypeCannotBeGeneratedByThisKeyGenerator", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Key of &apos;{0}&apos; does not match key of &apos;{1}&apos;..
         /// </summary>
         internal static string ExKeyOfXDoesNotMatchKeyOfY {
             get {
                 return ResourceManager.GetString("ExKeyOfXDoesNotMatchKeyOfY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Key provider &apos;{0}&apos; and hierarchy {1} key field amount mismatch..
-        /// </summary>
-        internal static string ExKeyProviderXAndHierarchyYKeyFieldAmountMismatch {
-            get {
-                return ResourceManager.GetString("ExKeyProviderXAndHierarchyYKeyFieldAmountMismatch", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Key provider &apos;{0}&apos; should define at least one key field..
-        /// </summary>
-        internal static string ExKeyProviderXShouldDefineAtLeastOneKeyField {
-            get {
-                return ResourceManager.GetString("ExKeyProviderXShouldDefineAtLeastOneKeyField", resourceCulture);
             }
         }
         
@@ -3916,15 +2697,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Key &apos;{0}&apos; was not found in storage..
-        /// </summary>
-        internal static string ExKeyXWasNotFoundInStorage {
-            get {
-                return ResourceManager.GetString("ExKeyXWasNotFoundInStorage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to LambdaExpression returned by &apos;{0}&apos; should return value that is assignable to &apos;{1}&apos;.
         /// </summary>
         internal static string ExLambdaExpressionReturnedByXShouldReturnValueThatIsAssignableToY {
@@ -3961,39 +2733,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Lambda &apos;{0}&apos; must have only one parameter..
-        /// </summary>
-        internal static string ExLambdaXMustHaveOnlyOneParameter {
-            get {
-                return ResourceManager.GetString("ExLambdaXMustHaveOnlyOneParameter", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to LeftJoin does not support query provider of type &apos;{0}&apos;..
         /// </summary>
         internal static string ExLeftJoinDoesNotSupportQueryProviderOfTypeX {
             get {
                 return ResourceManager.GetString("ExLeftJoinDoesNotSupportQueryProviderOfTypeX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Legacy schema is not compatible. Details: 
-        ///{0}.
-        /// </summary>
-        internal static string ExLegacySchemaIsNotCompatible_DetailsX {
-            get {
-                return ResourceManager.GetString("ExLegacySchemaIsNotCompatible_DetailsX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &apos;Length&apos; constraint violation on field &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExLengthConstraintViolationOnFieldX {
-            get {
-                return ResourceManager.GetString("ExLengthConstraintViolationOnFieldX", resourceCulture);
             }
         }
         
@@ -4007,47 +2751,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The limit of the graph depth is exceeded..
-        /// </summary>
-        internal static string ExLimitOfGraphDepthIsExceeded {
-            get {
-                return ResourceManager.GetString("ExLimitOfGraphDepthIsExceeded", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Linked operation for property {0} missing..
-        /// </summary>
-        internal static string ExLinkedOperationMissingFormat {
-            get {
-                return ResourceManager.GetString("ExLinkedOperationMissingFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to translate expression &apos;{0}&apos;. LINQ translator does not support method &apos;{1}&apos;..
         /// </summary>
         internal static string ExLinqTranslatorDoesNotSupportMethodX {
             get {
                 return ResourceManager.GetString("ExLinqTranslatorDoesNotSupportMethodX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Literal type &apos;{0}&apos; is not supported..
-        /// </summary>
-        internal static string ExLiteralTypeXIsNotSupported {
-            get {
-                return ResourceManager.GetString("ExLiteralTypeXIsNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Local collection should not be query root..
-        /// </summary>
-        internal static string ExLocalCollectionShouldNotBeQueryRoot {
-            get {
-                return ResourceManager.GetString("ExLocalCollectionShouldNotBeQueryRoot", resourceCulture);
             }
         }
         
@@ -4088,29 +2796,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Loop in action dependency chain is detected..
-        /// </summary>
-        internal static string ExLoopInActionDependencyChain {
-            get {
-                return ResourceManager.GetString("ExLoopInActionDependencyChain", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The mapping for the property {0} has already been registered..
         /// </summary>
         internal static string ExMappingForPropertyXHasAlreadyBeenRegistered {
             get {
                 return ResourceManager.GetString("ExMappingForPropertyXHasAlreadyBeenRegistered", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Materialization error: Entity&apos;s TypeId column does not exist in the underlying RecordSet..
-        /// </summary>
-        internal static string ExMaterializationErrorTypeIdColumnDoesNotExistsInTheUnderlyingRecordSet {
-            get {
-                return ResourceManager.GetString("ExMaterializationErrorTypeIdColumnDoesNotExistsInTheUnderlyingRecordSet", resourceCulture);
             }
         }
         
@@ -4188,15 +2878,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Merge operation require intersection of operands..
-        /// </summary>
-        internal static string ExMergeOperationRequireIntersectionOfOperands {
-            get {
-                return ResourceManager.GetString("ExMergeOperationRequireIntersectionOfOperands", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to MethodCall expression &apos;{0}&apos; is not supported..
         /// </summary>
         internal static string ExMethodCallExpressionXIsNotSupported {
@@ -4220,15 +2901,6 @@ namespace Xtensive {
         internal static string ExMethodXNotFound {
             get {
                 return ResourceManager.GetString("ExMethodXNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to MinMaxValues aren&apos;t supported for TupleFieldAdvancedComparer..
-        /// </summary>
-        internal static string ExMinMaxValuesAreNotSupportedForTupleFieldAdvancedComparer {
-            get {
-                return ResourceManager.GetString("ExMinMaxValuesAreNotSupportedForTupleFieldAdvancedComparer", resourceCulture);
             }
         }
         
@@ -4287,15 +2959,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ValueColumns collection contains more then one reference to column &quot;{0}&quot;..
-        /// </summary>
-        internal static string ExMoreThenOneValueColumnReferenceToColumnX {
-            get {
-                return ResourceManager.GetString("ExMoreThenOneValueColumnReferenceToColumnX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Multi-database mode is active, but no database specified for &apos;{0}&apos;.
         /// </summary>
         internal static string ExMultidatabaseModeIsActiveButNoDatabaseSpecifiedForX {
@@ -4328,24 +2991,6 @@ namespace Xtensive {
         internal static string ExMultipleHintsFound {
             get {
                 return ResourceManager.GetString("ExMultipleHintsFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Multiple languages not supported for fulltext column {0} of index {1}..
-        /// </summary>
-        internal static string ExMultipleLanguagesNotSupportedForFulltextColumnXOfIndexY {
-            get {
-                return ResourceManager.GetString("ExMultipleLanguagesNotSupportedForFulltextColumnXOfIndexY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Specified query returns multiple results..
-        /// </summary>
-        internal static string ExMultipleResults {
-            get {
-                return ResourceManager.GetString("ExMultipleResults", resourceCulture);
             }
         }
         
@@ -4395,24 +3040,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Name &apos;{0}&apos; is invalid..
-        /// </summary>
-        internal static string ExNameXIsInvalid {
-            get {
-                return ResourceManager.GetString("ExNameXIsInvalid", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Nested collection is not supported..
-        /// </summary>
-        internal static string ExNestedCollectionIsNotSupported {
-            get {
-                return ResourceManager.GetString("ExNestedCollectionIsNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Nested field &apos;{0}&apos; is not supported..
         /// </summary>
         internal static string ExNestedFieldXIsNotSupported {
@@ -4422,29 +3049,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There are no more available items..
-        /// </summary>
-        internal static string ExNoAvailableItems {
-            get {
-                return ResourceManager.GetString("ExNoAvailableItems", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Comparer.Current is null..
         /// </summary>
         internal static string ExNoCurrentComparer {
             get {
                 return ResourceManager.GetString("ExNoCurrentComparer", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to There is no current Session..
-        /// </summary>
-        internal static string ExNoCurrentSession {
-            get {
-                return ResourceManager.GetString("ExNoCurrentSession", resourceCulture);
             }
         }
         
@@ -4476,15 +3085,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No message template is registered for code: {0}.
-        /// </summary>
-        internal static string ExNoMessageTemplateIsRegisteredForCodeX {
-            get {
-                return ResourceManager.GetString("ExNoMessageTemplateIsRegisteredForCodeX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Non-enum parameters for Enum.HasFlag are not supported.
         /// </summary>
         internal static string ExNonEnumParametersForEnumHasFlagAreNotSupported {
@@ -4512,15 +3112,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Non-temporary keys must be generated by descendants..
-        /// </summary>
-        internal static string ExNonTemporaryKeysMustBeGeneratedByDescendants {
-            get {
-                return ResourceManager.GetString("ExNonTemporaryKeysMustBeGeneratedByDescendants", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to There is no object with specified key..
         /// </summary>
         internal static string ExNoObjectWithSpecifiedKey {
@@ -4539,33 +3130,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The normalized boolean expression must be the root expression..
-        /// </summary>
-        internal static string ExNormalizedExpressionMustBeRoot {
-            get {
-                return ResourceManager.GetString("ExNormalizedExpressionMustBeRoot", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The normalized boolean expression must have the &apos;{0}&apos; form..
-        /// </summary>
-        internal static string ExNormalizedExpressionMustHaveXForm {
-            get {
-                return ResourceManager.GetString("ExNormalizedExpressionMustHaveXForm", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The normalized boolean expression must not be the root expression..
-        /// </summary>
-        internal static string ExNormalizedExpressionMustNotBeRoot {
-            get {
-                return ResourceManager.GetString("ExNormalizedExpressionMustNotBeRoot", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Instance is not initialized (or not initialized properly)..
         /// </summary>
         internal static string ExNotInitialized {
@@ -4575,38 +3139,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;NotNullable&apos; constraint violation on field &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExNotNullableConstraintViolationOnFieldX {
-            get {
-                return ResourceManager.GetString("ExNotNullableConstraintViolationOnFieldX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to No upgrade handler is found for assembly &apos;{0}&apos;, version &apos;{1}&apos;..
-        /// </summary>
-        internal static string ExNoUpgradeHandlerIsFoundForAssemblyXVersionY {
-            get {
-                return ResourceManager.GetString("ExNoUpgradeHandlerIsFoundForAssemblyXVersionY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Nullable and NullableOnUpgrade flags can&apos;t be used with &apos;{0}&apos; field. They can be used only with reference-typed fields (except Structure descendants)..
         /// </summary>
         internal static string ExNullableAndNullableOnUpgradeCannotBeUsedWithXField {
             get {
                 return ResourceManager.GetString("ExNullableAndNullableOnUpgradeCannotBeUsedWithXField", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The nullable property {0} is bound to the property {1} that isn&apos;t nullable..
-        /// </summary>
-        internal static string ExNullablePropertyXIsBoundToPropertyYThatIsNotNullable {
-            get {
-                return ResourceManager.GetString("ExNullablePropertyXIsBoundToPropertyYThatIsNotNullable", resourceCulture);
             }
         }
         
@@ -4638,47 +3175,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You can&apos;t Activate new operation, since old ActiveOperation is still running..
-        /// </summary>
-        internal static string ExOldActiveOperationIsStillRunning {
-            get {
-                return ResourceManager.GetString("ExOldActiveOperationIsStillRunning", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Only breakable nodes :(.
         /// </summary>
         internal static string ExOnlyBreakableNodesSadSmile {
             get {
                 return ResourceManager.GetString("ExOnlyBreakableNodesSadSmile", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Only entities could be hierarchy roots..
-        /// </summary>
-        internal static string ExOnlyEntitiesCouldBeHierarchyRoots {
-            get {
-                return ResourceManager.GetString("ExOnlyEntitiesCouldBeHierarchyRoots", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Only equality ranges are supported..
-        /// </summary>
-        internal static string ExOnlyEqualityRangesAreSupported {
-            get {
-                return ResourceManager.GetString("ExOnlyEqualityRangesAreSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Only the normalized expression having the different normal form can be added as the immediate descendant to the root expression..
-        /// </summary>
-        internal static string ExOnlyNormalizedExpressionCanBeAddedAsChildToRoot {
-            get {
-                return ResourceManager.GetString("ExOnlyNormalizedExpressionCanBeAddedAsChildToRoot", resourceCulture);
             }
         }
         
@@ -4697,15 +3198,6 @@ namespace Xtensive {
         internal static string ExOnlyOneOperationCanBeRegisteredInEachScope {
             get {
                 return ResourceManager.GetString("ExOnlyOneOperationCanBeRegisteredInEachScope", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Only one primary operation can be logged by each OperationContext instance..
-        /// </summary>
-        internal static string ExOnlyOnePrimaryOperationCanBeLogged {
-            get {
-                return ResourceManager.GetString("ExOnlyOnePrimaryOperationCanBeLogged", resourceCulture);
             }
         }
         
@@ -4782,33 +3274,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Operation LinkType should be defined before it can be registered in OperationDictionary..
-        /// </summary>
-        internal static string ExOperationLinkTypeUndefined {
-            get {
-                return ResourceManager.GetString("ExOperationLinkTypeUndefined", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Operation must be locked before it can be registered in OperationDictionary..
-        /// </summary>
-        internal static string ExOperationMustBeLocked {
-            get {
-                return ResourceManager.GetString("ExOperationMustBeLocked", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Operation PropertyName must be specified before it can be registered in OperationDictionary..
-        /// </summary>
-        internal static string ExOperationPropertyNameUndefined {
-            get {
-                return ResourceManager.GetString("ExOperationPropertyNameUndefined", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to OperatonStarted is alerady called for this operation..
         /// </summary>
         internal static string ExOperationStartedIsAlreadyCalledForThisOperation {
@@ -4854,38 +3319,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Origin is not null..
-        /// </summary>
-        internal static string ExOriginIsNotNull {
-            get {
-                return ResourceManager.GetString("ExOriginIsNotNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Origin is null..
-        /// </summary>
-        internal static string ExOriginIsNull {
-            get {
-                return ResourceManager.GetString("ExOriginIsNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Outer parameter reference found, but no SqlCompiler provided.
         /// </summary>
         internal static string ExOuterParameterReferenceFoundButNoSqlCompilerProvided {
             get {
                 return ResourceManager.GetString("ExOuterParameterReferenceFoundButNoSqlCompilerProvided", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Object is outside of initial transaction scope..
-        /// </summary>
-        internal static string ExOutOfTransactionScope {
-            get {
-                return ResourceManager.GetString("ExOutOfTransactionScope", resourceCulture);
             }
         }
         
@@ -4913,15 +3351,6 @@ namespace Xtensive {
         internal static string ExPairedIdentityColumnsForTypesXAndXNotFound {
             get {
                 return ResourceManager.GetString("ExPairedIdentityColumnsForTypesXAndXNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to [Association] attribute with PairTo can not be use with field &apos;{0}&apos; of type &apos;{1}&apos;. It is already applied to field &apos;{2}&apos; of type &apos;{3}&apos;..
-        /// </summary>
-        internal static string ExPairToAttributeCanNotBeAppliedToXField {
-            get {
-                return ResourceManager.GetString("ExPairToAttributeCanNotBeAppliedToXField", resourceCulture);
             }
         }
         
@@ -4998,33 +3427,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pool should be in syncronized mode to utilize AutoCleanup feature..
-        /// </summary>
-        internal static string ExPoolMustBeSyncronized {
-            get {
-                return ResourceManager.GetString("ExPoolMustBeSyncronized", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Item already exists in the pool with another key..
-        /// </summary>
-        internal static string ExPoolWrongKey {
-            get {
-                return ResourceManager.GetString("ExPoolWrongKey", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Port value must be in [0,65535] range..
-        /// </summary>
-        internal static string ExPortOutOfRange {
-            get {
-                return ResourceManager.GetString("ExPortOutOfRange", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Position value should be greater than zero..
         /// </summary>
         internal static string ExPositionValueShouldBeGreaterThanZero {
@@ -5034,29 +3436,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Precision should be non-negative value..
-        /// </summary>
-        internal static string ExPrecisionShouldBeNonNegativeValue {
-            get {
-                return ResourceManager.GetString("ExPrecisionShouldBeNonNegativeValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Predicate contains accesses to different ApplyParameters..
         /// </summary>
         internal static string ExPredicateContainsAccessesToDifferentApplyParameters {
             get {
                 return ResourceManager.GetString("ExPredicateContainsAccessesToDifferentApplyParameters", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Prefetch does not support query provider of type &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExPrefetchDoesNotSupportQueryProviderOfTypeX {
-            get {
-                return ResourceManager.GetString("ExPrefetchDoesNotSupportQueryProviderOfTypeX", resourceCulture);
             }
         }
         
@@ -5097,15 +3481,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Field &apos;{0}&apos; is a part of primary key. It can&apos;t be changed..
-        /// </summary>
-        internal static string ExPrimaryKeyFieldCantBeChanged {
-            get {
-                return ResourceManager.GetString("ExPrimaryKeyFieldCantBeChanged", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Primary key field &apos;{0}&apos; can&apos;t be marked as Version..
         /// </summary>
         internal static string ExPrimaryKeyFieldXCanTBeMarkedAsVersion {
@@ -5115,38 +3490,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The primitive property {0} is bound to the property {1} that isn&apos;t primitive..
-        /// </summary>
-        internal static string ExPrimitivePropertyXIsBoundToPropertyYThatIsNotPrimitive {
-            get {
-                return ResourceManager.GetString("ExPrimitivePropertyXIsBoundToPropertyYThatIsNotPrimitive", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Processing of VoidProvider is not supported..
         /// </summary>
         internal static string ExProcessingOfVoidProviderIsNotSupported {
             get {
                 return ResourceManager.GetString("ExProcessingOfVoidProviderIsNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The properties {0} and {1} have different primitive types..
-        /// </summary>
-        internal static string ExPropertiesXAndYHaveDifferentPrimitiveTypes {
-            get {
-                return ResourceManager.GetString("ExPropertiesXAndYHaveDifferentPrimitiveTypes", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The properties &quot;{0}&quot; and &quot;{1}&quot; have incompatible types..
-        /// </summary>
-        internal static string ExPropertiesXAndYHaveIncompatibleTypes {
-            get {
-                return ResourceManager.GetString("ExPropertiesXAndYHaveIncompatibleTypes", resourceCulture);
             }
         }
         
@@ -5196,38 +3544,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Property &apos;{0}&apos; doesn&apos;t have public setter..
-        /// </summary>
-        internal static string ExPropertyXDoesnTHavePublicSetter {
-            get {
-                return ResourceManager.GetString("ExPropertyXDoesnTHavePublicSetter", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Property &apos;{0}&apos; must be declared in type &apos;{1}&apos;..
         /// </summary>
         internal static string ExPropertyXMustBeDeclaredInTypeY {
             get {
                 return ResourceManager.GetString("ExPropertyXMustBeDeclaredInTypeY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Property &apos;{0}.{1}&apos; doesn&apos;t have public getter..
-        /// </summary>
-        internal static string ExPropertyXYDoesnTHavePublicGetter {
-            get {
-                return ResourceManager.GetString("ExPropertyXYDoesnTHavePublicGetter", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Property &quot;{0}.{1}&quot; is not found..
-        /// </summary>
-        internal static string ExPropertyXYIsNotFound {
-            get {
-                return ResourceManager.GetString("ExPropertyXYIsNotFound", resourceCulture);
             }
         }
         
@@ -5259,15 +3580,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The query contains closures of different types..
-        /// </summary>
-        internal static string ExQueryContainsClosuresOfDifferentTypes {
-            get {
-                return ResourceManager.GetString("ExQueryContainsClosuresOfDifferentTypes", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The SQL query has too many parameters. The server supports a maximum of {0} parameters..
         /// </summary>
         internal static string ExQueryHasTooManyParametersMaxCountOfParametersIsX {
@@ -5282,24 +3594,6 @@ namespace Xtensive {
         internal static string ExQueryTaskIsNotExecutedYet {
             get {
                 return ResourceManager.GetString("ExQueryTaskIsNotExecutedYet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Range is empty..
-        /// </summary>
-        internal static string ExRangeIsEmpty {
-            get {
-                return ResourceManager.GetString("ExRangeIsEmpty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Reader is not in consistent state..
-        /// </summary>
-        internal static string ExReaderIsNotInConsistentState {
-            get {
-                return ResourceManager.GetString("ExReaderIsNotInConsistentState", resourceCulture);
             }
         }
         
@@ -5327,60 +3621,6 @@ namespace Xtensive {
         internal static string ExReferencedColumnsCountCantBeLessThenOne {
             get {
                 return ResourceManager.GetString("ExReferencedColumnsCountCantBeLessThenOne", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Referenced column &quot;{0}&quot; does not belong to index &quot;{1}&quot;..
-        /// </summary>
-        internal static string ExReferencedColumnXDoesNotBelongToIndexY {
-            get {
-                return ResourceManager.GetString("ExReferencedColumnXDoesNotBelongToIndexY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Referenced field &apos;{0}&apos; and paired field are equal..
-        /// </summary>
-        internal static string ExReferencedFieldXAndPairedFieldAreEqual {
-            get {
-                return ResourceManager.GetString("ExReferencedFieldXAndPairedFieldAreEqual", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Reference &apos;{0}&apos; is already defined..
-        /// </summary>
-        internal static string ExReferenceIsAlreadyDefined {
-            get {
-                return ResourceManager.GetString("ExReferenceIsAlreadyDefined", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Reference &apos;{0}&apos; is not resolved yet..
-        /// </summary>
-        internal static string ExReferenceIsNotResolvedYet {
-            get {
-                return ResourceManager.GetString("ExReferenceIsNotResolvedYet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Reference points to null..
-        /// </summary>
-        internal static string ExReferenceIsNull {
-            get {
-                return ResourceManager.GetString("ExReferenceIsNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The reference property {0} is bound to the property {1} that isn&apos;t reference..
-        /// </summary>
-        internal static string ExReferencePropertyXIsBoundToPropertyYThatIsNotReference {
-            get {
-                return ResourceManager.GetString("ExReferencePropertyXIsBoundToPropertyYThatIsNotReference", resourceCulture);
             }
         }
         
@@ -5430,15 +3670,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Referential integrity violation..
-        /// </summary>
-        internal static string ExReferentialIntegrityViolation {
-            get {
-                return ResourceManager.GetString("ExReferentialIntegrityViolation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Request is not prepared.
         /// </summary>
         internal static string ExRequestIsNotPrepared {
@@ -5475,15 +3706,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Row amount should be positive number..
-        /// </summary>
-        internal static string ExRowAmountShouldBePositiveNumber {
-            get {
-                return ResourceManager.GetString("ExRowAmountShouldBePositiveNumber", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to ROW_NUMBER window function is not supported on this version of PostgreSQL.
         /// </summary>
         internal static string ExRowNumberWindowFunctionIsNotSupportedOnThisVersionOfPostgreSql {
@@ -5502,15 +3724,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Scale should be non-negative value..
-        /// </summary>
-        internal static string ExScaleShouldBeNonNegativeValue {
-            get {
-                return ResourceManager.GetString("ExScaleShouldBeNonNegativeValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Schema mapping requires multischema domain configuration. Please provide at least DefaultSchema setting..
         /// </summary>
         internal static string ExSchemaMappingRequiresMultischemaDomainConfiguration {
@@ -5525,15 +3738,6 @@ namespace Xtensive {
         internal static string ExSchemaMustBeNotNull {
             get {
                 return ResourceManager.GetString("ExSchemaMustBeNotNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Scope-bound transaction can be committed only by its scope. Use TransactionScopeBase.Complete() \  Dispose() methods of  appropriate TransactionScopeBase descendant instance to do this..
-        /// </summary>
-        internal static string ExScopeBoundTransactionCanBeCommittedOnlyByItsScope {
-            get {
-                return ResourceManager.GetString("ExScopeBoundTransactionCanBeCommittedOnlyByItsScope", resourceCulture);
             }
         }
         
@@ -5570,15 +3774,6 @@ namespace Xtensive {
         internal static string ExSegmentIsOutOfRange {
             get {
                 return ResourceManager.GetString("ExSegmentIsOutOfRange", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SelectMany collection selector &apos;{0}&apos; must have only one lambda parameter..
-        /// </summary>
-        internal static string ExSelectManyCollectionSelector0MustHaveOnlyOneLambdaParameter {
-            get {
-                return ResourceManager.GetString("ExSelectManyCollectionSelector0MustHaveOnlyOneLambdaParameter", resourceCulture);
             }
         }
         
@@ -5646,15 +3841,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Service with name &apos;{0}&apos; already exists in StorageInfo.Services collection..
-        /// </summary>
-        internal static string ExServiceWithNameAlreadyExistsInStorageInfoServicesCollection {
-            get {
-                return ResourceManager.GetString("ExServiceWithNameAlreadyExistsInStorageInfoServicesCollection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Service with name &quot;{0}&quot; of type &apos;{1}&apos; is not available..
         /// </summary>
         internal static string ExServiceWithNameXOfTypeYIsNotAvailable {
@@ -5669,15 +3855,6 @@ namespace Xtensive {
         internal static string ExServiceXIsNotSupported {
             get {
                 return ResourceManager.GetString("ExServiceXIsNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Session bound object is out of session scope..
-        /// </summary>
-        internal static string ExSessionBoundObjectOutOfSessionScope {
-            get {
-                return ResourceManager.GetString("ExSessionBoundObjectOutOfSessionScope", resourceCulture);
             }
         }
         
@@ -5736,15 +3913,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Size should be not negative value..
-        /// </summary>
-        internal static string ExSizeShouldBeNotNegativeValue {
-            get {
-                return ResourceManager.GetString("ExSizeShouldBeNotNegativeValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &apos;Skip&apos; does not support query provider of type &apos;{0}&apos;..
         /// </summary>
         internal static string ExSkipDoesNotSupportQueryProviderOfTypeX {
@@ -5759,15 +3927,6 @@ namespace Xtensive {
         internal static string ExSkipNotSupportedInCompiledQueries {
             get {
                 return ResourceManager.GetString("ExSkipNotSupportedInCompiledQueries", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Some operands are not Expressions  of type &apos;System.Boolean&apos;..
-        /// </summary>
-        internal static string ExSomeOperandsAreNotExpressionsOfTypeBoolean {
-            get {
-                return ResourceManager.GetString("ExSomeOperandsAreNotExpressionsOfTypeBoolean", resourceCulture);
             }
         }
         
@@ -5808,33 +3967,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The specified expression can&apos;t be parsed..
-        /// </summary>
-        internal static string ExSpecifiedExpressionCanNotBeParsed {
-            get {
-                return ResourceManager.GetString("ExSpecifiedExpressionCanNotBeParsed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The specified expression is not a MemberExpression..
-        /// </summary>
-        internal static string ExSpecifiedExpressionIsNotMemberExpression {
-            get {
-                return ResourceManager.GetString("ExSpecifiedExpressionIsNotMemberExpression", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Specified key field type is not supported by this temporary key generator..
-        /// </summary>
-        internal static string ExSpecifiedKeyFieldTypeIsNotSupportedByThisTemporaryKeyGenerator {
-            get {
-                return ResourceManager.GetString("ExSpecifiedKeyFieldTypeIsNotSupportedByThisTemporaryKeyGenerator", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Specified precision ({0}) is greater than maximum supported by storage ({1})..
         /// </summary>
         internal static string ExSpecifiedPrecisionXIsGreaterThanMaximumSupportedByStorageY {
@@ -5844,38 +3976,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The specified property {0} is not persistent..
-        /// </summary>
-        internal static string ExSpecifiedPropertyXIsNotPersistent {
-            get {
-                return ResourceManager.GetString("ExSpecifiedPropertyXIsNotPersistent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Specified RedoDescriptor can&apos;t be logged..
-        /// </summary>
-        internal static string ExSpecifiedRedoDescriptorCantBeLogged {
-            get {
-                return ResourceManager.GetString("ExSpecifiedRedoDescriptorCantBeLogged", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The specified type&apos;s hierarchy is different from the key&apos;s hierarchy..
         /// </summary>
         internal static string ExSpecifiedTypeHierarchyIsDifferentFromKeyHierarchy {
             get {
                 return ResourceManager.GetString("ExSpecifiedTypeHierarchyIsDifferentFromKeyHierarchy", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Specified type should be either GeneratedTupleDescriptor or its descendant..
-        /// </summary>
-        internal static string ExSpecifiedTypeShouldBeGeneratedTupleDescriptorOrItsDescendant {
-            get {
-                return ResourceManager.GetString("ExSpecifiedTypeShouldBeGeneratedTupleDescriptorOrItsDescendant", resourceCulture);
             }
         }
         
@@ -5894,60 +3999,6 @@ namespace Xtensive {
         internal static string ExSqlContainerExpressionCanNotBeCompiled {
             get {
                 return ResourceManager.GetString("ExSqlContainerExpressionCanNotBeCompiled", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SQL Server below 2005 is not supported..
-        /// </summary>
-        internal static string ExSqlServerBelow2005IsNotSupported {
-            get {
-                return ResourceManager.GetString("ExSqlServerBelow2005IsNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SQL Server supports trimming of space characters only..
-        /// </summary>
-        internal static string ExSqlServerSupportsTrimmingOfSpaceCharactersOnly {
-            get {
-                return ResourceManager.GetString("ExSqlServerSupportsTrimmingOfSpaceCharactersOnly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to State is not loaded..
-        /// </summary>
-        internal static string ExStateIsNotLoaded {
-            get {
-                return ResourceManager.GetString("ExStateIsNotLoaded", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to State is removed..
-        /// </summary>
-        internal static string ExStateIsRemoved {
-            get {
-                return ResourceManager.GetString("ExStateIsRemoved", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to StateTransaction property value differs from the current transaction..
-        /// </summary>
-        internal static string ExStateTransactionIsDifferent {
-            get {
-                return ResourceManager.GetString("ExStateTransactionIsDifferent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to State with key &apos;{0}&apos; is already exists..
-        /// </summary>
-        internal static string ExStateWithKeyXIsAlreadyExists {
-            get {
-                return ResourceManager.GetString("ExStateWithKeyXIsAlreadyExists", resourceCulture);
             }
         }
         
@@ -5997,15 +4048,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to String does not correspond to the specified descriptor..
-        /// </summary>
-        internal static string ExStringDoesNotCorrespondToDescriptor {
-            get {
-                return ResourceManager.GetString("ExStringDoesNotCorrespondToDescriptor", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to String.Trim(char[]), String.TrimStart(char[]), string.TrimEnd(char[]) supported only with argument being array of constants..
         /// </summary>
         internal static string ExStringTrimSupportedOnlyWithConstants {
@@ -6038,15 +4080,6 @@ namespace Xtensive {
         internal static string ExStructureXCantContainFieldOfTheSameType {
             get {
                 return ResourceManager.GetString("ExStructureXCantContainFieldOfTheSameType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to System date \ time has been changed..
-        /// </summary>
-        internal static string ExSystemTimeChanged {
-            get {
-                return ResourceManager.GetString("ExSystemTimeChanged", resourceCulture);
             }
         }
         
@@ -6150,38 +4183,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Temporary table &apos;{0}&apos; is locked.
-        /// </summary>
-        internal static string ExTemporaryTableXIsLocked {
-            get {
-                return ResourceManager.GetString("ExTemporaryTableXIsLocked", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Term weight value must be between {0} and {1}.
         /// </summary>
         internal static string ExTermWeightValueMustBeBetweenXAndY {
             get {
                 return ResourceManager.GetString("ExTermWeightValueMustBeBetweenXAndY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The data type must be exact numeric without scale or with zero scale..
-        /// </summary>
-        internal static string ExTheDataTypeMustBeExactNumericWithoutScaleOrWithZeroScale {
-            get {
-                return ResourceManager.GetString("ExTheDataTypeMustBeExactNumericWithoutScaleOrWithZeroScale", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The data type must be exact numeric with scale 0..
-        /// </summary>
-        internal static string ExTheDataTypeMustBeExactNumericWithScale0 {
-            get {
-                return ResourceManager.GetString("ExTheDataTypeMustBeExactNumericWithScale0", resourceCulture);
             }
         }
         
@@ -6204,38 +4210,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There are no suitable types in &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExThereAreNoSuitableTypes {
-            get {
-                return ResourceManager.GetString("ExThereAreNoSuitableTypes", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to There is no current HttpRequest, or SessionManager is not bound to it yet..
-        /// </summary>
-        internal static string ExThereIsNoCurrentHttpRequestOrSessionManagerIsnTBoundToItYet {
-            get {
-                return ResourceManager.GetString("ExThereIsNoCurrentHttpRequestOrSessionManagerIsnTBoundToItYet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to There is no implemetation of &apos;{0}.{1}&apos; member in &apos;{0}&apos; type..
         /// </summary>
         internal static string ExThereIsNoImplemetationOfXYMemberInZType {
             get {
                 return ResourceManager.GetString("ExThereIsNoImplemetationOfXYMemberInZType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The scale must be less than or equal to precision..
-        /// </summary>
-        internal static string ExTheScaleMustBeLessThanOrEqualToPrecision {
-            get {
-                return ResourceManager.GetString("ExTheScaleMustBeLessThanOrEqualToPrecision", resourceCulture);
             }
         }
         
@@ -6276,16 +4255,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This operation is not allowed for the parameter context operating with expected values of parameters..
-        /// </summary>
-        internal static string ExThisOperationIsNotAllowedForParameterContextOperatingWithExpectedValuesOfParameters {
-            get {
-                return ResourceManager.GetString("ExThisOperationIsNotAllowedForParameterContextOperatingWithExpectedValuesOfParame" +
-                        "ters", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to This storage does not support &apos;{0}&apos;..
         /// </summary>
         internal static string ExThisStorageDoesNotSupportX {
@@ -6313,56 +4282,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Transaction is already activated..
-        /// </summary>
-        internal static string ExTransactionIsAlreadyActivated {
-            get {
-                return ResourceManager.GetString("ExTransactionIsAlreadyActivated", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Transaction is already open..
-        /// </summary>
-        internal static string ExTransactionIsAlreadyOpen {
-            get {
-                return ResourceManager.GetString("ExTransactionIsAlreadyOpen", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Transaction is not active..
         /// </summary>
         internal static string ExTransactionIsNotActive {
             get {
                 return ResourceManager.GetString("ExTransactionIsNotActive", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Transaction is not open..
-        /// </summary>
-        internal static string ExTransactionIsNotOpen {
-            get {
-                return ResourceManager.GetString("ExTransactionIsNotOpen", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A transaction is running, but there should be no active transaction..
-        /// </summary>
-        internal static string ExTransactionIsRunning {
-            get {
-                return ResourceManager.GetString("ExTransactionIsRunning", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to TransactionScope.IsCompleted can not be set to &apos;false&apos;..
-        /// </summary>
-        internal static string ExTransactionScopeIsCompletedCanNotBeSetToFalse {
-            get {
-                return ResourceManager.GetString("ExTransactionScopeIsCompletedCanNotBeSetToFalse", resourceCulture);
             }
         }
         
@@ -6421,15 +4345,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type cannot be null..
-        /// </summary>
-        internal static string ExTypeCantBeNull {
-            get {
-                return ResourceManager.GetString("ExTypeCantBeNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Type column &apos;{0}&apos; for fulltext column&apos;{1}&apos; must be type of string..
         /// </summary>
         internal static string ExTypeColumnXForFulltextColumnYMustBeTypeOfString {
@@ -6475,47 +4390,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; has no primary index..
-        /// </summary>
-        internal static string ExTypeHasNoPrimaryIndex {
-            get {
-                return ResourceManager.GetString("ExTypeHasNoPrimaryIndex", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to TypeId for type &apos;{0}&apos; is not found..
-        /// </summary>
-        internal static string ExTypeIdForTypeXIsNotFound {
-            get {
-                return ResourceManager.GetString("ExTypeIdForTypeXIsNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to TypeId is not assigned for type &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExTypeIdIsNotAssignedForTypeX {
-            get {
-                return ResourceManager.GetString("ExTypeIdIsNotAssignedForTypeX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Type with TypeId={0} is not registered..
         /// </summary>
         internal static string ExTypeIdXIsNotRegistered {
             get {
                 return ResourceManager.GetString("ExTypeIdXIsNotRegistered", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to TypeInfo hierarchy does not correspond to provided hierarchy..
-        /// </summary>
-        internal static string ExTypeInfoHierarchyMistmatch {
-            get {
-                return ResourceManager.GetString("ExTypeInfoHierarchyMistmatch", resourceCulture);
             }
         }
         
@@ -6529,47 +4408,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type is not supported by BinaryPrimitiveSerializer..
-        /// </summary>
-        internal static string ExTypeIsNotSupportedByBinaryPrimitiveSerializer {
-            get {
-                return ResourceManager.GetString("ExTypeIsNotSupportedByBinaryPrimitiveSerializer", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid type specified..
-        /// </summary>
-        internal static string ExTypeMustBeEntityDescendant {
-            get {
-                return ResourceManager.GetString("ExTypeMustBeEntityDescendant", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Type &apos;{0}&apos; is not found in model..
         /// </summary>
         internal static string ExTypeNotFoundInModel {
             get {
                 return ResourceManager.GetString("ExTypeNotFoundInModel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Type of entity stored in Key is undefined..
-        /// </summary>
-        internal static string ExTypeOfEntityStoredInKeyIsUndefined {
-            get {
-                return ResourceManager.GetString("ExTypeOfEntityStoredInKeyIsUndefined", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The type of the expression&apos;s return value is not &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExTypeOfExpressionReturnValueIsNotX {
-            get {
-                return ResourceManager.GetString("ExTypeOfExpressionReturnValueIsNotX", resourceCulture);
             }
         }
         
@@ -6610,47 +4453,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type with name &apos;{0}&apos; is not found in metadata..
-        /// </summary>
-        internal static string ExTypeWithNameXIsNotFoundInMetadata {
-            get {
-                return ResourceManager.GetString("ExTypeWithNameXIsNotFoundInMetadata", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Type with name &apos;{0}&apos; isn&apos;t registered in the Domain..
         /// </summary>
         internal static string ExTypeWithNameXIsNotRegistered {
             get {
                 return ResourceManager.GetString("ExTypeWithNameXIsNotRegistered", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Type with type TypeId=&apos;{0}&apos; is not found..
-        /// </summary>
-        internal static string ExTypeWithTypeIdXIsNotFound {
-            get {
-                return ResourceManager.GetString("ExTypeWithTypeIdXIsNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The type {0} can&apos;t be transformed..
-        /// </summary>
-        internal static string ExTypeXCanNotBeTransformed {
-            get {
-                return ResourceManager.GetString("ExTypeXCanNotBeTransformed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; can&apos;t contain Version fields, because it is not a hierarchy root type..
-        /// </summary>
-        internal static string ExTypeXCantContainsVersionFieldsAsItsNotAHierarchyRoot {
-            get {
-                return ResourceManager.GetString("ExTypeXCantContainsVersionFieldsAsItsNotAHierarchyRoot", resourceCulture);
             }
         }
         
@@ -6683,42 +4490,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; does not have a parameterless constructor..
-        /// </summary>
-        internal static string ExTypeXDoesNotHaveAParameterlessConstructor {
-            get {
-                return ResourceManager.GetString("ExTypeXDoesNotHaveAParameterlessConstructor", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; does not have property &apos;{1}&apos;..
-        /// </summary>
-        internal static string ExTypeXDoesNotHavePropertyY {
-            get {
-                return ResourceManager.GetString("ExTypeXDoesNotHavePropertyY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; does not implement &apos;{1}&apos; interface..
-        /// </summary>
-        internal static string ExTypeXDoesNotImplementYInterface {
-            get {
-                return ResourceManager.GetString("ExTypeXDoesNotImplementYInterface", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The type {0} has already been registered..
-        /// </summary>
-        internal static string ExTypeXHasAlreadyBeenRegistered {
-            get {
-                return ResourceManager.GetString("ExTypeXHasAlreadyBeenRegistered", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Type &apos;{0}&apos; has multiple clustered indexes: {1}.
         /// </summary>
         internal static string ExTypeXHasMultipleClusteredIndexesY {
@@ -6728,29 +4499,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The type {0} hasn&apos;t been registered..
-        /// </summary>
-        internal static string ExTypeXHasNotBeenRegistered {
-            get {
-                return ResourceManager.GetString("ExTypeXHasNotBeenRegistered", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Type &apos;{0}&apos; is already defined..
         /// </summary>
         internal static string ExTypeXIsAlreadyDefined {
             get {
                 return ResourceManager.GetString("ExTypeXIsAlreadyDefined", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; is not collatable..
-        /// </summary>
-        internal static string ExTypeXIsNotCollatable {
-            get {
-                return ResourceManager.GetString("ExTypeXIsNotCollatable", resourceCulture);
             }
         }
         
@@ -6791,15 +4544,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The type {0} isn&apos;t a subclass of the type {1}..
-        /// </summary>
-        internal static string ExTypeXIsNotSubclassOfTypeY {
-            get {
-                return ResourceManager.GetString("ExTypeXIsNotSubclassOfTypeY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Type &apos;{0}&apos; is not supported..
         /// </summary>
         internal static string ExTypeXIsNotSupported {
@@ -6809,29 +4553,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; is not supported in &apos;new&apos; expression..
-        /// </summary>
-        internal static string ExTypeXIsNotSupportedInNewExpression {
-            get {
-                return ResourceManager.GetString("ExTypeXIsNotSupportedInNewExpression", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Type &apos;{0}&apos; must belong to hierarchy..
         /// </summary>
         internal static string ExTypeXMustBelongToHierarchy {
             get {
                 return ResourceManager.GetString("ExTypeXMustBelongToHierarchy", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; must be non-abstract type..
-        /// </summary>
-        internal static string ExTypeXMustBeNonAbstractType {
-            get {
-                return ResourceManager.GetString("ExTypeXMustBeNonAbstractType", resourceCulture);
             }
         }
         
@@ -6859,24 +4585,6 @@ namespace Xtensive {
         internal static string ExTypeXShouldNotBeGeneric {
             get {
                 return ResourceManager.GetString("ExTypeXShouldNotBeGeneric", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; was not registered for activation..
-        /// </summary>
-        internal static string ExTypeXWasNotRegisteredForActivation {
-            get {
-                return ResourceManager.GetString("ExTypeXWasNotRegisteredForActivation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to activate EntitySet for &apos;{0}&apos; field because it does not has association..
-        /// </summary>
-        internal static string ExUnableToActivateEntitySetWithoutAssociation {
-            get {
-                return ResourceManager.GetString("ExUnableToActivateEntitySetWithoutAssociation", resourceCulture);
             }
         }
         
@@ -6922,25 +4630,6 @@ namespace Xtensive {
         internal static string ExUnableToBuildFulltextIndexesForHierarchyWithInheritanceSchemaClassTable {
             get {
                 return ResourceManager.GetString("ExUnableToBuildFulltextIndexesForHierarchyWithInheritanceSchemaClassTable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to build generic instance types for &apos;{0}&apos; type because it contains more then 1 generic parameter..
-        /// </summary>
-        internal static string ExUnableToBuildGenericInstanceTypesForXTypeBecauseItContainsMoreThen1GenericParameter {
-            get {
-                return ResourceManager.GetString("ExUnableToBuildGenericInstanceTypesForXTypeBecauseItContainsMoreThen1GenericParam" +
-                        "eter", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to build generic instance types for &apos;{0}&apos; type because parameter is not constrained..
-        /// </summary>
-        internal static string ExUnableToBuildGenericInstanceTypesForXTypeBecauseParameterIsNotConstrained {
-            get {
-                return ResourceManager.GetString("ExUnableToBuildGenericInstanceTypesForXTypeBecauseParameterIsNotConstrained", resourceCulture);
             }
         }
         
@@ -7008,24 +4697,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to clone non-user session configuration..
-        /// </summary>
-        internal static string ExUnableToCloneNonUserSessionConfiguration {
-            get {
-                return ResourceManager.GetString("ExUnableToCloneNonUserSessionConfiguration", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to create the connection. Check if all needed assemblies are available..
-        /// </summary>
-        internal static string ExUnableToCreateConnection {
-            get {
-                return ResourceManager.GetString("ExUnableToCreateConnection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to create key for &apos;{0}&apos; hierarchy. Key value or key generator should be specified..
         /// </summary>
         internal static string ExUnableToCreateKeyForXHierarchy {
@@ -7035,29 +4706,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to create provider instance. Check if provider&apos;s class has static &quot;Instance&quot; property..
-        /// </summary>
-        internal static string ExUnableToCreateProviderInstance {
-            get {
-                return ResourceManager.GetString("ExUnableToCreateProviderInstance", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to define type identifier &apos;{0}&apos; for type &apos;{1}&apos;. Type is not exists..
         /// </summary>
         internal static string ExUnableToDefineTypeIdentifierXForTypeYTypeIsNotExists {
             get {
                 return ResourceManager.GetString("ExUnableToDefineTypeIdentifierXForTypeYTypeIsNotExists", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to find column &apos;{0}&apos; of index &apos;{1}&apos; in primary index..
-        /// </summary>
-        internal static string ExUnableToFindColumnInPrimaryIndex {
-            get {
-                return ResourceManager.GetString("ExUnableToFindColumnInPrimaryIndex", resourceCulture);
             }
         }
         
@@ -7116,38 +4769,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to initialize JoinIndexProvider. Columns count mismatch..
-        /// </summary>
-        internal static string ExUnableToInitializeJoinIndexProviderColumnsCountMismatch {
-            get {
-                return ResourceManager.GetString("ExUnableToInitializeJoinIndexProviderColumnsCountMismatch", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to materialize back local collection item &apos;{0}&apos;..
         /// </summary>
         internal static string ExUnableToMaterializeBackLocalCollectionItem {
             get {
                 return ResourceManager.GetString("ExUnableToMaterializeBackLocalCollectionItem", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to modify removed object..
-        /// </summary>
-        internal static string ExUnableToModifyDeletedObject {
-            get {
-                return ResourceManager.GetString("ExUnableToModifyDeletedObject", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to parse prefetch expression &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExUnabletoParsePrefetchExpressionX {
-            get {
-                return ResourceManager.GetString("ExUnabletoParsePrefetchExpressionX", resourceCulture);
             }
         }
         
@@ -7166,15 +4792,6 @@ namespace Xtensive {
         internal static string ExUnableToPersistTypeXBecauseOfLoopReference {
             get {
                 return ResourceManager.GetString("ExUnableToPersistTypeXBecauseOfLoopReference", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to prepare command: no parts registered..
-        /// </summary>
-        internal static string ExUnableToPrepareCommandNoPartsRegistered {
-            get {
-                return ResourceManager.GetString("ExUnableToPrepareCommandNoPartsRegistered", resourceCulture);
             }
         }
         
@@ -7206,15 +4823,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to remap one of filtered columns..
-        /// </summary>
-        internal static string ExUnableToRemapOneOfFilteredColumns {
-            get {
-                return ResourceManager.GetString("ExUnableToRemapOneOfFilteredColumns", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to remove Owner from EntitySetExpression..
         /// </summary>
         internal static string ExUnableToRemoveOwnerFromEntitySetExpression {
@@ -7242,15 +4850,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to resolve owner of StructureExpression &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExUnableToResolveOwnerOfStructureExpressionX {
-            get {
-                return ResourceManager.GetString("ExUnableToResolveOwnerOfStructureExpressionX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to resolve schema for node &apos;{0}&apos;. Please verify that this schema exists..
         /// </summary>
         internal static string ExUnableToResolveSchemaForNodeXPleaseVerifyThatThisSchemaExists {
@@ -7265,24 +4864,6 @@ namespace Xtensive {
         internal static string ExUnableToResolveTypeForKeyX {
             get {
                 return ResourceManager.GetString("ExUnableToResolveTypeForKeyX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to save modified entites because some asynchronous query is incomplete. Make sure you awaited started asynchronous queries before persisting any changes..
-        /// </summary>
-        internal static string ExUnableToSaveModifiedEntitesBecauseOfIncompleteAsynchronousQueries {
-            get {
-                return ResourceManager.GetString("ExUnableToSaveModifiedEntitesBecauseOfIncompleteAsynchronousQueries", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to save modified entites because some asynchronous query is incomplete. Make sure you awaited asyncronous queries before persisting any changes..
-        /// </summary>
-        internal static string ExUnableToSaveModifiedEntitesBecauseSomeAsynchronousQueryIsIncomplete {
-            get {
-                return ResourceManager.GetString("ExUnableToSaveModifiedEntitesBecauseSomeAsynchronousQueryIsIncomplete", resourceCulture);
             }
         }
         
@@ -7387,29 +4968,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unauthorized: the caller is declared outside of any of registered assemblies..
-        /// </summary>
-        internal static string ExUnauthorizedAccessDeclarationOfCallerTypeIsNotInRegisteredAssembly {
-            get {
-                return ResourceManager.GetString("ExUnauthorizedAccessDeclarationOfCallerTypeIsNotInRegisteredAssembly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unbound column &apos;{0}&apos;..
         /// </summary>
         internal static string ExUnboundColumn {
             get {
                 return ResourceManager.GetString("ExUnboundColumn", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to ForeignKey is undefined..
-        /// </summary>
-        internal static string ExUndefinedForeignKey {
-            get {
-                return ResourceManager.GetString("ExUndefinedForeignKey", resourceCulture);
             }
         }
         
@@ -7441,29 +5004,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Underlying storage provider does not support SQL..
-        /// </summary>
-        internal static string ExUnderlyingStorageProviderDoesNotSupportSQL {
-            get {
-                return ResourceManager.GetString("ExUnderlyingStorageProviderDoesNotSupportSQL", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unexpected type of parameter..
         /// </summary>
         internal static string ExUnexpectedTypeOfParameter {
             get {
                 return ResourceManager.GetString("ExUnexpectedTypeOfParameter", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unknown entity serialization kind &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExUnknownEntitySerializationKindX {
-            get {
-                return ResourceManager.GetString("ExUnknownEntitySerializationKindX", resourceCulture);
             }
         }
         
@@ -7486,29 +5031,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; is not supported by current storage provider..
-        /// </summary>
-        internal static string ExUnsupportedColumnType {
-            get {
-                return ResourceManager.GetString("ExUnsupportedColumnType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unsupported expression type: &apos;{0}&apos;..
         /// </summary>
         internal static string ExUnsupportedExpressionType {
             get {
                 return ResourceManager.GetString("ExUnsupportedExpressionType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unsupported field type: &apos;{0}&apos;.
-        /// </summary>
-        internal static string ExUnsupportedFieldTypeX {
-            get {
-                return ResourceManager.GetString("ExUnsupportedFieldTypeX", resourceCulture);
             }
         }
         
@@ -7585,15 +5112,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use LogCaptureScope constructor instead..
-        /// </summary>
-        internal static string ExUseLogCaptureScopeConstructorInstead {
-            get {
-                return ResourceManager.GetString("ExUseLogCaptureScopeConstructorInstead", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Use LogIndentScope constructor instead..
         /// </summary>
         internal static string ExUseLogIndentScopeConstructorInstead {
@@ -7612,29 +5130,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User defined type identifier &apos;{0}&apos; for type &apos;{1}&apos;  less then 100..
-        /// </summary>
-        internal static string ExUserDefinedTypeIdentifierXForTypeYLessThan100 {
-            get {
-                return ResourceManager.GetString("ExUserDefinedTypeIdentifierXForTypeYLessThan100", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to validateVersion=true is incompatible with PersistRequestKind=Insert.
         /// </summary>
         internal static string ExValidateVersionEqTrueIsIncompatibleWithPersistRequestKindEqInsert {
             get {
                 return ResourceManager.GetString("ExValidateVersionEqTrueIsIncompatibleWithPersistRequestKindEqInsert", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Validation context is in invalid state. This means that some validation error has happened, but later it was suppressed..
-        /// </summary>
-        internal static string ExValidationContextIsInvalid {
-            get {
-                return ResourceManager.GetString("ExValidationContextIsInvalid", resourceCulture);
             }
         }
         
@@ -7711,15 +5211,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The value of the parameter {0} can&apos;t be {1}, if the value of the parameter {2} is {3}..
-        /// </summary>
-        internal static string ExValueOfParameterWCantBeXIfValueOfParameterYIsZ {
-            get {
-                return ResourceManager.GetString("ExValueOfParameterWCantBeXIfValueOfParameterYIsZ", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Value should be &apos;{0}&apos; descendant..
         /// </summary>
         internal static string ExValueShouldBeXDescendant {
@@ -7729,47 +5220,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value with name &apos;{0}&apos; already exists..
-        /// </summary>
-        internal static string ExValueWithNameXAlreadyExists {
-            get {
-                return ResourceManager.GetString("ExValueWithNameXAlreadyExists", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Value with name &apos;{0}&apos; is not found..
-        /// </summary>
-        internal static string ExValueWithNameXIsNotFound {
-            get {
-                return ResourceManager.GetString("ExValueWithNameXIsNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not allowed or invalid here..
         /// </summary>
         internal static string ExValueXIsNotAllowedHere {
             get {
                 return ResourceManager.GetString("ExValueXIsNotAllowedHere", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Version conflict..
-        /// </summary>
-        internal static string ExVersionConflict {
-            get {
-                return ResourceManager.GetString("ExVersionConflict", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Version conflict on object {0}: expected: {1} = {2}, but it is {3}..
-        /// </summary>
-        internal static string ExVersionConflictEx {
-            get {
-                return ResourceManager.GetString("ExVersionConflictEx", resourceCulture);
             }
         }
         
@@ -7837,24 +5292,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Wrong persistent type candidate: &apos;{0}&apos;..
-        /// </summary>
-        internal static string ExWrongPersistentTypeCandidate {
-            get {
-                return ResourceManager.GetString("ExWrongPersistentTypeCandidate", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Source collection contains at least one item of type &quot;{0}&quot;, that cannot be cast to the item type of the destination collection..
-        /// </summary>
-        internal static string ExWrongSourceCollectionElementType {
-            get {
-                return ResourceManager.GetString("ExWrongSourceCollectionElementType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0} can&apos;t be executed on specified sources..
         /// </summary>
         internal static string ExXCantBeExecuted {
@@ -7909,15 +5346,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The {0} is neither class nor value type..
-        /// </summary>
-        internal static string ExXIsNeitherClassNorValueType {
-            get {
-                return ResourceManager.GetString("ExXIsNeitherClassNorValueType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not suitable field for full-text search.
         /// </summary>
         internal static string ExXIsNotSuitableFieldFoFullTextSearch {
@@ -7941,15 +5369,6 @@ namespace Xtensive {
         internal static string ExXIsNotValidNameForX {
             get {
                 return ResourceManager.GetString("ExXIsNotValidNameForX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} is obsolete. Use {1} and {2} instead..
-        /// </summary>
-        internal static string ExXIsObsoleteUseYAndZInstead {
-            get {
-                return ResourceManager.GetString("ExXIsObsoleteUseYAndZInstead", resourceCulture);
             }
         }
         
@@ -8004,15 +5423,6 @@ namespace Xtensive {
         internal static string ExXYFieldPairedToZAFieldShouldBeEntitySetOfBButCurrentIsC {
             get {
                 return ResourceManager.GetString("ExXYFieldPairedToZAFieldShouldBeEntitySetOfBButCurrentIsC", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You must either apply or cancel cached changes before changing this property..
-        /// </summary>
-        internal static string ExYouMustEitherApplyOrCancelCachedChangesToChangeThisProperty {
-            get {
-                return ResourceManager.GetString("ExYouMustEitherApplyOrCancelCachedChangesToChangeThisProperty", resourceCulture);
             }
         }
         
@@ -8103,15 +5513,6 @@ namespace Xtensive {
         internal static string HasVersionFormat {
             get {
                 return ResourceManager.GetString("HasVersionFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Hierarchy columns.
-        /// </summary>
-        internal static string HierarchyColumns {
-            get {
-                return ResourceManager.GetString("HierarchyColumns", resourceCulture);
             }
         }
         
@@ -8339,15 +5740,6 @@ namespace Xtensive {
         internal static string LogComparisonResultX {
             get {
                 return ResourceManager.GetString("LogComparisonResultX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Connection restore failed..
-        /// </summary>
-        internal static string LogConnectionRestoreFailed {
-            get {
-                return ResourceManager.GetString("LogConnectionRestoreFailed", resourceCulture);
             }
         }
         
@@ -9410,42 +6802,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: value can not be empty..
-        /// </summary>
-        internal static string PropertyValueCanNotBeEmpty {
-            get {
-                return ResourceManager.GetString("PropertyValueCanNotBeEmpty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0}: value can not be null..
-        /// </summary>
-        internal static string PropertyValueCanNotBeNull {
-            get {
-                return ResourceManager.GetString("PropertyValueCanNotBeNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0}: length of the value must be in [{1} ... {2}] range..
-        /// </summary>
-        internal static string PropertyValueLengthMustBeInXYRange {
-            get {
-                return ResourceManager.GetString("PropertyValueLengthMustBeInXYRange", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0}: value must be in [{1} ... {2}] range..
-        /// </summary>
-        internal static string PropertyValueMustBeInXYRange {
-            get {
-                return ResourceManager.GetString("PropertyValueMustBeInXYRange", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Query &apos;{0}&apos;.
         /// </summary>
         internal static string QueryX {
@@ -9810,24 +7166,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; is not supported &apos;{1}&apos; node..
-        /// </summary>
-        internal static string TypeXIsNotSupportedYNode {
-            get {
-                return ResourceManager.GetString("TypeXIsNotSupportedYNode", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to dispose an item when disposable container has an invalid state..
-        /// </summary>
-        internal static string UnableToDisposeItemWhenContainerIsNotDisposed {
-            get {
-                return ResourceManager.GetString("UnableToDisposeItemWhenContainerIsNotDisposed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to find column &apos;{0}&apos; of type &apos;{1}&apos; of current model..
         /// </summary>
         internal static string UnableToFindColumnXInTypeYOfCurrentModel {
@@ -9882,33 +7220,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value can not be less then {0}..
-        /// </summary>
-        internal static string ValueCanNotBeLessThenX {
-            get {
-                return ResourceManager.GetString("ValueCanNotBeLessThenX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Value can not be null..
-        /// </summary>
-        internal static string ValueCanNotBeNull {
-            get {
-                return ResourceManager.GetString("ValueCanNotBeNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Value can not be an entity that is already removed..
-        /// </summary>
-        internal static string ValueCanNotBeRemovedEntity {
-            get {
-                return ResourceManager.GetString("ValueCanNotBeRemovedEntity", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Value does not match regex pattern &apos;{0}&apos;..
         /// </summary>
         internal static string ValueDoesNotMatchRegexPatternX {
@@ -9945,15 +7256,6 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value can not exceed {0}..
-        /// </summary>
-        internal static string ValueLengthCanNotExceedX {
-            get {
-                return ResourceManager.GetString("ValueLengthCanNotExceedX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Value should be a valid e-mail..
         /// </summary>
         internal static string ValueShouldBeAValidEMail {
@@ -9981,29 +7283,11 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value should match regex pattern &apos;{0}&apos;.
-        /// </summary>
-        internal static string ValueShouldMatchRegexPatternX {
-            get {
-                return ResourceManager.GetString("ValueShouldMatchRegexPatternX", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Value should not be empty..
         /// </summary>
         internal static string ValueShouldNotBeEmpty {
             get {
                 return ResourceManager.GetString("ValueShouldNotBeEmpty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Value should not be null or empty..
-        /// </summary>
-        internal static string ValueShouldNotBeEmptyOrEmpty {
-            get {
-                return ResourceManager.GetString("ValueShouldNotBeEmptyOrEmpty", resourceCulture);
             }
         }
         
@@ -10040,15 +7324,6 @@ namespace Xtensive {
         internal static string ValueShouldNotBeNull {
             get {
                 return ResourceManager.GetString("ValueShouldNotBeNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Value type mismatch for field &apos;{0}&apos;.
-        /// </summary>
-        internal static string ValueTypeMismatchForFieldX {
-            get {
-                return ResourceManager.GetString("ValueTypeMismatchForFieldX", resourceCulture);
             }
         }
         

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -135,23 +135,8 @@
   <data name="ExCollectionIsReadOnly" xml:space="preserve">
     <value>Collection is read-only.</value>
   </data>
-  <data name="ExDependencyOperationIsAlreadyRegistered" xml:space="preserve">
-    <value>Dependency operation with full name "{0}" is already registered.</value>
-  </data>
-  <data name="ExDescriptorIsInInvalidState" xml:space="preserve">
-    <value>Descriptor is in invalid state.</value>
-  </data>
   <data name="ExDestionationArrayIsTooSmall" xml:space="preserve">
     <value>Destionation array is too small.</value>
-  </data>
-  <data name="ExGivenKeyNotPresent" xml:space="preserve">
-    <value>The given key was not present in the dictionary.</value>
-  </data>
-  <data name="ExIncompatibleArrayType" xml:space="preserve">
-    <value>Incompatible array type.</value>
-  </data>
-  <data name="ExInconsistentComparisons" xml:space="preserve">
-    <value>The two collections cannot be combined because they use different comparison operations.</value>
   </data>
   <data name="ExIndexShouldBeInNMRange" xml:space="preserve">
     <value>Index should be in [{0}...{1}] range.</value>
@@ -162,50 +147,14 @@
   <data name="ExInvalidCapacity" xml:space="preserve">
     <value>The specified capacity value is less than collection count.</value>
   </data>
-  <data name="ExItemCantBeCachedIncompatibleType" xml:space="preserve">
-    <value>The specified item cannot be cached because its type is incompatible with underlying storage format.</value>
-  </data>
-  <data name="ExItemIsInUse" xml:space="preserve">
-    <value>Specified item is already in use.</value>
-  </data>
-  <data name="ExItemIsNotInUse" xml:space="preserve">
-    <value>Specified item is not in use.</value>
-  </data>
-  <data name="ExItemIsNotPooled" xml:space="preserve">
-    <value>Specified item isn't pooled.</value>
-  </data>
   <data name="ExItemNotFound" xml:space="preserve">
     <value>Specified item isn't found.</value>
-  </data>
-  <data name="ExLinkedOperationMissingFormat" xml:space="preserve">
-    <value>Linked operation for property {0} missing.</value>
   </data>
   <data name="ExMaxItemCountIsN" xml:space="preserve">
     <value>Maximal item count is {0}.</value>
   </data>
-  <data name="ExNoAvailableItems" xml:space="preserve">
-    <value>There are no more available items.</value>
-  </data>
   <data name="ExNoObjectWithSpecifiedKey" xml:space="preserve">
     <value>There is no object with specified key.</value>
-  </data>
-  <data name="ExOperationLinkTypeUndefined" xml:space="preserve">
-    <value>Operation LinkType should be defined before it can be registered in OperationDictionary.</value>
-  </data>
-  <data name="ExOperationMustBeLocked" xml:space="preserve">
-    <value>Operation must be locked before it can be registered in OperationDictionary.</value>
-  </data>
-  <data name="ExOperationPropertyNameUndefined" xml:space="preserve">
-    <value>Operation PropertyName must be specified before it can be registered in OperationDictionary.</value>
-  </data>
-  <data name="ExPoolMustBeSyncronized" xml:space="preserve">
-    <value>Pool should be in syncronized mode to utilize AutoCleanup feature.</value>
-  </data>
-  <data name="ExPoolWrongKey" xml:space="preserve">
-    <value>Item already exists in the pool with another key.</value>
-  </data>
-  <data name="ExPortOutOfRange" xml:space="preserve">
-    <value>Port value must be in [0,65535] range.</value>
   </data>
   <data name="ExInvalidUrl" xml:space="preserve">
     <value>"{0}" is invalid URL.</value>
@@ -213,17 +162,8 @@
   <data name="ExArrayDoesNotHaveZeroBasedIndexing" xml:space="preserve">
     <value>Array does not have zero-based indexing.</value>
   </data>
-  <data name="ExWrongSourceCollectionElementType" xml:space="preserve">
-    <value>Source collection contains at least one item of type "{0}", that cannot be cast to the item type of the destination collection.</value>
-  </data>
-  <data name="ExInstanceMustHaveSyncRoot" xml:space="preserve">
-    <value>A instance must have non-null IHasSyncRoot.SyncRoot property value.</value>
-  </data>
   <data name="ExCouldNotLoadTypesFromAssembly" xml:space="preserve">
     <value>Could not load types from the assembly '{0}'.</value>
-  </data>
-  <data name="ExItemCantBeComparedIncompatibleType" xml:space="preserve">
-    <value>The specified item cannot be cached because its type is incompatible with ITuple.</value>
   </data>
   <data name="ExArgumentCannotBeEmptyString" xml:space="preserve">
     <value>Argument can't be an empty string.</value>
@@ -242,9 +182,6 @@
   </data>
   <data name="ExInvalidArgumentType" xml:space="preserve">
     <value>Invalid argument type: expected type is {0}.</value>
-  </data>
-  <data name="ExSystemTimeChanged" xml:space="preserve">
-    <value>System date \ time has been changed.</value>
   </data>
   <data name="ExMeasurementIsAlreadyCompleted" xml:space="preserve">
     <value>Measurement is already completed.</value>
@@ -267,12 +204,6 @@
   <data name="ExMemberIsNotPublicPropertyOrField" xml:space="preserve">
     <value>Member: '{0}' is not a Public Property or Field of Type: '{1}'</value>
   </data>
-  <data name="ExDeserializationStreamLengthIncorrect" xml:space="preserve">
-    <value>Stream length not enough to deserialize object of specified type.</value>
-  </data>
-  <data name="ExTypeIsNotSupportedByBinaryPrimitiveSerializer" xml:space="preserve">
-    <value>Type is not supported by BinaryPrimitiveSerializer.</value>
-  </data>
   <data name="ExObjectIsReadOnly" xml:space="preserve">
     <value>Object is read-only.</value>
   </data>
@@ -281,9 +212,6 @@
   </data>
   <data name="ExPropertyIsAlreadyInitialized" xml:space="preserve">
     <value>Property '{0}' is already initialized.</value>
-  </data>
-  <data name="ExInvalidActiveScope" xml:space="preserve">
-    <value>Active scope is invalid - it differs from the expected one. Probably you have forgot to dispose some nested scope.</value>
   </data>
   <data name="ExScopeCantBeDisposed" xml:space="preserve">
     <value>Scope can't be disposed. Most likely it is bound to a different thread.</value>
@@ -294,17 +222,8 @@
   <data name="ExCantFindAssociate" xml:space="preserve">
     <value>Can't find associated {0} of type '{1}' for type '{2}'.</value>
   </data>
-  <data name="ExCopyToMustOperateWithDifferentStreams" xml:space="preserve">
-    <value>Unable to copy a part of the stream to itself. Use StreamExtensions.Copy method instead.</value>
-  </data>
-  <data name="ExUnableToCreateProviderInstance" xml:space="preserve">
-    <value>Unable to create provider instance. Check if provider's class has static "Instance" property.</value>
-  </data>
   <data name="LogScopeDisposeError" xml:space="preserve">
     <value>Scope dispose error.</value>
-  </data>
-  <data name="ExCollectionOrCoutableExcpected" xml:space="preserve">
-    <value>Item should be either an ICollection or ICountable.</value>
   </data>
   <data name="ExCantCreateAssociateForGenericTypeDefinitions" xml:space="preserve">
     <value>Can't create associates for generic type definitions (type '{0}').</value>
@@ -321,9 +240,6 @@
   <data name="ExCantFindAssociate2" xml:space="preserve">
     <value>Can't find associated {0} of type '{1}' for type '{2}' or '{3}'.</value>
   </data>
-  <data name="ExCantPassNoInfinityToThisConstructor" xml:space="preserve">
-    <value>InfinityType.None can't be passed to this constructor.</value>
-  </data>
   <data name="ExValueIsNotAvailable" xml:space="preserve">
     <value>Value is not available.</value>
   </data>
@@ -333,26 +249,14 @@
   <data name="ReversedFormat" xml:space="preserve">
     <value>Reversed({0})</value>
   </data>
-  <data name="ExInadmissibleTypeConversion" xml:space="preserve">
-    <value>Conversion from type {0} to type {1} is inadmissible.</value>
-  </data>
   <data name="LogCantFindAssociateFor" xml:space="preserve">
     <value>Can't find {0} ('{1}') for type '{2}'.</value>
-  </data>
-  <data name="ExMinMaxValuesAreNotSupportedForTupleFieldAdvancedComparer" xml:space="preserve">
-    <value>MinMaxValues aren't supported for TupleFieldAdvancedComparer.</value>
-  </data>
-  <data name="ExSpecifiedTypeShouldBeGeneratedTupleDescriptorOrItsDescendant" xml:space="preserve">
-    <value>Specified type should be either GeneratedTupleDescriptor or its descendant.</value>
   </data>
   <data name="ExTypeXMustBeReferenceType" xml:space="preserve">
     <value>Type '{0}' must be reference type.</value>
   </data>
   <data name="ExTypeXMustImplementY" xml:space="preserve">
     <value>Type '{0}' must implement '{1}', or must be its descendant.</value>
-  </data>
-  <data name="ExFieldIsInfinite" xml:space="preserve">
-    <value>Field with index '{0}' is infinite.</value>
   </data>
   <data name="ExCultureOfAppliedRuleShouldBeEitherNullOrTheSameAsOnTarget" xml:space="preserve">
     <value>Culture of the applied rule should either be undefined (null), or be the same as on target rule.</value>
@@ -363,29 +267,14 @@
   <data name="ExGenericParameterShouldBeOfTypeT" xml:space="preserve">
     <value>Generic parameter '{0}' should be of type '{1}'.</value>
   </data>
-  <data name="ExMergeOperationRequireIntersectionOfOperands" xml:space="preserve">
-    <value>Merge operation require intersection of operands.</value>
-  </data>
-  <data name="ExEndPointOrderMustBeEqual" xml:space="preserve">
-    <value>EndPoints order of both ranges must be equal.</value>
-  </data>
-  <data name="ExRangeIsEmpty" xml:space="preserve">
-    <value>Range is empty.</value>
-  </data>
   <data name="ExValueXIsNotAllowedHere" xml:space="preserve">
     <value>'{0}' is not allowed or invalid here.</value>
   </data>
   <data name="ExItemWithNameWasNotFound" xml:space="preserve">
     <value>Item with name '{0}' was not found.</value>
   </data>
-  <data name="ExEnumerationIsAlreadyFinished" xml:space="preserve">
-    <value>Enumeration is already finished.</value>
-  </data>
   <data name="ExInvalidCast" xml:space="preserve">
     <value>Cast from '{0}' to '{1}' is invalid.</value>
-  </data>
-  <data name="ExBothMeasurementsHaveNoValue" xml:space="preserve">
-    <value>Both measurements have no value.</value>
   </data>
   <data name="ExMeasurementMustHaveValue" xml:space="preserve">
     <value>Measurement '{0}' must have value.</value>
@@ -428,9 +317,6 @@
   </data>
   <data name="ExPropertyIsNotInitialized" xml:space="preserve">
     <value>Property '{0}' is not initialized (or not initialized properly).</value>
-  </data>
-  <data name="ExDifferentTupleDescriptors" xml:space="preserve">
-    <value>Different TupleDescriptors are not valid here: {0} and {1}.</value>
   </data>
   <data name="LogRegionBegin" xml:space="preserve">
     <value>{0}: started.</value>
@@ -483,9 +369,6 @@
   <data name="LogException" xml:space="preserve">
     <value>Exception!</value>
   </data>
-  <data name="ExUseLogCaptureScopeConstructorInstead" xml:space="preserve">
-    <value>Use LogCaptureScope constructor instead.</value>
-  </data>
   <data name="LogUnableToGetDefaultHasherForTypeXxx" xml:space="preserve">
     <value>Unable to get default hasher for type {0}</value>
   </data>
@@ -510,24 +393,6 @@
   <data name="ExAlreadyDisposed" xml:space="preserve">
     <value>Object is already disposed.</value>
   </data>
-  <data name="ExInvalidRecordType" xml:space="preserve">
-    <value>Record with invalid (possibly - unspecified) type is found.</value>
-  </data>
-  <data name="ExInvalidSerializerType" xml:space="preserve">
-    <value>Generic parameter T is resolved to associated '{0}', although '{1}' is expected.</value>
-  </data>
-  <data name="ExInvalidFormatterProcessType" xml:space="preserve">
-    <value>'{0}' formatter process type is invalid for the current operation.</value>
-  </data>
-  <data name="ExReferenceIsAlreadyDefined" xml:space="preserve">
-    <value>Reference '{0}' is already defined.</value>
-  </data>
-  <data name="ExReferenceIsNotResolvedYet" xml:space="preserve">
-    <value>Reference '{0}' is not resolved yet.</value>
-  </data>
-  <data name="ExReferenceIsNull" xml:space="preserve">
-    <value>Reference points to null.</value>
-  </data>
   <data name="ReferenceFormat" xml:space="preserve">
     <value>#({0})</value>
   </data>
@@ -537,29 +402,8 @@
   <data name="EmptyString" xml:space="preserve">
     <value>''</value>
   </data>
-  <data name="ExDeserializationErrorUnrecognizedSlotsAreFound" xml:space="preserve">
-    <value>Deserialization error: some SerializationData slots were not recognized, thus the format of the serialized data differs from the supported one.</value>
-  </data>
-  <data name="ExInvalidSerializerBehaviorMustNotBeReferable" xml:space="preserve">
-    <value>'{0}' can't be an IsReferable serializer, since it serializes IReference type.</value>
-  </data>
-  <data name="UnableToDisposeItemWhenContainerIsNotDisposed" xml:space="preserve">
-    <value>Unable to dispose an item when disposable container has an invalid state.</value>
-  </data>
-  <data name="ExValueWithNameXAlreadyExists" xml:space="preserve">
-    <value>Value with name '{0}' already exists.</value>
-  </data>
-  <data name="ExValueWithNameXIsNotFound" xml:space="preserve">
-    <value>Value with name '{0}' is not found.</value>
-  </data>
   <data name="SerializationDataFormat" xml:space="preserve">
     <value>Type='{0}', #='{1}' ({2})</value>
-  </data>
-  <data name="ExInvalidObjectSerializerSimilarValueSerializerExists" xml:space="preserve">
-    <value>Object serializer is invalid, since similar value serializer exists.</value>
-  </data>
-  <data name="ExStringDoesNotCorrespondToDescriptor" xml:space="preserve">
-    <value>String does not correspond to the specified descriptor.</value>
   </data>
   <data name="ExUnknownExpressionType" xml:space="preserve">
     <value>Unknown expression type: '{0} ({1})'</value>
@@ -567,35 +411,8 @@
   <data name="ExEscapeCharacterMustDifferFromDelimiterCharacter" xml:space="preserve">
     <value>Escape character must differ from delimiter character.</value>
   </data>
-  <data name="ExExpressionMustReturnValueOfTypeX" xml:space="preserve">
-    <value>The expression must return a value of type '{0}'.</value>
-  </data>
   <data name="ExArgumentMustnotBeOfTypeX" xml:space="preserve">
     <value>The argument must not be of type '{0}'.</value>
-  </data>
-  <data name="ExExpressionHavingEqualNormalFormMustBeRoot" xml:space="preserve">
-    <value>The expression having the equal normal form must be a root expression.</value>
-  </data>
-  <data name="ExExpressionHavingDifferentNormalFormMustNotBeRoot" xml:space="preserve">
-    <value>The expression having the different normal form must not be a root expression.</value>
-  </data>
-  <data name="ExOnlyNormalizedExpressionCanBeAddedAsChildToRoot" xml:space="preserve">
-    <value>Only the normalized expression having the different normal form can be added as the immediate descendant to the root expression.</value>
-  </data>
-  <data name="ExActualConjunctionOperandCountGreaterThanExpected" xml:space="preserve">
-    <value>Actual conjunction operand count greater than MaxConjunctionOperandCount.</value>
-  </data>
-  <data name="ExCannotParseCallToComparisonMethod" xml:space="preserve">
-    <value>Can't parse the call to the comparison method.</value>
-  </data>
-  <data name="ExSomeOperandsAreNotExpressionsOfTypeBoolean" xml:space="preserve">
-    <value>Some operands are not Expressions  of type 'System.Boolean'.</value>
-  </data>
-  <data name="ExExpectedValueOfParameterIsAlreadySet" xml:space="preserve">
-    <value>The expected value of the parameter is already set.</value>
-  </data>
-  <data name="ExThisOperationIsNotAllowedForParameterContextOperatingWithExpectedValuesOfParameters" xml:space="preserve">
-    <value>This operation is not allowed for the parameter context operating with expected values of parameters.</value>
   </data>
   <data name="ExScopeRequired" xml:space="preserve">
     <value>{0} is required.</value>
@@ -615,15 +432,6 @@
   <data name="ExArgumentMustBeLessThanX" xml:space="preserve">
     <value>Argument must be less than '{0}'</value>
   </data>
-  <data name="ExKeyAlreadyExists" xml:space="preserve">
-    <value>Key already exists.</value>
-  </data>
-  <data name="ExTypeXMustBeNonAbstractType" xml:space="preserve">
-    <value>Type '{0}' must be non-abstract type.</value>
-  </data>
-  <data name="ExExceptionWasThrownDuringTaskExecution" xml:space="preserve">
-    <value>The exception was thrown during the task's execution.</value>
-  </data>
   <data name="ExUnableToCastNullValueToXUseXInstead" xml:space="preserve">
     <value>Unable to cast null value to {0}; use {0}? instead.</value>
   </data>
@@ -642,62 +450,17 @@
   <data name="ExUnableToUseExpressionXAsXParameterOfLambdaXBecauseOfTypeMistmatch" xml:space="preserve">
     <value>Unable to use expression {0} as {1} parameter of lambda {2} because of type mistmatch.</value>
   </data>
-  <data name="ExTypeXDoesNotHavePropertyY" xml:space="preserve">
-    <value>Type '{0}' does not have property '{1}'.</value>
-  </data>
   <data name="ExResourcePropertyXIsNotOfStringType" xml:space="preserve">
     <value>Resource property {0} is not of string type.</value>
   </data>
-  <data name="ExTypeXHasAlreadyBeenRegistered" xml:space="preserve">
-    <value>The type {0} has already been registered.</value>
-  </data>
   <data name="ExMappingForPropertyXHasAlreadyBeenRegistered" xml:space="preserve">
     <value>The mapping for the property {0} has already been registered.</value>
-  </data>
-  <data name="ExTypeXHasNotBeenRegistered" xml:space="preserve">
-    <value>The type {0} hasn't been registered.</value>
-  </data>
-  <data name="ExSpecifiedExpressionIsNotMemberExpression" xml:space="preserve">
-    <value>The specified expression is not a MemberExpression.</value>
-  </data>
-  <data name="ExAccessedMemberIsNotProperty" xml:space="preserve">
-    <value>The accessed member is not a property.</value>
-  </data>
-  <data name="ExSpecifiedExpressionCanNotBeParsed" xml:space="preserve">
-    <value>The specified expression can't be parsed.</value>
   </data>
   <data name="ExKeyXIsNotFound" xml:space="preserve">
     <value>Key {0} is not found.</value>
   </data>
   <data name="ExCollectionHasBeenModified" xml:space="preserve">
     <value>Collection has been modified.</value>
-  </data>
-  <data name="ExPropertiesXAndYHaveIncompatibleTypes" xml:space="preserve">
-    <value>The properties "{0}" and "{1}" have incompatible types.</value>
-  </data>
-  <data name="ExReferencePropertyXIsBoundToPropertyYThatIsNotReference" xml:space="preserve">
-    <value>The reference property {0} is bound to the property {1} that isn't reference.</value>
-  </data>
-  <data name="ExCollectionPropertyXIsBoundToPropertyYThatIsNotCollection" xml:space="preserve">
-    <value>The collection property {0} is bound to the property {1} that isn't collection.</value>
-  </data>
-  <data name="ExPrimitivePropertyXIsBoundToPropertyYThatIsNotPrimitive" xml:space="preserve">
-    <value>The primitive property {0} is bound to the property {1} that isn't primitive.</value>
-  </data>
-  <data name="ExTypeXIsNotSubclassOfTypeY" xml:space="preserve">
-    <value>The type {0} isn't a subclass of the type {1}.</value>
-  </data>
-  <data name="ExLimitOfGraphDepthIsExceeded" xml:space="preserve">
-    <value>The limit of the graph depth is exceeded.</value>
-  </data>
-  <data name="ExNestedCollectionIsNotSupported" xml:space="preserve">
-    <value>Nested collection is not supported.</value>
-  </data>
-  <data name="ExDetectionOfChangesInUserStructureCollectionIsNotSupported" xml:space="preserve">
-    <value>The detection of changes in user structure collection isn't supported.</value>
-  </data>
-  <data name="ExTypeXCanNotBeTransformed" xml:space="preserve">
-    <value>The type {0} can't be transformed.</value>
   </data>
   <data name="XInY" xml:space="preserve">
     <value>{0} in {1}</value>
@@ -726,9 +489,6 @@
   <data name="ExRecursiveConstructorParameterDependencyIsDetected" xml:space="preserve">
     <value>Recursive constructor parameter dependency is detected.</value>
   </data>
-  <data name="ExXIsNeitherClassNorValueType" xml:space="preserve">
-    <value>The {0} is neither class nor value type.</value>
-  </data>
   <data name="ExArgumentMustBeGreaterThatOrEqualX" xml:space="preserve">
     <value>Argument must be greater that or equal '{0}'</value>
   </data>
@@ -743,15 +503,6 @@
   </data>
   <data name="ExSegmentIsOutOfRange" xml:space="preserve">
     <value>Segment is out of range.</value>
-  </data>
-  <data name="ExNullablePropertyXIsBoundToPropertyYThatIsNotNullable" xml:space="preserve">
-    <value>The nullable property {0} is bound to the property {1} that isn't nullable.</value>
-  </data>
-  <data name="ExPropertiesXAndYHaveDifferentPrimitiveTypes" xml:space="preserve">
-    <value>The properties {0} and {1} have different primitive types.</value>
-  </data>
-  <data name="ExInvalidParentValue" xml:space="preserve">
-    <value>Invalid Parent value.</value>
   </data>
   <data name="ExItemWithNameXAlreadyExists" xml:space="preserve">
     <value>Item with name '{0}' already exists.</value>
@@ -813,9 +564,6 @@
   <data name="ExPropertyValueMustBelongToTheSameModel" xml:space="preserve">
     <value>Property value must belong to the same Model.</value>
   </data>
-  <data name="ExLoopInActionDependencyChain" xml:space="preserve">
-    <value>Loop in action dependency chain is detected.</value>
-  </data>
   <data name="ExNoCurrentComparer" xml:space="preserve">
     <value>Comparer.Current is null.</value>
   </data>
@@ -824,9 +572,6 @@
   </data>
   <data name="ExInvalidContextActivationSequence" xml:space="preserve">
     <value>Invalid context activation sequence.</value>
-  </data>
-  <data name="ExInvalidAfterPathPropertyValue" xml:space="preserve">
-    <value>Invalid AfterPath property value.</value>
   </data>
   <data name="ExInvalidNestingOfNodeX" xml:space="preserve">
     <value>Invalid Nesting of node "{0}".</value>
@@ -864,21 +609,6 @@
   <data name="ExDifferenceRelatedToXTypeIsNotFoundOnTheUpgradeContextStack" xml:space="preserve">
     <value>Difference related to {0} type is not found on the UpgradeContext stack.</value>
   </data>
-  <data name="ExPropertyXYIsNotFound" xml:space="preserve">
-    <value>Property "{0}.{1}" is not found.</value>
-  </data>
-  <data name="ExInvalidTransactionState" xml:space="preserve">
-    <value>Invalid transaction state ('{0}'). Expected state(s) is (are) '{1}'.</value>
-  </data>
-  <data name="ExTransactionIsAlreadyActivated" xml:space="preserve">
-    <value>Transaction is already activated.</value>
-  </data>
-  <data name="ExTransactionScopeIsCompletedCanNotBeSetToFalse" xml:space="preserve">
-    <value>TransactionScope.IsCompleted can not be set to 'false'.</value>
-  </data>
-  <data name="ExScopeBoundTransactionCanBeCommittedOnlyByItsScope" xml:space="preserve">
-    <value>Scope-bound transaction can be committed only by its scope. Use TransactionScopeBase.Complete() \  Dispose() methods of  appropriate TransactionScopeBase descendant instance to do this.</value>
-  </data>
   <data name="ExExpression0MustReferenceField" xml:space="preserve">
     <value>Expression '{0}' must reference field.</value>
   </data>
@@ -915,17 +645,11 @@
   <data name="ExItemWithNameXAlreadyExistsInY" xml:space="preserve">
     <value>Item with name '{0}' already exists in '{1}'.</value>
   </data>
-  <data name="ExTypeIdIsNotAssignedForTypeX" xml:space="preserve">
-    <value>TypeId is not assigned for type '{0}'.</value>
-  </data>
   <data name="NodeFormat" xml:space="preserve">
     <value>{0} ({1})</value>
   </data>
   <data name="UnnamedNodeDisplayName" xml:space="preserve">
     <value>&lt;Unnamed&gt;</value>
-  </data>
-  <data name="ExKeyContainsMultipleFieldsWithIsTypeIdTrueFlag" xml:space="preserve">
-    <value>Key contains multiple fields with IsTypeId==true flag.</value>
   </data>
   <data name="ExCanNotExtractForeignKey" xml:space="preserve">
     <value>Can't extract foreign key.</value>
@@ -936,59 +660,14 @@
   <data name="ExDefaultTypeIsAlreadyRegistered" xml:space="preserve">
     <value>Default type is already registered.</value>
   </data>
-  <data name="ExInstanceMustBeLockedBeforeThisOperation" xml:space="preserve">
-    <value>Instance must be locked before this operation.</value>
-  </data>
   <data name="NodeCollectionFullNameFormat" xml:space="preserve">
     <value>{0}.{1}</value>
   </data>
   <data name="LogExErrorSettingDefaultValueXForColumnYInTypeZ" xml:space="preserve">
     <value>Error setting default value {0} for column '{1}' in type '{2}'. Most likely, its type is incorrect.</value>
   </data>
-  <data name="ExIndexIsChanged" xml:space="preserve">
-    <value>Index '{0}' is changed.</value>
-  </data>
-  <data name="ExErrorOnInsert" xml:space="preserve">
-    <value>Unable to insert instance of type '{0}' with specified key. Query affected {1} tables, but expected {2} tables.</value>
-  </data>
-  <data name="ExInstanceMultipleResults" xml:space="preserve">
-    <value>Multiple instances of type '{0}' with specified key are found.</value>
-  </data>
-  <data name="ExInstanceNotFound" xml:space="preserve">
-    <value>Instance of type '{0}' with specified key is not found.</value>
-  </data>
-  <data name="ExMultipleResults" xml:space="preserve">
-    <value>Specified query returns multiple results.</value>
-  </data>
-  <data name="ExTypeHasNoPrimaryIndex" xml:space="preserve">
-    <value>Type '{0}' has no primary index.</value>
-  </data>
-  <data name="ExUnableToCreateConnection" xml:space="preserve">
-    <value>Unable to create the connection. Check if all needed assemblies are available.</value>
-  </data>
-  <data name="ExUnsupportedColumnType" xml:space="preserve">
-    <value>Type '{0}' is not supported by current storage provider.</value>
-  </data>
   <data name="ExUnsupportedIndex" xml:space="preserve">
     <value>Index '{0}' with attributes '{1}' is not supported.</value>
-  </data>
-  <data name="ExErrorOnUpdate" xml:space="preserve">
-    <value>Unable to update instance of type {0} with specified key. Query affected {1} tables, but expecrted {2} tables.</value>
-  </data>
-  <data name="ExReaderIsNotInConsistentState" xml:space="preserve">
-    <value>Reader is not in consistent state.</value>
-  </data>
-  <data name="ExEnumerationIsNotStarted" xml:space="preserve">
-    <value>Enumeration is not started.</value>
-  </data>
-  <data name="ExUnableToFindColumnInPrimaryIndex" xml:space="preserve">
-    <value>Unable to find column '{0}' of index '{1}' in primary index.</value>
-  </data>
-  <data name="ExTransactionIsAlreadyOpen" xml:space="preserve">
-    <value>Transaction is already open.</value>
-  </data>
-  <data name="ExTransactionIsNotOpen" xml:space="preserve">
-    <value>Transaction is not open.</value>
   </data>
   <data name="ExIndexXIsNotFound" xml:space="preserve">
     <value>Index '{0}' is not found.</value>
@@ -1058,9 +737,6 @@
   <data name="ExXIsNotSupported" xml:space="preserve">
     <value>'{0}' is not supported</value>
   </data>
-  <data name="ExTemporaryTableXIsLocked" xml:space="preserve">
-    <value>Temporary table '{0}' is locked</value>
-  </data>
   <data name="LogSessionXMakeSavepointY" xml:space="preserve">
     <value>Session '{0}'. Make savepoint '{1}'.</value>
   </data>
@@ -1069,9 +745,6 @@
   </data>
   <data name="LogSessionXReleaseSavepointY" xml:space="preserve">
     <value>Session '{0}'. Release savepoint '{1}'.</value>
-  </data>
-  <data name="ExConnectionIsNotOpen" xml:space="preserve">
-    <value>Connection is not open.</value>
   </data>
   <data name="ExCommandsAreAlreadyTranslated" xml:space="preserve">
     <value>Commands are already translated.</value>
@@ -1091,15 +764,6 @@
   <data name="ExRequestIsNotPrepared" xml:space="preserve">
     <value>Request is not prepared</value>
   </data>
-  <data name="ExThereAreNoSuitableTypes" xml:space="preserve">
-    <value>There are no suitable types in '{0}'.</value>
-  </data>
-  <data name="ExElementWithNameContainedInThisInstanceAlready" xml:space="preserve">
-    <value>Element with name '{0}' is contained in this instance already.</value>
-  </data>
-  <data name="ExServiceWithNameAlreadyExistsInStorageInfoServicesCollection" xml:space="preserve">
-    <value>Service with name '{0}' already exists in StorageInfo.Services collection.</value>
-  </data>
   <data name="ExFieldWithNameAlreadyExistsInEntityFieldsCollection" xml:space="preserve">
     <value>Field with name '{0}' already exists in EntityInfo.Fields collection.</value>
   </data>
@@ -1109,29 +773,11 @@
   <data name="ExUnsupportedType" xml:space="preserve">
     <value>Unsupported type: '{0}'.</value>
   </data>
-  <data name="ExElementWithTypeIsContainedInThisInstanceAlready" xml:space="preserve">
-    <value>Element with type '{0}' is already contained in this instance.</value>
-  </data>
-  <data name="ExTypeCantBeNull" xml:space="preserve">
-    <value>Type cannot be null.</value>
-  </data>
   <data name="ExIndexAlreadyContainsField" xml:space="preserve">
     <value>Index already contains field '{0}'.</value>
   </data>
-  <data name="ExIndexFieldXIsIncorrect" xml:space="preserve">
-    <value>Index field '{0}' is incorrect.</value>
-  </data>
   <data name="ExTypeNotFoundInModel" xml:space="preserve">
     <value>Type '{0}' is not found in model.</value>
-  </data>
-  <data name="ExOutOfTransactionScope" xml:space="preserve">
-    <value>Object is outside of initial transaction scope.</value>
-  </data>
-  <data name="ExUnableToModifyDeletedObject" xml:space="preserve">
-    <value>Unable to modify removed object.</value>
-  </data>
-  <data name="ExSessionBoundObjectOutOfSessionScope" xml:space="preserve">
-    <value>Session bound object is out of session scope.</value>
   </data>
   <data name="ExFieldNotFoundInModel" xml:space="preserve">
     <value>Field '{0}' is not found in model.</value>
@@ -1142,20 +788,8 @@
   <data name="ExStorageProviderXIsNotFound" xml:space="preserve">
     <value>Storage provider '{0}' is not found.</value>
   </data>
-  <data name="ExInvalidKeyParams" xml:space="preserve">
-    <value>Unable to create Key. Key params do not correspond to its structure.</value>
-  </data>
-  <data name="ExTypeInfoHierarchyMistmatch" xml:space="preserve">
-    <value>TypeInfo hierarchy does not correspond to provided hierarchy.</value>
-  </data>
-  <data name="ExPrimaryKeyFieldCantBeChanged" xml:space="preserve">
-    <value>Field '{0}' is a part of primary key. It can't be changed.</value>
-  </data>
   <data name="ExEntityRemoved" xml:space="preserve">
     <value>Unable to modify removed entity.</value>
-  </data>
-  <data name="AspectExMultipleAttributesOfTypeXAreNotAllowedHere" xml:space="preserve">
-    <value>{0}: multiple attributes of type '{1}' are not allowed here.</value>
   </data>
   <data name="ExColumnLength" xml:space="preserve">
     <value>Value length {0} is greater than column length {1}.</value>
@@ -1163,38 +797,8 @@
   <data name="ExColumnNotNullable" xml:space="preserve">
     <value>Unable to assign null to non-nullable column.</value>
   </data>
-  <data name="ExTypeMustBeEntityDescendant" xml:space="preserve">
-    <value>Invalid type specified.</value>
-  </data>
-  <data name="ExInvalidSession" xml:space="preserve">
-    <value>The Session of specified ISessionBound object is invalid.</value>
-  </data>
-  <data name="ValueCanNotBeNull" xml:space="preserve">
-    <value>Value can not be null.</value>
-  </data>
   <data name="ExEntityIsRemoved" xml:space="preserve">
     <value>Entity is removed.</value>
-  </data>
-  <data name="ValueLengthCanNotExceedX" xml:space="preserve">
-    <value>Value can not exceed {0}.</value>
-  </data>
-  <data name="ValueShouldMatchRegexPatternX" xml:space="preserve">
-    <value>Value should match regex pattern '{0}'</value>
-  </data>
-  <data name="ExInvalidFieldValueConstraintXIsViolated" xml:space="preserve">
-    <value>Invalid field value, constraint {0} is violated.</value>
-  </data>
-  <data name="ValueCanNotBeLessThenX" xml:space="preserve">
-    <value>Value can not be less then {0}.</value>
-  </data>
-  <data name="ExErrorsDuringStorageBuild" xml:space="preserve">
-    <value>Some errors have been occurred during storage build. See error log for details.</value>
-  </data>
-  <data name="ExKeyFieldXWasNotFoundInTypeY" xml:space="preserve">
-    <value>Key field '{0}' was not found in type '{1}'.</value>
-  </data>
-  <data name="ValueTypeMismatchForFieldX" xml:space="preserve">
-    <value>Value type mismatch for field '{0}'</value>
   </data>
   <data name="ExFieldWithNameXIsAlreadyRegistered" xml:space="preserve">
     <value>Field with name '{0}' is already registered.</value>
@@ -1202,17 +806,8 @@
   <data name="ExFieldXIsAlreadyDefinedInTypeXOrItsAncestor" xml:space="preserve">
     <value>Field '{0}' is already defined in type '{1}' or in its ancestor.</value>
   </data>
-  <data name="ExInterfaceXDoesNotBelongToXHierarchy" xml:space="preserve">
-    <value>Interface '{0}' does not belong to '{1}' hierarchy.</value>
-  </data>
   <data name="TypeXDoesNotImplementYZField" xml:space="preserve">
     <value>Type '{0}' does not implement '{1}.{2}' property.</value>
-  </data>
-  <data name="ExConstraintViolation" xml:space="preserve">
-    <value>Constraint violation: constraint {0} on field '{1}.{2}' of object '{3}' failed on value {4}.</value>
-  </data>
-  <data name="ValueCanNotBeRemovedEntity" xml:space="preserve">
-    <value>Value can not be an entity that is already removed.</value>
   </data>
   <data name="ExIndexedPropertiesAreNotSupported" xml:space="preserve">
     <value>Indexed properties are not supported.</value>
@@ -1232,9 +827,6 @@
   <data name="ExIndexWithNameXIsAlreadyRegistered" xml:space="preserve">
     <value>Index with name '{0}' is already registered.</value>
   </data>
-  <data name="ExTypeXWasNotRegisteredForActivation" xml:space="preserve">
-    <value>Type '{0}' was not registered for activation.</value>
-  </data>
   <data name="ExTypeDefXIsAlreadyBelongsToHierarchyWithTheRootY" xml:space="preserve">
     <value>TypeDef '{0}' already belongs to hierarchy with '{1}' root.</value>
   </data>
@@ -1244,35 +836,20 @@
   <data name="ExPairedFieldXHasWrongTypeItShouldBeReferenceToEntityOrAEntitySet" xml:space="preserve">
     <value>Paired field '{0}' has wrong type. A descendant of Entity or EntitySet is expected.</value>
   </data>
-  <data name="ExReferencedFieldXAndPairedFieldAreEqual" xml:space="preserve">
-    <value>Referenced field '{0}' and paired field are equal.</value>
-  </data>
   <data name="ExPairedFieldXYWasNotFoundInZType" xml:space="preserve">
     <value>Paired field '{0}.{1}' was not found in '{2}' type.</value>
   </data>
   <data name="ExAssociationAttributeCanNotBeAppliedToXField" xml:space="preserve">
     <value>'AssociationAttribute' can't be applied to '{0}' field.</value>
   </data>
-  <data name="ExKeyProviderXShouldDefineAtLeastOneKeyField" xml:space="preserve">
-    <value>Key provider '{0}' should define at least one key field.</value>
-  </data>
-  <data name="ExKeyProviderXAndHierarchyYKeyFieldAmountMismatch" xml:space="preserve">
-    <value>Key provider '{0}' and hierarchy {1} key field amount mismatch.</value>
-  </data>
   <data name="ExInvalidLengthAttributeOnXField" xml:space="preserve">
     <value>Invalid Length attribute on '{0}' field.</value>
-  </data>
-  <data name="ExFieldXHasYTypeButIsMarkedAsNotNullable" xml:space="preserve">
-    <value>Field '{0}' has '{1}' type but is marked as not nullable.</value>
   </data>
   <data name="LogExplicitLazyLoadAttributeOnFieldXIsRedundant" xml:space="preserve">
     <value>Explicit LazyLoad=true on field '{0}' is redundant.</value>
   </data>
   <data name="ExplicitMappingNameSettingIsRedundantTheSameNameXWillBeGeneratedAutomatically" xml:space="preserve">
     <value>Explicit mapping name setting is redundant. The same name '{0}' will be generated automatically.</value>
-  </data>
-  <data name="ExInvalidMappingNameX" xml:space="preserve">
-    <value>Invalid mapping name '{0}'.</value>
   </data>
   <data name="ExIndexMustContainAtLeastOneField" xml:space="preserve">
     <value>Index must contain at least one field.</value>
@@ -1283,29 +860,14 @@
   <data name="ExColumnXIsNotFound" xml:space="preserve">
     <value>Column '{0}' is not found.</value>
   </data>
-  <data name="ExTypeXDoesNotImplementYInterface" xml:space="preserve">
-    <value>Type '{0}' does not implement '{1}' interface.</value>
-  </data>
-  <data name="ExTypeXIsNotCollatable" xml:space="preserve">
-    <value>Type '{0}' is not collatable.</value>
-  </data>
   <data name="XIsNotApplicableToYDescendants" xml:space="preserve">
     <value>'{0}' is not applicable to '{1}' descendants.</value>
-  </data>
-  <data name="ExNameXIsInvalid" xml:space="preserve">
-    <value>Name '{0}' is invalid.</value>
   </data>
   <data name="ExIndexNameXIsInvalid" xml:space="preserve">
     <value>Index name '{0}' is invalid.</value>
   </data>
   <data name="ExPropertyXMustBeDeclaredInTypeY" xml:space="preserve">
     <value>Property '{0}' must be declared in type '{1}'.</value>
-  </data>
-  <data name="ExUnsupportedFieldTypeX" xml:space="preserve">
-    <value>Unsupported field type: '{0}'</value>
-  </data>
-  <data name="ExKeyXWasNotFoundInStorage" xml:space="preserve">
-    <value>Key '{0}' was not found in storage.</value>
   </data>
   <data name="ExCannotFindHandlerOfTypeX" xml:space="preserve">
     <value>Cannot find a handler of type '{0}'.</value>
@@ -1346,35 +908,8 @@
   <data name="Indexes" xml:space="preserve">
     <value>Indexes</value>
   </data>
-  <data name="Columns" xml:space="preserve">
-    <value>Columns</value>
-  </data>
-  <data name="HierarchyColumns" xml:space="preserve">
-    <value>Hierarchy columns</value>
-  </data>
-  <data name="ExWrongPersistentTypeCandidate" xml:space="preserve">
-    <value>Wrong persistent type candidate: '{0}'.</value>
-  </data>
-  <data name="ExNotNullableConstraintViolationOnFieldX" xml:space="preserve">
-    <value>'NotNullable' constraint violation on field '{0}'.</value>
-  </data>
-  <data name="ExLengthConstraintViolationOnFieldX" xml:space="preserve">
-    <value>'Length' constraint violation on field '{0}'.</value>
-  </data>
   <data name="ExSessionIsAlreadyDisposed" xml:space="preserve">
     <value>Session is already disposed.</value>
-  </data>
-  <data name="ExCannotUseDefaultGeneratorForComplexKeys" xml:space="preserve">
-    <value>Cannot use default generator for complex (multicolumn) Keys.</value>
-  </data>
-  <data name="ExUnableToCloneNonUserSessionConfiguration" xml:space="preserve">
-    <value>Unable to clone non-user session configuration.</value>
-  </data>
-  <data name="ExEntityIsInInconsistentState" xml:space="preserve">
-    <value>Entity is in inconsistent state.</value>
-  </data>
-  <data name="ExCanNotOpenTransactionNoCurrentSession" xml:space="preserve">
-    <value>Can not open a transaction: there is no current Session.</value>
   </data>
   <data name="ExFieldXYIsNotFound" xml:space="preserve">
     <value>Field '{0}.{1}' is not found.</value>
@@ -1388,26 +923,11 @@
   <data name="ExEntitySetCanTBeAssigned" xml:space="preserve">
     <value>EntitySet can't be assigned.</value>
   </data>
-  <data name="ExAssociationMultiplicityIsNotValidForField" xml:space="preserve">
-    <value>Association multiplicity '{0}' is not valid for field '{1}'.</value>
-  </data>
   <data name="ExFieldXYIsAlreadyPairedWithABRemoveCD" xml:space="preserve">
     <value>Field '{0}.{1}' is already paired with '{2}.{3}'. Please remove [Association] attribute at '{4}.{5}'.</value>
   </data>
-  <data name="ExUnableToActivateEntitySetWithoutAssociation" xml:space="preserve">
-    <value>Unable to activate EntitySet for '{0}' field because it does not has association.</value>
-  </data>
   <data name="ExEntitySetInvalidBecauseTransactionIsNotActive" xml:space="preserve">
     <value>Entity set is invalid due to current transaction is not active.</value>
-  </data>
-  <data name="ExCanNotCommitATransactionValidationContextIsInInconsistentState" xml:space="preserve">
-    <value>Can not commit a transaction: ValidationContext is in inconsistent state.</value>
-  </data>
-  <data name="ExItemNotFoundInEntitySet" xml:space="preserve">
-    <value>Item is not found in EntitySet.</value>
-  </data>
-  <data name="ExCanNotGetValidationContextThereIsNoActiveTransaction" xml:space="preserve">
-    <value>Can not get validation context: there is no active transaction.</value>
   </data>
   <data name="ExDefaultGeneratorCanServeHierarchyWithExactlyOneKeyField" xml:space="preserve">
     <value>Default generator can serve hierarchy with exactly one key field.</value>
@@ -1427,26 +947,14 @@
   <data name="ExConfigurationForDomainIsNotFoundInApplicationConfigurationFile" xml:space="preserve">
     <value>Configuration for Domain with name '{0}' is not found in application configuration file (section '{1}').</value>
   </data>
-  <data name="ExFieldXCannotBeNullableAsItIsIncludedInPrimaryKey" xml:space="preserve">
-    <value>Field '{0}' cannot be Nullable as it is included into primary key.</value>
-  </data>
-  <data name="ExNoCurrentSession" xml:space="preserve">
-    <value>There is no current Session.</value>
-  </data>
   <data name="ExWrongKeyStructure" xml:space="preserve">
     <value>Wrong key structure.</value>
-  </data>
-  <data name="ExStateTransactionIsDifferent" xml:space="preserve">
-    <value>StateTransaction property value differs from the current transaction.</value>
   </data>
   <data name="ExInvalidKeyString" xml:space="preserve">
     <value>String representaion of the Key has invalid format.</value>
   </data>
   <data name="ExCannotAssociateNonEmptyEntityStateWithKeyOfUnknownType" xml:space="preserve">
     <value>Attempt to associate non-empty EntityState with Key of unknown type.</value>
-  </data>
-  <data name="ExPairToAttributeCanNotBeAppliedToXField" xml:space="preserve">
-    <value>[Association] attribute with PairTo can not be use with field '{0}' of type '{1}'. It is already applied to field '{2}' of type '{3}'.</value>
   </data>
   <data name="ExSessionWithNameXAlreadyExists" xml:space="preserve">
     <value>Session with name '{0}' already exists.</value>
@@ -1469,17 +977,11 @@
   <data name="ExUnableToFindFactoryMethodForTypeXMakeSureAssemblyYProcessedByWeaver" xml:space="preserve">
     <value>Unable to find factory method for type '{0}'. Make sure assembly '{0}' is processed by weaver. See section 2 of Manual for details.</value>
   </data>
-  <data name="ExActiveSerializationContextIsNotFound" xml:space="preserve">
-    <value>Active serialization context is not found.</value>
-  </data>
   <data name="ExCannotResolveEntityWithKeyX" xml:space="preserve">
     <value>Cannot resolve entity with key '{0}'.</value>
   </data>
   <data name="ExUnableToResolveTypeForKeyX" xml:space="preserve">
     <value>Unable to resolve type for Key '{0}'.</value>
-  </data>
-  <data name="ExUnknownEntitySerializationKindX" xml:space="preserve">
-    <value>Unknown entity serialization kind '{0}'.</value>
   </data>
   <data name="ExUnableToCreateKeyForXHierarchy" xml:space="preserve">
     <value>Unable to create key for '{0}' hierarchy. Key value or key generator should be specified.</value>
@@ -1487,64 +989,17 @@
   <data name="ExCompilerContainerAttributeIsNotAppliedToTypeX" xml:space="preserve">
     <value>[CompilerContainer] attribute isn't applied to type '{0}'.</value>
   </data>
-  <data name="ExInvalidUpgraderVersion" xml:space="preserve">
-    <value>Invalid upgrader version.</value>
-  </data>
-  <data name="ExTypeIdForTypeXIsNotFound" xml:space="preserve">
-    <value>TypeId for type '{0}' is not found.</value>
-  </data>
-  <data name="ExTypeWithTypeIdXIsNotFound" xml:space="preserve">
-    <value>Type with type TypeId='{0}' is not found.</value>
-  </data>
-  <data name="ExActualSchemaVersionOfAssemblyXIsExpectedToBeYButCurrentlyItIsZ" xml:space="preserve">
-    <value>Actual schema version of assembly '{0}' is expected to be '{1}', but currently it is '{2}'.</value>
-  </data>
-  <data name="ExOnlyEqualityRangesAreSupported" xml:space="preserve">
-    <value>Only equality ranges are supported.</value>
-  </data>
-  <data name="ExCouldNotFindFieldSegmentForFieldX" xml:space="preserve">
-    <value>Could not find field segment for field '{0}'.</value>
-  </data>
-  <data name="ExCouldNotFindEntityMappingForFieldX" xml:space="preserve">
-    <value>Could not find entity mapping for field '{0}'.</value>
-  </data>
-  <data name="ExCouldNotFindAnonymousMappingForFieldX" xml:space="preserve">
-    <value>Could not find anonymous mapping for field '{0}'.</value>
-  </data>
   <data name="ExBinaryExpressionsWithNodeTypeXAreNotSupported" xml:space="preserve">
     <value>Binary expressions with NodeType = 'ExpressionType.{0}' aren't supported.</value>
   </data>
-  <data name="ExCouldNotFindGroupingMappingForFieldX" xml:space="preserve">
-    <value>Could not find grouping mapping for field '{0}'.</value>
-  </data>
-  <data name="ExCouldNotFindSubqueryMappingForFieldX" xml:space="preserve">
-    <value>Could not find subquery mapping for field '{0}'.</value>
-  </data>
   <data name="ExSpecifiedValuesArentEnoughToCreateKeyForTypeX" xml:space="preserve">
     <value>Specified values aren't enough to create key for type '{0}'.</value>
-  </data>
-  <data name="ExExtractedSchemaIsNotCompatibleWithTheTargetSchema_DetailsX" xml:space="preserve">
-    <value>Extracted schema is not compatible with the target schema. Details:
-{0}</value>
-  </data>
-  <data name="ExCanNotUpgradeSchemaSafely_DetailsX" xml:space="preserve">
-    <value>Cannot upgrade schema safely. Details:
-{0}</value>
   </data>
   <data name="ExUpgradeOfAssemblyXFromVersionYToZIsNotSupported" xml:space="preserve">
     <value>Upgrade of assembly '{0}' from version '{1}' to '{2}' is not supported.</value>
   </data>
   <data name="ZeroAssemblyVersion" xml:space="preserve">
     <value>&lt;none&gt;</value>
-  </data>
-  <data name="ExDuplicateAssemblyNameX" xml:space="preserve">
-    <value>Duplicate assembly name: '{0}'.</value>
-  </data>
-  <data name="ExNoUpgradeHandlerIsFoundForAssemblyXVersionY" xml:space="preserve">
-    <value>No upgrade handler is found for assembly '{0}', version '{1}'.</value>
-  </data>
-  <data name="ExTypeWithNameXIsNotFoundInMetadata" xml:space="preserve">
-    <value>Type with name '{0}' is not found in metadata.</value>
   </data>
   <data name="LogMetadataTypeRenamedXToY" xml:space="preserve">
     <value>Metadata.Type renamed: '{0}' to '{1}'.</value>
@@ -1631,15 +1086,6 @@ Schema difference:
   <data name="ExAsOperatorSupportsEntityOnly" xml:space="preserve">
     <value>'as' operator supports casting only inside Entity hierarchy.</value>
   </data>
-  <data name="ExPrefetchDoesNotSupportQueryProviderOfTypeX" xml:space="preserve">
-    <value>Prefetch does not support query provider of type '{0}'.</value>
-  </data>
-  <data name="ExExcludeFieldsDoesNotSupportQueryProviderOfTypeX" xml:space="preserve">
-    <value>ExcludeFields does not support query provider of type '{0}'.</value>
-  </data>
-  <data name="ExIncludeFieldsDoesNotSupportQueryProviderOfTypeX" xml:space="preserve">
-    <value>IncludeFields does not support query provider of type '{0}'.</value>
-  </data>
   <data name="ExMethodXNotFound" xml:space="preserve">
     <value>Method '{0}' is not found.</value>
   </data>
@@ -1667,9 +1113,6 @@ Schema difference:
   <data name="ExTypeXMustBelongToHierarchy" xml:space="preserve">
     <value>Type '{0}' must belong to hierarchy.</value>
   </data>
-  <data name="ExUnauthorizedAccessDeclarationOfCallerTypeIsNotInRegisteredAssembly" xml:space="preserve">
-    <value>Unauthorized: the caller is declared outside of any of registered assemblies.</value>
-  </data>
   <data name="ExStructureOfFieldXDoesNotMatchStructureOfFieldY" xml:space="preserve">
     <value>Structure of field '{0}' does not match structure of field '{1}'.</value>
   </data>
@@ -1688,9 +1131,6 @@ Schema difference:
   <data name="ExActiveSessionIsRequiredForThisOperation" xml:space="preserve">
     <value>Active Session is required for this operation. Use Session.Open(...) to open it.</value>
   </data>
-  <data name="ExReferentialIntegrityViolation" xml:space="preserve">
-    <value>Referential integrity violation.</value>
-  </data>
   <data name="ReferentialIntegrityViolationOnAttemptToRemoveXKeyY" xml:space="preserve">
     <value>Referential integrity violation on attempt to remove '{0}', Key='{1}'.
 Association: {2}
@@ -1700,17 +1140,8 @@ Referenced Entity Key: {4}</value>
   <data name="ExLeftJoinDoesNotSupportQueryProviderOfTypeX" xml:space="preserve">
     <value>LeftJoin does not support query provider of type '{0}'.</value>
   </data>
-  <data name="ExTypeXDoesNotHaveAParameterlessConstructor" xml:space="preserve">
-    <value>Type '{0}' does not have a parameterless constructor.</value>
-  </data>
-  <data name="ExCurrentSessionGetterIsAlreadyAssigned" xml:space="preserve">
-    <value>Current session getter is already assigned.</value>
-  </data>
   <data name="ExValueIsAlreadyAssigned" xml:space="preserve">
     <value>Value is already assigned.</value>
-  </data>
-  <data name="ExMaterializationErrorTypeIdColumnDoesNotExistsInTheUnderlyingRecordSet" xml:space="preserve">
-    <value>Materialization error: Entity's TypeId column does not exist in the underlying RecordSet.</value>
   </data>
   <data name="KeyFormat" xml:space="preserve">
     <value>{0}, {1}</value>
@@ -1751,23 +1182,8 @@ Referenced Entity Key: {4}</value>
   <data name="ExFieldXIsNotAnEntitySetField" xml:space="preserve">
     <value>Field '{0}' is not an EntitySet field.</value>
   </data>
-  <data name="ExEntityOfTypeXIsIncompatibleWithThisEntitySet" xml:space="preserve">
-    <value>Entity of type '{0}' is incompatible with this EntitySet.</value>
-  </data>
   <data name="EntityWithKeyXDoesNotExist" xml:space="preserve">
     <value>Entity with Key = '{0}' does not exist.</value>
-  </data>
-  <data name="ExThereIsNoCurrentHttpRequestOrSessionManagerIsnTBoundToItYet" xml:space="preserve">
-    <value>There is no current HttpRequest, or SessionManager is not bound to it yet.</value>
-  </data>
-  <data name="ExQueryContainsClosuresOfDifferentTypes" xml:space="preserve">
-    <value>The query contains closures of different types.</value>
-  </data>
-  <data name="ExInvalidPrefetchSelectorX" xml:space="preserve">
-    <value>Invalid prefetch selector '{0}'.</value>
-  </data>
-  <data name="ExCanNotCommitATransactionValidationContextIsInInvalidState" xml:space="preserve">
-    <value>Can not commit a transaction. Validation context is in invalid state.</value>
   </data>
   <data name="ExLockDoesNotSupportQueryProviderOfTypeX" xml:space="preserve">
     <value>Lock does not support query provider of type '{0}'.</value>
@@ -1795,9 +1211,6 @@ Referenced Entity Key: {4}</value>
   </data>
   <data name="ExCouldNotGetMemberXFromExpression" xml:space="preserve">
     <value>Could not get member {0} from expression.</value>
-  </data>
-  <data name="ExIncorrectNamespaceSynonyms" xml:space="preserve">
-    <value>Incorrect namespace synonyms.</value>
   </data>
   <data name="ExMethodXIsntSupported" xml:space="preserve">
     <value>'{0}' method isn't supported.</value>
@@ -1856,12 +1269,6 @@ Referenced Entity Key: {4}</value>
   <data name="ExHierarchyIsNotFoundForTypeX" xml:space="preserve">
     <value>Hierarchy is not found for type '{0}'.</value>
   </data>
-  <data name="ExUnableToBuildGenericInstanceTypesForXTypeBecauseItContainsMoreThen1GenericParameter" xml:space="preserve">
-    <value>Unable to build generic instance types for '{0}' type because it contains more then 1 generic parameter.</value>
-  </data>
-  <data name="ExUnableToBuildGenericInstanceTypesForXTypeBecauseParameterIsNotConstrained" xml:space="preserve">
-    <value>Unable to build generic instance types for '{0}' type because parameter is not constrained.</value>
-  </data>
   <data name="ExItemByKeyXWasNotFound" xml:space="preserve">
     <value>Item by key ='{0}' was not found.</value>
   </data>
@@ -1883,17 +1290,8 @@ Referenced Entity Key: {4}</value>
   <data name="ExXDoesNotSupportX" xml:space="preserve">
     <value>'{0}' does not support '{1}'.</value>
   </data>
-  <data name="ExHierarchyRootIsNotRegistered" xml:space="preserve">
-    <value>Hierarchy root is not registered.</value>
-  </data>
-  <data name="ExOnlyEntitiesCouldBeHierarchyRoots" xml:space="preserve">
-    <value>Only entities could be hierarchy roots.</value>
-  </data>
   <data name="ExFieldXIsNotAnEntityReferenceNorEntitySet" xml:space="preserve">
     <value>Field '{0}' is not an entity reference, nor entity set.</value>
-  </data>
-  <data name="ExFieldXIsNotAnEntitySet" xml:space="preserve">
-    <value>Field '{0}' is not an entity set.</value>
   </data>
   <data name="ExUnableToRemapKeyExpression" xml:space="preserve">
     <value>Unable to remap KeyExpression.</value>
@@ -1907,14 +1305,8 @@ Referenced Entity Key: {4}</value>
   <data name="ExUnableToUseBaseImplementationOfVisitGenericExpressionWithoutSpecifyingGenericProcessorDelegate" xml:space="preserve">
     <value>Unable to use base implementation of VisitGenericExpression without specifying genericProcessor delegate.</value>
   </data>
-  <data name="ExUnableToResolveOwnerOfStructureExpressionX" xml:space="preserve">
-    <value>Unable to resolve owner of StructureExpression '{0}'.</value>
-  </data>
   <data name="ExUnableToResolveOwnerOfFieldExpressionX" xml:space="preserve">
     <value>Unable to resolve owner of FieldExpression '{0}'.</value>
-  </data>
-  <data name="ExSelectManyCollectionSelector0MustHaveOnlyOneLambdaParameter" xml:space="preserve">
-    <value>SelectMany collection selector '{0}' must have only one lambda parameter.</value>
   </data>
   <data name="SubqueryXHeaderMustHaveOnlyOneColumn" xml:space="preserve">
     <value>Subquery '{0}' header must have only one column.</value>
@@ -1958,23 +1350,11 @@ Referenced Entity Key: {4}</value>
   <data name="ExMethodCallExpressionXIsNotSupported" xml:space="preserve">
     <value>MethodCall expression '{0}' is not supported.</value>
   </data>
-  <data name="ExLambdaXMustHaveOnlyOneParameter" xml:space="preserve">
-    <value>Lambda '{0}' must have only one parameter.</value>
-  </data>
   <data name="ExAggregateMethodXIsNotSupported" xml:space="preserve">
     <value>Unable to translate '{0}' expression. Aggregate method '{1} is not supported.</value>
   </data>
-  <data name="ExCantAccessMemberOfTypeEntitySet" xml:space="preserve">
-    <value>Can't access member of type 'EntitySet&lt;&gt;'.</value>
-  </data>
-  <data name="CantAccessMemberX" xml:space="preserve">
-    <value>Can't access member '{0}'</value>
-  </data>
   <data name="ExUnableToTranslateLambdaExpressionXBecauseItRequiresToMaterializeEntityOfTypeX" xml:space="preserve">
     <value>Unable to translate lambda expression '{0}' because it requires to materialize entity of type '{1}'.</value>
-  </data>
-  <data name="ExTypeXIsNotSupportedInNewExpression" xml:space="preserve">
-    <value>Type '{0}' is not supported in 'new' expression.</value>
   </data>
   <data name="ExCanNotCommitATransactionEntitiesValidationFailed" xml:space="preserve">
     <value>Can not commit a transaction. Entities validation failed.</value>
@@ -1994,9 +1374,6 @@ Referenced Entity Key: {4}</value>
   <data name="ExFieldXIsNotDeclaredInTypeYOrInOneOfItsAncestors" xml:space="preserve">
     <value>The field {0} is not declared in the type {1} or in one of its ancestors.</value>
   </data>
-  <data name="ExIndexesOfColumnsToBeLoadedAreNotSpecified" xml:space="preserve">
-    <value>Indexes of columns to be loaded are not specified.</value>
-  </data>
   <data name="ExReferencingEntityWithKeyXIsNotFound" xml:space="preserve">
     <value>The referencing entity with key {0} is not found.</value>
   </data>
@@ -2005,12 +1382,6 @@ Referenced Entity Key: {4}</value>
   </data>
   <data name="ExForeignKeyValueHaveNotBeenLoaded" xml:space="preserve">
     <value>The foreign key's value have not been loaded.</value>
-  </data>
-  <data name="ExAccessToTypeMemberCanNotBeExtractedFromSpecifiedExpression" xml:space="preserve">
-    <value>The access to a type's member can not be extracted from the specified expression.</value>
-  </data>
-  <data name="ExSpecifiedPropertyXIsNotPersistent" xml:space="preserve">
-    <value>The specified property {0} is not persistent.</value>
   </data>
   <data name="ExPrimaryKeyFieldXCanTBeMarkedAsVersion" xml:space="preserve">
     <value>Primary key field '{0}' can't be marked as Version.</value>
@@ -2027,9 +1398,6 @@ Referenced Entity Key: {4}</value>
   <data name="VersionFieldXCanTBeTypeIdField" xml:space="preserve">
     <value>Version field '{0}' can't be TypeId field.</value>
   </data>
-  <data name="ExTypeXCantContainsVersionFieldsAsItsNotAHierarchyRoot" xml:space="preserve">
-    <value>Type '{0}' can't contain Version fields, because it is not a hierarchy root type.</value>
-  </data>
   <data name="ExTakeDoesNotSupportQueryProviderOfTypeX" xml:space="preserve">
     <value>'Take' does not support query provider of type '{0}'.</value>
   </data>
@@ -2044,15 +1412,6 @@ Referenced Entity Key: {4}</value>
   </data>
   <data name="ExCouldNotConstructNewKeyInstanceTypeXIsNotAnEntity" xml:space="preserve">
     <value>Could not construct new Key instance. Type '{0}' is not an entity.</value>
-  </data>
-  <data name="CantChangeTypeOfColumnX" xml:space="preserve">
-    <value> (can't change type of column '{0}')</value>
-  </data>
-  <data name="CantRemoveTableX" xml:space="preserve">
-    <value> (can't remove table '{0}')</value>
-  </data>
-  <data name="CantRemoveColumnX" xml:space="preserve">
-    <value> (can't remove column '{0}')</value>
   </data>
   <data name="ExUnableToBuildIndexXBecauseItWasBuiltOverInheritedFields" xml:space="preserve">
     <value>Unable to build index {0} because it contains inherited fields.</value>
@@ -2156,47 +1515,17 @@ Referenced Entity Key: {4}</value>
   <data name="ExElementAtIndexMustBeGreaterOrEqualToZero" xml:space="preserve">
     <value>ElementAt index must be greater or equal to zero.</value>
   </data>
-  <data name="ExLocalCollectionShouldNotBeQueryRoot" xml:space="preserve">
-    <value>Local collection should not be query root.</value>
-  </data>
-  <data name="ExConnectionIsRequired" xml:space="preserve">
-    <value>Connection is required.</value>
-  </data>
-  <data name="ExDisconnectedStateIsAlreadyAttachedToSession" xml:space="preserve">
-    <value>DisconnectedState is already attached to session.</value>
-  </data>
-  <data name="ExDisconnectedStateIsDetached" xml:space="preserve">
-    <value>DisconnectedState is detached.</value>
-  </data>
-  <data name="ExStateWithKeyXIsAlreadyExists" xml:space="preserve">
-    <value>State with key '{0}' is already exists.</value>
-  </data>
-  <data name="ExStateIsNotLoaded" xml:space="preserve">
-    <value>State is not loaded.</value>
-  </data>
-  <data name="ExStateIsRemoved" xml:space="preserve">
-    <value>State is removed.</value>
-  </data>
   <data name="ExKeyXShouldHaveExactType" xml:space="preserve">
     <value>Key {0} should have exact type.</value>
   </data>
   <data name="ExServiceXIsNotSupported" xml:space="preserve">
     <value>Service '{0}' is not supported.</value>
   </data>
-  <data name="ExXIsObsoleteUseYAndZInstead" xml:space="preserve">
-    <value>{0} is obsolete. Use {1} and {2} instead.</value>
-  </data>
   <data name="ExCanNotCompleteOuterTransactionInnerTransactionIsActive" xml:space="preserve">
     <value>Can not complete outer transaction: inner transaction is active.</value>
   </data>
-  <data name="ExCanNotOpenMoreThanOneInnerTransaction" xml:space="preserve">
-    <value>Can not open more than one inner transaction.</value>
-  </data>
   <data name="ExCanNotReuseOpenedTransactionRequestedIsolationLevelIsDifferent" xml:space="preserve">
     <value>Can not reuse opened transaction: requested isolation level is different.</value>
-  </data>
-  <data name="ExCanNotMarkStateAsModifiedItIsNotValidInCurrentTransaction" xml:space="preserve">
-    <value>Can not mark state as modified: it is not valid in current transaction.</value>
   </data>
   <data name="ExTransactionIsNotActive" xml:space="preserve">
     <value>Transaction is not active.</value>
@@ -2212,9 +1541,6 @@ Referenced Entity Key: {4}</value>
   </data>
   <data name="ExCantRegisterState" xml:space="preserve">
     <value>Can't register state.</value>
-  </data>
-  <data name="ExCantMergeState" xml:space="preserve">
-    <value>Can't merge state.</value>
   </data>
   <data name="LogSessionXOpeningTransaction" xml:space="preserve">
     <value>Session '{0}'. Opening transaction.</value>
@@ -2315,32 +1641,14 @@ Referenced Entity Key: {4}</value>
   <data name="ExSessionOfAnotherSessionBoundMustBeTheSame" xml:space="preserve">
     <value>Session of another SessionBound must be the same.</value>
   </data>
-  <data name="ExUnderlyingStorageProviderDoesNotSupportSQL" xml:space="preserve">
-    <value>Underlying storage provider does not support SQL.</value>
-  </data>
   <data name="ExConnectionInfoIsWrongYouShouldSetEitherConnectionUrlElementOrProviderAndConnectionStringElements" xml:space="preserve">
     <value>ConnectionInfo is wrong. You should set either 'connectionUrl' element or 'provider' and 'connectionString' elements.</value>
-  </data>
-  <data name="ExNonTemporaryKeysMustBeGeneratedByDescendants" xml:space="preserve">
-    <value>Non-temporary keys must be generated by descendants.</value>
-  </data>
-  <data name="ExSpecifiedKeyFieldTypeIsNotSupportedByThisTemporaryKeyGenerator" xml:space="preserve">
-    <value>Specified key field type is not supported by this temporary key generator.</value>
-  </data>
-  <data name="ExKeyOfSpecifiedTypeCannotBeGeneratedByThisKeyGenerator" xml:space="preserve">
-    <value>Key of specified type cannot be generated by this KeyGenerator.</value>
   </data>
   <data name="KeyGenerators" xml:space="preserve">
     <value>Key generators</value>
   </data>
   <data name="ExKeyGeneratorAttributeOnTypeXRequiresNameToBeSet" xml:space="preserve">
     <value>[KeyGenerator] attribute on type '{0}' requires Name to be set.</value>
-  </data>
-  <data name="ExTransactionIsRunning" xml:space="preserve">
-    <value>A transaction is running, but there should be no active transaction.</value>
-  </data>
-  <data name="ExCanNotMergeTheState" xml:space="preserve">
-    <value>Can't merge the state.</value>
   </data>
   <data name="ExQueryTaskIsNotExecutedYet" xml:space="preserve">
     <value>Query task is not executed yet.</value>
@@ -2360,21 +1668,11 @@ SessionOptions.AllowSwitching flag to avoid this exception, if this is intention
   <data name="ExCannotGenerateNextVersionValueOfTypeX" xml:space="preserve">
     <value>Can't generate next version value of type '{0}'.</value>
   </data>
-  <data name="ExPropertyXYDoesnTHavePublicGetter" xml:space="preserve">
-    <value>Property '{0}.{1}' doesn't have public getter.</value>
-  </data>
-  <data name="ExPropertyXDoesnTHavePublicSetter" xml:space="preserve">
-    <value>Property '{0}' doesn't have public setter.</value>
-  </data>
   <data name="ExTypeOfXMustBeADescendantOfYType" xml:space="preserve">
     <value>Type of '{0}' must be a descendant of {1} type.</value>
   </data>
   <data name="ExActiveTransactionIsRequiredForThisOperationUseSessionOpenTransactionToOpenIt" xml:space="preserve">
     <value>Active Transaction is required for this operation. Use Session.OpenTransaction(...) to open it.</value>
-  </data>
-  <data name="ExLegacySchemaIsNotCompatible_DetailsX" xml:space="preserve">
-    <value>Legacy schema is not compatible. Details: 
-{0}</value>
   </data>
   <data name="LogSkippingSchemaSynchronization" xml:space="preserve">
     <value>Skipping schema synchronization.</value>
@@ -2387,9 +1685,6 @@ SessionOptions.AllowSwitching flag to avoid this exception, if this is intention
   </data>
   <data name="ExConnectionInfoIsMissing" xml:space="preserve">
     <value>ConnectionInfo is missing. If you are using configuration file you should specify either 'connectionUrl' element or 'connectionString' and 'provider' elements</value>
-  </data>
-  <data name="ExConnectionInfoIsWrongYouShouldSetEitherConnectionUrlElementOrConnectionStringElement" xml:space="preserve">
-    <value>ConnectionInfo is wrong. You should set either  'connectionUrl' element or 'connectionString' element.</value>
   </data>
   <data name="ExTypeWithNameXIsNotRegistered" xml:space="preserve">
     <value>Type with name '{0}' isn't registered in the Domain.</value>
@@ -2436,15 +1731,6 @@ SessionOptions.AllowSwitching flag to avoid this exception, if this is intention
   <data name="ExUnableToCastItemOfTypeXToY" xml:space="preserve">
     <value>Unable to cast item of type '{0}' to '{1}' in queries.</value>
   </data>
-  <data name="ExOriginIsNull" xml:space="preserve">
-    <value>Origin is null.</value>
-  </data>
-  <data name="ExOriginIsNotNull" xml:space="preserve">
-    <value>Origin is not null.</value>
-  </data>
-  <data name="ExOnlyOnePrimaryOperationCanBeLogged" xml:space="preserve">
-    <value>Only one primary operation can be logged by each OperationContext instance.</value>
-  </data>
   <data name="LogSessionXEntityWithKeyYIdentifiedAsZ" xml:space="preserve">
     <value>Session '{0}'. Identifying entity: Key = '{1}', identified as '{2}'.</value>
   </data>
@@ -2462,9 +1748,6 @@ SessionOptions.AllowSwitching flag to avoid this exception, if this is intention
   </data>
   <data name="ExRunningOperationRegistrationMustBeFinished" xml:space="preserve">
     <value>Running operation registration must be finished before invocation of this method.</value>
-  </data>
-  <data name="ExYouMustEitherApplyOrCancelCachedChangesToChangeThisProperty" xml:space="preserve">
-    <value>You must either apply or cancel cached changes before changing this property.</value>
   </data>
   <data name="LogFailedToAddSchemaHintXErrorY" xml:space="preserve">
     <value>Failed to add schema hint '{0}' to schema hint collection. The hint will be ignored.
@@ -2503,9 +1786,6 @@ Error: {1}</value>
   </data>
   <data name="ExOnlyPrefetchMethodSupportedButFoundX" xml:space="preserve">
     <value>Only 'Prefetch(source, expression, params[] expressions)' method is supported within prefetch expression. But found '{0}'.</value>
-  </data>
-  <data name="ExUnabletoParsePrefetchExpressionX" xml:space="preserve">
-    <value>Unable to parse prefetch expression '{0}'.</value>
   </data>
   <data name="ExOnlyPropertAccessPrefetchOrAnonymousTypeSupportedButFoundX" xml:space="preserve">
     <value>Only persistented property access, calls of Prefetch method or anonymous type constructors are supported, but found '{0}' expression.</value>
@@ -2579,9 +1859,6 @@ Error: {1}</value>
   <data name="ExEntityWithKeyXAlreadyExists" xml:space="preserve">
     <value>Entity with key '{0}' already exists</value>
   </data>
-  <data name="ExInvalidFieldNameX" xml:space="preserve">
-    <value>Invalid field name '{0}'.</value>
-  </data>
   <data name="ExCantCompileProviderX" xml:space="preserve">
     <value>Can't compile the provider '{0}'.</value>
   </data>
@@ -2594,38 +1871,17 @@ Error: {1}</value>
   <data name="ExAtLeastOneColumnIndexPairMustBeSpecified" xml:space="preserve">
     <value>At least one column index pair must be specified.</value>
   </data>
-  <data name="ExCanNotCompileNoEnumerationContext" xml:space="preserve">
-    <value>Can't compile - no active EnumerationContext exists.</value>
-  </data>
   <data name="ExCanNotCompileNoCompiler" xml:space="preserve">
     <value>Can't compile - active CompilationContext has no Compiler (Compiler is null).</value>
   </data>
-  <data name="ExCantOpenEnumerationScopeSinceThereIsNoCurrentCompilationContext" xml:space="preserve">
-    <value>Can't open EnumerationScope, since there is no current CompilationContext.</value>
-  </data>
   <data name="NotAvailable" xml:space="preserve">
     <value>n/a</value>
-  </data>
-  <data name="ExTypeOfExpressionReturnValueIsNotX" xml:space="preserve">
-    <value>The type of the expression's return value is not '{0}'.</value>
-  </data>
-  <data name="ExNormalizedExpressionMustHaveXForm" xml:space="preserve">
-    <value>The normalized boolean expression must have the '{0}' form.</value>
-  </data>
-  <data name="ExNormalizedExpressionMustBeRoot" xml:space="preserve">
-    <value>The normalized boolean expression must be the root expression.</value>
-  </data>
-  <data name="ExNormalizedExpressionMustNotBeRoot" xml:space="preserve">
-    <value>The normalized boolean expression must not be the root expression.</value>
   </data>
   <data name="ExXCantBeExecuted" xml:space="preserve">
     <value>{0} can't be executed on specified sources.</value>
   </data>
   <data name="ExParameterXIsNotATupleAccessExpression" xml:space="preserve">
     <value>Parameter '{0}' is not a tuple access expression</value>
-  </data>
-  <data name="ExValueOfParameterWCantBeXIfValueOfParameterYIsZ" xml:space="preserve">
-    <value>The value of the parameter {0} can't be {1}, if the value of the parameter {2} is {3}.</value>
   </data>
   <data name="ExSelectProviderRemovesColumnsUsedForOrdering" xml:space="preserve">
     <value>The SelectProvider removes columns used for an ordering.</value>
@@ -2654,23 +1910,11 @@ Error: {1}</value>
   <data name="ExOrderKeyNotFoundInMapping" xml:space="preserve">
     <value>Order key not found in mapping.</value>
   </data>
-  <data name="ExFilterTupleDescriptorMistmatchesWithSourceMappingDescriptor" xml:space="preserve">
-    <value>Filter tuple descriptor mistmatches with source mapping descriptor.</value>
-  </data>
-  <data name="ExUnableToInitializeJoinIndexProviderColumnsCountMismatch" xml:space="preserve">
-    <value>Unable to initialize JoinIndexProvider. Columns count mismatch.</value>
-  </data>
-  <data name="ExColumnGroupCouldNotBeFound" xml:space="preserve">
-    <value>Column group could not be found.</value>
-  </data>
   <data name="ExOnlySingleColumnKeySupported" xml:space="preserve">
     <value>Only single-column key supported.</value>
   </data>
   <data name="ExSequenceContainsMoreThanOneElement" xml:space="preserve">
     <value>Sequence contains more than one element.</value>
-  </data>
-  <data name="ExCurrentCompilerIsNotSuitableForThisOperationMostLikelyThereIsNoActiveSession" xml:space="preserve">
-    <value>Current compiler is not suitable for this operation, most likely there is no active Session.</value>
   </data>
   <data name="ExProcessingOfVoidProviderIsNotSupported" xml:space="preserve">
     <value>Processing of VoidProvider is not supported.</value>
@@ -2681,17 +1925,8 @@ Error: {1}</value>
   <data name="ExColumnXContainsBothKeyAndValueCollections" xml:space="preserve">
     <value>Column "{0}" contains both key and value collections.</value>
   </data>
-  <data name="ExCanNotFindReferenceToColumnX" xml:space="preserve">
-    <value>Can not find reference to column "{0}".</value>
-  </data>
   <data name="ExMoreThenOneKeyColumnReferenceToColumnX" xml:space="preserve">
     <value>KeyColumns collection contains more then one reference to column "{0}".</value>
-  </data>
-  <data name="ExReferencedColumnXDoesNotBelongToIndexY" xml:space="preserve">
-    <value>Referenced column "{0}" does not belong to index "{1}".</value>
-  </data>
-  <data name="ExMoreThenOneValueColumnReferenceToColumnX" xml:space="preserve">
-    <value>ValueColumns collection contains more then one reference to column "{0}".</value>
   </data>
   <data name="ExUndefinedTypeOfColumnX" xml:space="preserve">
     <value>Type of column "{0}" is undefined.</value>
@@ -2701,9 +1936,6 @@ Error: {1}</value>
   </data>
   <data name="ExPrimaryKeyColumnCanNotBeNullable" xml:space="preserve">
     <value>Primary key column can not be nullable.</value>
-  </data>
-  <data name="ExUndefinedForeignKey" xml:space="preserve">
-    <value>ForeignKey is undefined.</value>
   </data>
   <data name="ExInvalidForeignKeyStructure" xml:space="preserve">
     <value>Invalid ForeignKey structure: its column sequence do not match PrimaryKey column sequence.</value>
@@ -2759,47 +1991,14 @@ Error: {1}</value>
   <data name="NativeType" xml:space="preserve">
     <value>Native type</value>
   </data>
-  <data name="ExSpecifiedRedoDescriptorCantBeLogged" xml:space="preserve">
-    <value>Specified RedoDescriptor can't be logged.</value>
-  </data>
   <data name="LogUndoError" xml:space="preserve">
     <value>Error during Undo execution: descriptor {0}.</value>
-  </data>
-  <data name="ExConcurrencyConflict" xml:space="preserve">
-    <value>Concurrency conflict.</value>
   </data>
   <data name="ExDeadlock" xml:space="preserve">
     <value>Deadlock was found.</value>
   </data>
-  <data name="ExVersionConflict" xml:space="preserve">
-    <value>Version conflict.</value>
-  </data>
-  <data name="ExVersionConflictEx" xml:space="preserve">
-    <value>Version conflict on object {0}: expected: {1} = {2}, but it is {3}.</value>
-  </data>
-  <data name="ExAtomicContextIsSuspended" xml:space="preserve">
-    <value>AtomicContext is suspended.</value>
-  </data>
-  <data name="ExOldActiveOperationIsStillRunning" xml:space="preserve">
-    <value>You can't Activate new operation, since old ActiveOperation is still running.</value>
-  </data>
-  <data name="ExCantInvokeBlockingDescriptor" xml:space="preserve">
-    <value>Blocking descriptor can't be invoked.</value>
-  </data>
-  <data name="ExAlreadyCompleted" xml:space="preserve">
-    <value>UndoDescriptor is already completed.</value>
-  </data>
-  <data name="ExCompleteMustBeCalledJustOnce" xml:space="preserve">
-    <value>Complete method must be called just once.</value>
-  </data>
-  <data name="ExContextMustBeActivated" xml:space="preserve">
-    <value>Context is not activated.</value>
-  </data>
   <data name="ExObjectAndContextAreIncompatible" xml:space="preserve">
     <value>The specified object and the context are incompatible.</value>
-  </data>
-  <data name="ExIncorrectStageValue" xml:space="preserve">
-    <value>Incorrect Stage value: '{0}'.</value>
   </data>
   <data name="LogRelationSyncUndoError" xml:space="preserve">
     <value>Error during undoing the relation synchronization.</value>
@@ -2807,35 +2006,11 @@ Error: {1}</value>
   <data name="ValueDoesNotMatchRegexPatternX" xml:space="preserve">
     <value>Value does not match regex pattern '{0}'.</value>
   </data>
-  <data name="PropertyValueCanNotBeEmpty" xml:space="preserve">
-    <value>{0}: value can not be empty.</value>
-  </data>
-  <data name="AspectExFieldConstraintCanNotBeAppliedToReadOnlyPropertyX" xml:space="preserve">
-    <value>Field constraint can not be applied to read only property {0}.</value>
-  </data>
-  <data name="AspectExXDoesNotSupportYValueTypeLocationZ" xml:space="preserve">
-    <value>'{0}' does not support '{1}' value type (location: {2}).</value>
-  </data>
   <data name="X" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="ExValidationFailed" xml:space="preserve">
     <value>Validation failed.</value>
-  </data>
-  <data name="PropertyValueCanNotBeNull" xml:space="preserve">
-    <value>{0}: value can not be null.</value>
-  </data>
-  <data name="PropertyValueLengthMustBeInXYRange" xml:space="preserve">
-    <value>{0}: length of the value must be in [{1} ... {2}] range.</value>
-  </data>
-  <data name="PropertyValueMustBeInXYRange" xml:space="preserve">
-    <value>{0}: value must be in [{1} ... {2}] range.</value>
-  </data>
-  <data name="AspectExNoComparer" xml:space="preserve">
-    <value>[{0}] attribute on '{1}' requires a comparer for type '{2}'.</value>
-  </data>
-  <data name="DateMustBeInThePast" xml:space="preserve">
-    <value>Date must be in the past.</value>
   </data>
   <data name="ValueShouldBeInTheFuture" xml:space="preserve">
     <value>Value should be in the future.</value>
@@ -2861,9 +2036,6 @@ Error: {1}</value>
   <data name="ValueShouldNotBeNull" xml:space="preserve">
     <value>Value should not be null.</value>
   </data>
-  <data name="ValueShouldNotBeEmptyOrEmpty" xml:space="preserve">
-    <value>Value should not be null or empty.</value>
-  </data>
   <data name="FieldShouldBeOfComparableType" xml:space="preserve">
     <value>Field should be of comparable type.</value>
   </data>
@@ -2882,32 +2054,8 @@ Error: {1}</value>
   <data name="FailedToCreateRegularExpressionFromPatternX" xml:space="preserve">
     <value>Failed to create regular expression from pattern '{0}'.</value>
   </data>
-  <data name="AspectExApplyingXToPropertyYFailedZ" xml:space="preserve">
-    <value>Applying [{0}] to property '{1}' failed. {2}</value>
-  </data>
-  <data name="ExValidationContextIsInvalid" xml:space="preserve">
-    <value>Validation context is in invalid state. This means that some validation error has happened, but later it was suppressed.</value>
-  </data>
-  <data name="AspectExXAndYPropertiesMustBeUsedTogetherLocationZ" xml:space="preserve">
-    <value>'{0}' and '{1}' properties must be used together (location: {2}).</value>
-  </data>
-  <data name="AspectExBothLocalizableMessageResourceAndNotLocalizableMessageCanNotBeSpecifiedAtOnceLocationX" xml:space="preserve">
-    <value>Both localizable message resource and not localizable message can not be specified at once (location: {0}).</value>
-  </data>
-  <data name="ExSqlServerBelow2005IsNotSupported" xml:space="preserve">
-    <value>SQL Server below 2005 is not supported.</value>
-  </data>
-  <data name="ExSqlServerSupportsTrimmingOfSpaceCharactersOnly" xml:space="preserve">
-    <value>SQL Server supports trimming of space characters only.</value>
-  </data>
   <data name="ExInvalidBooleanStringX" xml:space="preserve">
     <value>Invalid boolean string '{0}'.</value>
-  </data>
-  <data name="ExMultipleLanguagesNotSupportedForFulltextColumnXOfIndexY" xml:space="preserve">
-    <value>Multiple languages not supported for fulltext column {0} of index {1}.</value>
-  </data>
-  <data name="ExNoMessageTemplateIsRegisteredForCodeX" xml:space="preserve">
-    <value>No message template is registered for code: {0}</value>
   </data>
   <data name="ExTablePropertyIsNotSet" xml:space="preserve">
     <value>Table is not set.</value>
@@ -2917,18 +2065,6 @@ Error: {1}</value>
   </data>
   <data name="ExUnboundColumn" xml:space="preserve">
     <value>Unbound column '{0}'.</value>
-  </data>
-  <data name="ExSizeShouldBeNotNegativeValue" xml:space="preserve">
-    <value>Size should be not negative value.</value>
-  </data>
-  <data name="ExScaleShouldBeNonNegativeValue" xml:space="preserve">
-    <value>Scale should be non-negative value.</value>
-  </data>
-  <data name="ExPrecisionShouldBeNonNegativeValue" xml:space="preserve">
-    <value>Precision should be non-negative value.</value>
-  </data>
-  <data name="ExTheScaleMustBeLessThanOrEqualToPrecision" xml:space="preserve">
-    <value>The scale must be less than or equal to precision.</value>
   </data>
   <data name="ExLengthShouldBeNotNegativeValue" xml:space="preserve">
     <value>Length should be not negative value.</value>
@@ -2948,17 +2084,8 @@ Error: {1}</value>
   <data name="ExReferencingColumnsCountCantBeLessThenOne" xml:space="preserve">
     <value>Referencing columns count cannot be less then one.</value>
   </data>
-  <data name="ExRowAmountShouldBePositiveNumber" xml:space="preserve">
-    <value>Row amount should be positive number.</value>
-  </data>
   <data name="ExCircularReferenceDetected" xml:space="preserve">
     <value>Circular reference is detected.</value>
-  </data>
-  <data name="ExTheDataTypeMustBeExactNumericWithScale0" xml:space="preserve">
-    <value>The data type must be exact numeric with scale 0.</value>
-  </data>
-  <data name="ExLiteralTypeXIsNotSupported" xml:space="preserve">
-    <value>Literal type '{0}' is not supported.</value>
   </data>
   <data name="LogUnableToGetDefaultNodeComparerForTypeXxx" xml:space="preserve">
     <value>Unable to get default SQL comparer for type {0}.</value>
@@ -3040,9 +2167,6 @@ Error: {1}</value>
   </data>
   <data name="ExIncrementMustNotBeZero" xml:space="preserve">
     <value>Increment must not be 0.</value>
-  </data>
-  <data name="ExTheDataTypeMustBeExactNumericWithoutScaleOrWithZeroScale" xml:space="preserve">
-    <value>The data type must be exact numeric without scale or with zero scale.</value>
   </data>
   <data name="ExNameMustBeNotNullOrEmpty" xml:space="preserve">
     <value>Name must be not null or empty.</value>
@@ -3164,9 +2288,6 @@ Error: {1}</value>
   <data name="ExTypeDiscriminatorIsNotFoundForXType" xml:space="preserve">
     <value>Type discriminator field is not found for '{0}' type</value>
   </data>
-  <data name="ExCurrentStorageDoesNotSupportChangingColumnTypes" xml:space="preserve">
-    <value>Current storage does not support changing column types</value>
-  </data>
   <data name="ExDirectQueryingForEntitySetInCompiledQueriesIsNotSupportedUseQueryEndpointItemsInstead" xml:space="preserve">
     <value>Direct querying for entity set in compiled queries is not supported, use QueryEndpoint.Items() instead.</value>
   </data>
@@ -3184,9 +2305,6 @@ Error: {1}</value>
   </data>
   <data name="ExCompilerXHasInvalidTargetType" xml:space="preserve">
     <value>Compiler {0} has invalid target type: target type should be either non-generic or generic type definition.</value>
-  </data>
-  <data name="ExCompilerXHasInvalidTargetMember" xml:space="preserve">
-    <value>Compiler {0} has invalid target member.</value>
   </data>
   <data name="ExCompilerXShouldHaveThisParameter" xml:space="preserve">
     <value>Compiler {0} should have "this" parameter.</value>
@@ -3220,9 +2338,6 @@ Error: {1}</value>
   </data>
   <data name="ExValidateVersionEqTrueIsIncompatibleWithPersistRequestKindEqInsert" xml:space="preserve">
     <value>validateVersion=true is incompatible with PersistRequestKind=Insert</value>
-  </data>
-  <data name="ExBatchingCommandProcessorDoesNotSupportValidationOfNumberOfAffectedRows" xml:space="preserve">
-    <value>BatchingCommandProcessor does not support validation of number of affected rows.</value>
   </data>
   <data name="ExUnableToResolveSchemaForNodeXPleaseVerifyThatThisSchemaExists" xml:space="preserve">
     <value>Unable to resolve schema for node '{0}'. Please verify that this schema exists.</value>
@@ -3314,9 +2429,6 @@ Error: {1}</value>
   <data name="ExCurrentTypeOfExpressionXIsNotSupported" xml:space="preserve">
     <value>Current type of expression '{0}' is not supported.</value>
   </data>
-  <data name="ExTypeOfEntityStoredInKeyIsUndefined" xml:space="preserve">
-    <value>Type of entity stored in Key is undefined.</value>
-  </data>
   <data name="ExAssemblyVersionMismatchMainAssemblyXYExtensionsAssemblyAB" xml:space="preserve">
     <value>Assembly version mismatch: main assembly '{0} {1}', extension assembly '{2} {3}'.</value>
   </data>
@@ -3350,9 +2462,6 @@ Error: {1}</value>
   <data name="ExUnableToDefineTypeIdentifierXForTypeYTypeIsNotExists" xml:space="preserve">
     <value>Unable to define type identifier '{0}' for type '{1}'. Type is not exists.</value>
   </data>
-  <data name="ExUserDefinedTypeIdentifierXForTypeYLessThan100" xml:space="preserve">
-    <value>User defined type identifier '{0}' for type '{1}'  less then 100.</value>
-  </data>
   <data name="ExCustomTypeIdentifierXOfTypeYBeyongsTheLimitsDefinedForDatabase" xml:space="preserve">
     <value>Custom type identifier '{0}' of type '{1}' beyongs the limits defined for database.</value>
   </data>
@@ -3364,9 +2473,6 @@ Error: {1}</value>
   </data>
   <data name="ExStorageIsNotSupportedLimitationOfRowCountToDelete" xml:space="preserve">
     <value>Storage is not supported limitation of row count to delete.</value>
-  </data>
-  <data name="ExUnableToRemapOneOfFilteredColumns" xml:space="preserve">
-    <value>Unable to remap one of filtered columns.</value>
   </data>
   <data name="ExUnableToFindTypeXInCurrentModel" xml:space="preserve">
     <value>Unable to find type '{0}' in current model.</value>
@@ -3385,9 +2491,6 @@ Error: {1}</value>
   </data>
   <data name="ExCollectionShouldContainAtLeastXElements" xml:space="preserve">
     <value>Collection should contain at least {0} elements.</value>
-  </data>
-  <data name="TypeXIsNotSupportedYNode" xml:space="preserve">
-    <value>Type '{0}' is not supported '{1}' node.</value>
   </data>
   <data name="ExTermWeightValueMustBeBetweenXAndY" xml:space="preserve">
     <value>Term weight value must be between {0} and {1}</value>
@@ -3428,17 +2531,8 @@ Error: {1}</value>
   <data name="ExExtractedAndTargetSchemasAreEqualButThereAreChangesInTypeIdentifiersSet" xml:space="preserve">
     <value>Extracted and target schemas are equal but there are changes in type identifiers set.</value>
   </data>
-  <data name="LogConnectionRestoreFailed" xml:space="preserve">
-    <value>Connection restore failed.</value>
-  </data>
   <data name="LogConnectionSuccessfullyRestored" xml:space="preserve">
     <value>Connection successfully restored.</value>
-  </data>
-  <data name="ExUnableToSaveModifiedEntitesBecauseOfIncompleteAsynchronousQueries" xml:space="preserve">
-    <value>Unable to save modified entites because some asynchronous query is incomplete. Make sure you awaited started asynchronous queries before persisting any changes.</value>
-  </data>
-  <data name="ExUnableToSaveModifiedEntitesBecauseSomeAsynchronousQueryIsIncomplete" xml:space="preserve">
-    <value>Unable to save modified entites because some asynchronous query is incomplete. Make sure you awaited asyncronous queries before persisting any changes.</value>
   </data>
   <data name="ExKeyBelongsToDifferentStorageNode" xml:space="preserve">
     <value>The Key belongs to different storage node.</value>
@@ -3463,9 +2557,6 @@ Error: {1}</value>
   </data>
   <data name="ExUnableToChangeCommandItIsAlreadyPrepared" xml:space="preserve">
     <value>Unable to change command: it is already prepared.</value>
-  </data>
-  <data name="ExUnableToPrepareCommandNoPartsRegistered" xml:space="preserve">
-    <value>Unable to prepare command: no parts registered.</value>
   </data>
   <data name="ExCantModifyActiveOrDisposedScope" xml:space="preserve">
     <value>Can't modify Active or Disposed scope.</value>

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -3479,4 +3479,7 @@ Error: {1}</value>
   <data name="ExArgumentContainsInvalidCharacters" xml:space="preserve">
     <value>Invalid argument: Argument {0} cannot contain '{1}' characters.</value>
   </data>
+  <data name="ExTagDoesNotSupportQueryProviderOfTypeX" xml:space="preserve">
+    <value>'Tag' does not support query provider of type '{0}'.</value>
+  </data>
 </root>

--- a/Orm/Xtensive.Orm/Xtensive.Orm.csproj
+++ b/Orm/Xtensive.Orm/Xtensive.Orm.csproj
@@ -43,45 +43,53 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="BitFaster.Caching" Version="1.0.4" />
   </ItemGroup>
-  <ItemGroup Label="T4GeneratorsUpdaters">
-    <None Update="Arithmetic\Internal\PrimitiveArithmetics.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
-    <None Update="Core\Extensions\DelegateBindExtensions.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
-    <None Update="Core\Extensions\ExpressionCompileExtensions.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
-    <None Update="InternalLogs.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
-    <None Update="Orm\Linq\MemberCompilation\MemberCompilerProvider-CreateCompiler.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
-  </ItemGroup>
   <ItemGroup Label="T4 templates">
     <None Include="Arithmetic\Internal\PrimitiveArithmetics.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>PrimitiveArithmetics.cs</LastGenOutput>
     </None>
+    <Compile Update="Arithmetic\Internal\PrimitiveArithmetics.cs">
+      <DesignTime>true</DesignTime>
+      <AutoGen>true</AutoGen>
+      <DependentUpon>PrimitiveArithmetics.tt</DependentUpon>
+    </Compile>
     <None Include="Core\Extensions\DelegateBindExtensions.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>DelegateBindExtensions.cs</LastGenOutput>
     </None>
+    <Compile Update="Core\Extensions\DelegateBindExtensions.cs">
+      <DesignTime>true</DesignTime>
+      <AutoGen>true</AutoGen>
+      <DependentUpon>DelegateBindExtensions.tt</DependentUpon>
+    </Compile>
     <None Include="Core\Extensions\ExpressionCompileExtensions.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ExpressionCompileExtensions.cs</LastGenOutput>
     </None>
+    <Compile Update="Core\Extensions\ExpressionCompileExtensions.cs">
+      <DesignTime>true</DesignTime>
+      <AutoGen>true</AutoGen>
+      <DependentUpon>ExpressionCompileExtensions.tt</DependentUpon>
+    </Compile>
     <None Include="DelegateGenerator.ttinclude" />
     <None Include="InternalLogs.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>InternalLogs.cs</LastGenOutput>
     </None>
+    <Compile Update="InternalLogs.cs">
+      <DesignTime>true</DesignTime>
+      <AutoGen>true</AutoGen>
+      <DependentUpon>InternalLogs.tt</DependentUpon>
+    </Compile>
     <None Include="Orm\Linq\MemberCompilation\MemberCompilerProvider-CreateCompiler.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>MemberCompilerProvider-CreateCompiler.cs</LastGenOutput>
     </None>
+    <Compile Update="Orm\Linq\MemberCompilation\MemberCompilerProvider-CreateCompiler.cs">
+      <DesignTime>true</DesignTime>
+      <AutoGen>true</AutoGen>
+      <DependentUpon>MemberCompilerProvider-CreateCompiler.tt</DependentUpon>
+    </Compile>
     <None Include="Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
- ```SimpleCommandProcessor``` manages task queue the same way as ```BatchingCommandProcessor``` (more efficient).
- Correct errors for ```.Tag()``` query extension if base query provider is not ours.
- T4 templates are correctly assigned with the files that they generate.
- Some notes in ColumnCollection and ColumnGroupCollection about unsafe optimization (just in case, to lower chances of wrong usage)
- Got rid of a lot of error messages which weren't in use.