### PR TITLE
Oracle: schemas extraction fix

### DIFF
--- a/ChangeLog/7.0.3_dev.txt
+++ b/ChangeLog/7.0.3_dev.txt
@@ -1,0 +1,2 @@
+[main] NodeCollection supports different equality comparers for internal name index
+[oracle] Fixed scheme extraction for case-sensitive schema names

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/Extractor.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/Extractor.cs
@@ -142,9 +142,9 @@ namespace Xtensive.Sql.Drivers.Oracle.v09
 
     private ExtractionContext CreateContext(string catalogName, string[] schemaNames)
     {
-      var catalog = new Catalog(catalogName);
+      var catalog = new Catalog(catalogName, true);
       for(var i = 0; i < schemaNames.Length; i++) {
-        schemaNames[i] = schemaNames[i].ToUpperInvariant();
+        schemaNames[i] = ToUpperInvariantIfNeeded(schemaNames[i]);
       }
 
       var replacements = new Dictionary<string, string>();

--- a/Orm/Xtensive.Orm.Tests.Framework/StorageTestHelper.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/StorageTestHelper.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.12.17
 
@@ -51,13 +51,16 @@ namespace Xtensive.Orm.Tests
         var extractionResult = driver.Extract(connection, new[] {extractionTask});
         var catalog = extractionResult.Catalogs.Single();
         var existingSchemas = catalog.Schemas.Select(s => s.Name);
-        var schemasToCreate = schemas.Except(existingSchemas, StringComparer.OrdinalIgnoreCase);
 
         // Oracle does not support creating schemas, user should be created instead.
-        if (connectionInfo.Provider==WellKnown.Provider.Oracle)
+        if (connectionInfo.Provider == WellKnown.Provider.Oracle) {
+          var schemasToCreate = schemas.Except(existingSchemas, StringComparer.Ordinal);
           CreateUsers(connection, schemasToCreate);
-        else
+        }
+        else {
+          var schemasToCreate = schemas.Except(existingSchemas, StringComparer.OrdinalIgnoreCase);
           CreateSchemas(connection, catalog, schemasToCreate);
+        }
 
         connection.Close();
       }

--- a/Orm/Xtensive.Orm.Tests/Storage/Multimapping/CaseSensitiveSchemasTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Multimapping/CaseSensitiveSchemasTest.cs
@@ -1,0 +1,106 @@
+// Copyright (C) 2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Linq;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using M = Xtensive.Orm.Tests.Storage.Multimapping.CaseSensitiveSchemasTestModel;
+
+namespace Xtensive.Orm.Tests.Storage.Multimapping.CaseSensitiveSchemasTestModel
+{
+  namespace Schema1
+  {
+    [HierarchyRoot]
+    public class Entity1 : Entity
+    {
+      [Field, Key]
+      public int Id { get; private set; }
+
+      [Field]
+      public string OriginalSchemaName { get; set; }
+    }
+  }
+
+  namespace Schema2
+  {
+    [HierarchyRoot]
+    public class Entity2 : Entity
+    {
+      [Field, Key]
+      public int Id { get; private set; }
+
+      [Field]
+      public string OriginalSchemaName { get; set; }
+    }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Storage.Multimapping
+{
+  public sealed class CaseSensitiveSchemasTest : MultimappingTest
+  {
+    private const string Schema1Name = WellKnownSchemas.Schema1;
+
+    private readonly string schema1UpperCaseName = Schema1Name.ToUpperInvariant();
+
+    protected override void CheckRequirements() => Require.ProviderIs(StorageProvider.Oracle);
+
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.DefaultSchema = Schema1Name;
+      configuration.Types.Register(typeof(M.Schema1.Entity1));
+      configuration.Types.Register(typeof(M.Schema2.Entity2));
+      var rules = configuration.MappingRules;
+      rules.Map(typeof(M.Schema1.Entity1).Namespace).ToSchema(Schema1Name);
+      rules.Map(typeof(M.Schema2.Entity2).Namespace).ToSchema(schema1UpperCaseName);
+      return configuration;
+    }
+
+    [Test]
+    public void MainTest()
+    {
+      BuildInitialDomain();
+      BuildUpgradedDomain();
+    }
+
+    private void BuildInitialDomain()
+    {
+      var config = BuildConfiguration();
+      PrepareSchema(config.ConnectionInfo);
+      var domain = Domain.Build(config);
+      using (domain) {
+        using (var session = domain.OpenSession())
+        using (var tx = session.OpenTransaction()) {
+          _ = new M.Schema1.Entity1 { OriginalSchemaName = Schema1Name };
+          _ = new M.Schema2.Entity2 { OriginalSchemaName = schema1UpperCaseName };
+          tx.Complete();
+        }
+      }
+    }
+
+    private void BuildUpgradedDomain()
+    {
+      var config = BuildConfiguration();
+      config.UpgradeMode = DomainUpgradeMode.PerformSafely;
+      var domain = Domain.Build(config);
+      using (domain) {
+        using (var session = domain.OpenSession())
+        using (var tx = session.OpenTransaction()) {
+          var e1 = session.Query.All<M.Schema1.Entity1>().Single();
+          var e2 = session.Query.All<M.Schema2.Entity2>().Single();
+          Assert.That(e1.OriginalSchemaName, Is.EqualTo(Schema1Name));
+          Assert.That(e2.OriginalSchemaName, Is.EqualTo(schema1UpperCaseName));
+          tx.Complete();
+        }
+      }
+    }
+
+    private void PrepareSchema(ConnectionInfo connectionInfo)
+    {
+      StorageTestHelper.DemandSchemas(
+        connectionInfo, Schema1Name, schema1UpperCaseName);
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Sql/Model/Catalog.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/Catalog.cs
@@ -198,10 +198,20 @@ namespace Xtensive.Sql.Model
 
     // Constructors
 
-    public Catalog(string name) : base(name)
+    public Catalog(string name)
+      : base(name)
     {
       schemas =
         new PairedNodeCollection<Catalog, Schema>(this, "Schemas", 1);
     }
+
+    public Catalog(string name, bool caseSensitiveNames = false)
+      : base(name)
+    {
+      schemas = caseSensitiveNames
+        ? new PairedNodeCollection<Catalog, Schema>(this, "Schemas", 1, StringComparer.Ordinal)
+        : new PairedNodeCollection<Catalog, Schema>(this, "Schemas", 1, StringComparer.OrdinalIgnoreCase);
+    }
+
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Model/NodeCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/NodeCollection.cs
@@ -84,5 +84,16 @@ namespace Xtensive.Sql.Model
     {
       nameIndex = new Dictionary<string, TNode>(capacity, Comparer);
     }
+
+    /// <summary>
+    /// Initializes new instance of this type.
+    /// </summary>
+    /// <param name="capacity">The initial collection capacity.</param>
+    /// <param name="comparer">Comparer for inner name index.</param>
+    public NodeCollection(int capacity, IEqualityComparer<string> comparer)
+      : base(capacity)
+    {
+      nameIndex = new Dictionary<string, TNode>(capacity, comparer);
+    }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Model/PairedNodeCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/PairedNodeCollection.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Xtensive.Core;
 
 namespace Xtensive.Sql.Model
@@ -69,6 +70,24 @@ namespace Xtensive.Sql.Model
     {
       ArgumentValidator.EnsureArgumentNotNull(owner, "owner");
       ArgumentValidator.EnsureArgumentNotNullOrEmpty(property, "property");
+      this.owner = owner;
+      this.property = property;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PairedNodeCollection{TOwner,TNode}"/> class.
+    /// </summary>
+    /// <param name="owner">The collection owner.</param>
+    /// <param name="property">Owner collection property.</param>
+    /// <param name="capacity">The initial collection capacity.</param>
+    /// <param name="equalityComparer">Comparer for inner name index.</param>
+    public PairedNodeCollection(TOwner owner, string property, int capacity, IEqualityComparer<string> equalityComparer)
+      : base(capacity, equalityComparer)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(owner, nameof(owner));
+      ArgumentValidator.EnsureArgumentNotNullOrEmpty(property, nameof(property));
+      ArgumentValidator.EnsureArgumentNotNull(equalityComparer, nameof(equalityComparer));
+
       this.owner = owner;
       this.property = property;
     }


### PR DESCRIPTION
- Fixes schema extraction problem for case-sensitive names
- Gives ability for schemas to be case-sensitive (Oracle supports it natively), before that it was prohibited due to name index within ```NodeCollection```