### PR TITLE
Issue: Cached query captures object in closure

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Issues/IssueGithub0224_DelayedQueryCapture.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueGithub0224_DelayedQueryCapture.cs
@@ -12,11 +12,11 @@ using System.Threading;
 using NUnit.Framework;
 using Xtensive.Caching;
 using Xtensive.Orm.Configuration;
-using Xtensive.Orm.Tests.Issues.Issue_DelayedQueryCapture_Model;
+using Xtensive.Orm.Tests.Issues.IssueGithub0224_DelayedQueryCapture_Model;
 
 namespace Xtensive.Orm.Tests.Issues
 {
-  namespace Issue_DelayedQueryCapture_Model
+  namespace IssueGithub0224_DelayedQueryCapture_Model
   {
     [HierarchyRoot]
     class Item : Entity
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.Tests.Issues
   }
 
   [Serializable]
-  public class Issue_DelayedQueryCapture : AutoBuildTest
+  public class IssueGithub0224_DelayedQueryCapture : AutoBuildTest
   {
     public class OtherService
     {

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_DelayedQueryCapture.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_DelayedQueryCapture.cs
@@ -12,7 +12,7 @@ using System.Threading;
 using NUnit.Framework;
 using Xtensive.Caching;
 using Xtensive.Orm.Configuration;
-using Xtensive.Orm.Tests.Issues.Issue0628_ExecuteFutureScalarError_Model;
+using Xtensive.Orm.Tests.Issues.Issue_DelayedQueryCapture_Model;
 
 namespace Xtensive.Orm.Tests.Issues
 {

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_DelayedQueryCapture.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_DelayedQueryCapture.cs
@@ -1,0 +1,94 @@
+// Copyright (C) 2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Dynamic;
+using System.Reflection;
+using System.Threading;
+using NUnit.Framework;
+using Xtensive.Caching;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Tests.Issues.Issue0628_ExecuteFutureScalarError_Model;
+
+namespace Xtensive.Orm.Tests.Issues
+{
+  namespace Issue_DelayedQueryCapture_Model
+  {
+    [HierarchyRoot]
+    class Item : Entity
+    {
+      [Field, Key]
+      public int Id { get; private set; }
+
+      [Field]
+      public int Tag { get; set; }
+    }
+  }
+
+  [Serializable]
+  public class Issue_DelayedQueryCapture : AutoBuildTest
+  {
+    public class OtherService
+    {
+      public static volatile int InstanceCount;
+
+      public int N;
+
+      public OtherService()
+      {
+        Interlocked.Increment(ref InstanceCount);
+      }
+
+      ~OtherService()
+      {
+        Interlocked.Decrement(ref InstanceCount);
+      }
+    }
+
+
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var config = base.BuildConfiguration();
+      config.Types.Register(typeof(Item).Assembly, typeof(Item).Namespace);
+      return config;
+    }
+
+    [Test]
+    public void DelayedQueryCapture()
+    {
+      using (var session = Domain.OpenSession())
+      using (var t = session.OpenTransaction()) {
+        var item = new Item() { Tag = 10 };
+        DelayedQuery(session);
+        t.Complete();
+      }
+      GC.Collect();
+      Thread.Sleep(1000);
+      GC.Collect();
+      Assert.AreEqual(0, OtherService.InstanceCount);
+    }
+
+    private void DelayedQuery(Session session)
+    {
+      var ids = new[] { 1, 2 };
+      var otherService = new OtherService();
+
+      var items = session.Query.CreateDelayedQuery(q =>
+                from t in q.All<Item>()
+                where t.Id.In(ids)
+                select t).ToArray();
+
+      var bb1 = items
+          .Select(a => new {
+            a.Id,
+            A = new {
+              B = otherService.N == a.Id
+            },
+          });
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -209,7 +209,7 @@ namespace Xtensive.Orm.Internals
       var typeInfo = type.GetTypeInfo();
       if (typeInfo.IsGenericType) {
         var genericDef = typeInfo.GetGenericTypeDefinition();
-        return (genericDef == WellKnownTypes.NullableOfT || genericDef.IsAssignableTo(WellKnownTypes.IReadOnlyList))
+        return (genericDef == WellKnownTypes.NullableOfT || genericDef.IsAssignableTo(WellKnownTypes.IReadOnlyListOfT))
           && TypeIsSimple(typeInfo.GetGenericArguments()[0]);
       }
       else if (typeInfo.IsArray) {

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -200,7 +200,7 @@ namespace Xtensive.Orm.Internals
         return null;
       });
 
-      return !closureType.Name.Contains("<>c__DisplayClass")            // 'DisplayClass' is generated class for captured objects
+      return !TypeHelper.IsClosure(closureType)
         || closureType.GetFields().All(FieldIsSimple);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2021 Xtensive LLC.
+// Copyright (C) 2012-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -7,6 +7,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xtensive.Caching;
@@ -19,6 +20,8 @@ namespace Xtensive.Orm.Internals
 {
   internal class CompiledQueryRunner
   {
+    private static readonly Func<FieldInfo, bool> FieldIsSimple = fieldInfo => TypeIsSimple(fieldInfo.FieldType);
+
     private readonly Domain domain;
     private readonly Session session;
     private readonly QueryEndpoint endpoint;
@@ -108,7 +111,7 @@ namespace Xtensive.Orm.Internals
     private ParameterizedQuery GetScalarQuery<TResult>(
       Func<QueryEndpoint, TResult> query, bool executeAsSideEffect, out TResult result)
     {
-      AllocateParameterAndReplacer();
+      var cacheable = AllocateParameterAndReplacer();
 
       var parameterContext = new ParameterContext(outerContext);
       parameterContext.SetValue(queryParameter, queryTarget);
@@ -123,7 +126,9 @@ namespace Xtensive.Orm.Internals
         throw new NotSupportedException(Strings.ExNonLinqCallsAreNotSupportedWithinQueryExecuteDelayed);
       }
 
-      PutCachedQuery(parameterizedQuery);
+      if (cacheable) {
+        PutCachedQuery(parameterizedQuery);
+      }
       return parameterizedQuery;
     }
 
@@ -135,7 +140,7 @@ namespace Xtensive.Orm.Internals
         return parameterizedQuery;
       }
 
-      AllocateParameterAndReplacer();
+      var cacheable = AllocateParameterAndReplacer();
       var scope = new CompiledQueryProcessingScope(queryParameter, queryParameterReplacer);
       using (scope.Enter()) {
         var result = query.Invoke(endpoint);
@@ -143,16 +148,18 @@ namespace Xtensive.Orm.Internals
         parameterizedQuery = (ParameterizedQuery) translatedQuery;
       }
 
-      PutCachedQuery(parameterizedQuery);
+      if (cacheable) {
+        PutCachedQuery(parameterizedQuery);
+      }
       return parameterizedQuery;
     }
 
-    private void AllocateParameterAndReplacer()
+    private bool AllocateParameterAndReplacer()
     {
       if (queryTarget == null) {
         queryParameter = null;
         queryParameterReplacer = new ExtendedExpressionReplacer(e => e);
-        return;
+        return true;
       }
 
       var closureType = queryTarget.GetType();
@@ -192,6 +199,25 @@ namespace Xtensive.Orm.Internals
         }
         return null;
       });
+
+      return !closureType.Name.Contains("<>c__DisplayClass")            // 'DisplayClass' is generated class for captured objects
+        || closureType.GetFields().All(FieldIsSimple);
+    }
+
+    private static bool TypeIsSimple(Type type)
+    {
+      var typeInfo = type.GetTypeInfo();
+      if (typeInfo.IsGenericType) {
+        var genericDef = typeInfo.GetGenericTypeDefinition();
+        return (genericDef == WellKnownTypes.NullableOfT || genericDef.IsAssignableTo(WellKnownTypes.IReadOnlyList))
+          && TypeIsSimple(typeInfo.GetGenericArguments()[0]);
+      }
+      else if (typeInfo.IsArray) {
+        return TypeIsSimple(typeInfo.GetElementType());
+      }
+      else {
+        return typeInfo.IsPrimitive || typeInfo.IsEnum || type == WellKnownTypes.String || type == WellKnownTypes.Decimal;
+      }
     }
 
     private ParameterizedQuery GetCachedQuery() =>

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Internals
 {
   internal class CompiledQueryRunner
   {
-    private static readonly Func<FieldInfo, bool> FieldIsSimple = fieldInfo => TypeIsSimple(fieldInfo.FieldType);
+    private static readonly Func<FieldInfo, bool> FieldIsSimple = fieldInfo => IsSimpleType(fieldInfo.FieldType);
 
     private readonly Domain domain;
     private readonly Session session;
@@ -204,16 +204,16 @@ namespace Xtensive.Orm.Internals
         || closureType.GetFields().All(FieldIsSimple);
     }
 
-    private static bool TypeIsSimple(Type type)
+    private static bool IsSimpleType(Type type)
     {
       var typeInfo = type.GetTypeInfo();
       if (typeInfo.IsGenericType) {
         var genericDef = typeInfo.GetGenericTypeDefinition();
         return (genericDef == WellKnownTypes.NullableOfT || genericDef.IsAssignableTo(WellKnownTypes.IReadOnlyListOfT))
-          && TypeIsSimple(typeInfo.GetGenericArguments()[0]);
+          && IsSimpleType(typeInfo.GetGenericArguments()[0]);
       }
       else if (typeInfo.IsArray) {
-        return TypeIsSimple(typeInfo.GetElementType());
+        return IsSimpleType(typeInfo.GetElementType());
       }
       else {
         return typeInfo.IsPrimitive || typeInfo.IsEnum || type == WellKnownTypes.String || type == WellKnownTypes.Decimal;

--- a/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
+++ b/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
@@ -74,7 +74,7 @@ namespace Xtensive.Reflection
 
     public static readonly Type ByteArray = typeof(byte[]);
     public static readonly Type ObjectArray = typeof(object[]);
-    public static readonly Type IReadOnlyList = typeof(IReadOnlyList<>);
+    public static readonly Type IReadOnlyListOfT = typeof(IReadOnlyList<>);
 
     public static readonly Type DefaultMemberAttribute = typeof(DefaultMemberAttribute);
   }

--- a/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
+++ b/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
@@ -1,8 +1,9 @@
-// Copyright (C) 2020 Xtensive LLC.
+// Copyright (C) 2020-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -73,6 +74,7 @@ namespace Xtensive.Reflection
 
     public static readonly Type ByteArray = typeof(byte[]);
     public static readonly Type ObjectArray = typeof(object[]);
+    public static readonly Type IReadOnlyList = typeof(IReadOnlyList<>);
 
     public static readonly Type DefaultMemberAttribute = typeof(DefaultMemberAttribute);
   }


### PR DESCRIPTION
It is expected that QueryCache should not keep references to any objects from closure.
Because cache record lifetime may be indefinitely long