### PR TITLE
Fix Memory (event handlers) leak of ColumnInfoCollection objects

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -661,8 +661,8 @@ namespace Xtensive.Orm.Model
       Fields.UpdateState();
       if (column != null)
         column.UpdateState();
-      columns = new ColumnInfoCollection(this, "Columns");
-      GetColumns(columns);
+      columns?.Clear();           // To prevent event handler leak
+      columns = null;
 
       HasImmediateValidators = validators.Count > 0 && validators.Any(v => v.IsImmediate);
 

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2021 Xtensive LLC.
+// Copyright (C) 2007-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -627,6 +627,7 @@ namespace Xtensive.Orm.Model
 
         var result = new ColumnInfoCollection(this, "Columns");
         GetColumns(result);
+        columns = result;
         return result;
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -747,7 +747,7 @@ namespace Xtensive.Orm.Model
 
     private void CreateTupleDescriptor()
     {
-      var orderedColumns = columns.OrderBy(c => c.Field.MappingInfo.Offset).ToList();
+      var orderedColumns = columns.OrderBy(c => c.Field.MappingInfo.Offset).ToList(columns.Count);
       columns.Clear();                    // To prevent event handler leak
       columns.AddRange(orderedColumns);
       TupleDescriptor = TupleDescriptor.Create(

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2020 Xtensive LLC.
+// Copyright (C) 2007-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -38,7 +38,7 @@ namespace Xtensive.Orm.Model
     /// </summary>
     public const int MinTypeId = 100;
 
-    private ColumnInfoCollection               columns;
+    private readonly ColumnInfoCollection      columns;
     private readonly FieldMap                  fieldMap;
     private readonly FieldInfoCollection       fields;
     private readonly TypeIndexInfoCollection   indexes;
@@ -747,8 +747,8 @@ namespace Xtensive.Orm.Model
 
     private void CreateTupleDescriptor()
     {
-      var orderedColumns = columns.OrderBy(c => c.Field.MappingInfo.Offset);
-      columns = new ColumnInfoCollection(this, "Columns");
+      var orderedColumns = columns.OrderBy(c => c.Field.MappingInfo.Offset).ToList();
+      columns.Clear();
       columns.AddRange(orderedColumns);
       TupleDescriptor = TupleDescriptor.Create(
         Columns.Select(c => c.ValueType).ToArray(Columns.Count));

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -748,7 +748,7 @@ namespace Xtensive.Orm.Model
     private void CreateTupleDescriptor()
     {
       var orderedColumns = columns.OrderBy(c => c.Field.MappingInfo.Offset).ToList();
-      columns.Clear();
+      columns.Clear();                    // To prevent event handler leak
       columns.AddRange(orderedColumns);
       TupleDescriptor = TupleDescriptor.Create(
         Columns.Select(c => c.ValueType).ToArray(Columns.Count));


### PR DESCRIPTION
* Every invocation of `FieldInfo.Columns` property creates `ColumnInfoCollection` instance which subscribes for columns changes.
This prevents garbage collection of ColumnInfoCollection instances

* `TypeInfo.CreateTupleDescriptor()`  leaks `ColumnInfoCollection` instances by the same reason
* `FieldInfo.UpdateState()`  leaks as well