### PR TITLE
Optimize size of PackedFieldDescriptor struct from 16 bytes to 8

### DIFF
--- a/Orm/Xtensive.Orm/Tuples/AccessorDelegates.cs
+++ b/Orm/Xtensive.Orm/Tuples/AccessorDelegates.cs
@@ -25,5 +25,5 @@ namespace Xtensive.Tuples
   /// <param name="tuple">Tuple to use.</param>
   /// <param name="descriptor">Field descriptor.</param>
   /// <param name="value">A value.</param>
-  internal delegate void SetValueDelegate<TValue>(PackedTuple tuple, ref PackedFieldDescriptor descriptor, TValue value);
+  internal delegate void SetValueDelegate<TValue>(PackedTuple tuple, in PackedFieldDescriptor descriptor, TValue value);
 }

--- a/Orm/Xtensive.Orm/Tuples/AccessorDelegates.cs
+++ b/Orm/Xtensive.Orm/Tuples/AccessorDelegates.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Tuples
   /// <param name="descriptor">Field descriptor.</param>
   /// <param name="fieldState">State of a field.</param>
   /// <returns></returns>
-  internal delegate TValue GetValueDelegate<TValue>(PackedTuple tuple, ref PackedFieldDescriptor descriptor, out TupleFieldState fieldState);
+  internal delegate TValue GetValueDelegate<TValue>(PackedTuple tuple, in PackedFieldDescriptor descriptor, out TupleFieldState fieldState);
 
   /// <summary>
   /// Incapsulates <see cref="Tuple.SetValue{T}"/> method.

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -249,10 +249,10 @@ namespace Xtensive.Tuples.Packed
       }
 
       var encoded = Encode(value);
-      var block = tuple.Values[valueIndex];
+      ref var block = ref tuple.Values[valueIndex];
       var valueBitOffset = d.ValueBitOffset;
       var mask = ValueBitMask << valueBitOffset;
-      tuple.Values[valueIndex] = (block & ~mask) | ((encoded << valueBitOffset) & mask);
+      block = (block & ~mask) | ((encoded << valueBitOffset) & mask);
     }
 
     private T Load(PackedTuple tuple, ref PackedFieldDescriptor d)

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -11,7 +11,7 @@ namespace Xtensive.Tuples.Packed
 {
   internal abstract class PackedFieldAccessor
   {
-    public static readonly PackedFieldAccessor[] All = new PackedFieldAccessor[20];
+    public static readonly PackedFieldAccessor[] All = new PackedFieldAccessor[18];
 
     /// <summary>
     /// Getter delegate.
@@ -135,7 +135,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public ObjectFieldAccessor()
-      : base(-1, 19)
+      : base(-1, 1)
     { }
   }
 
@@ -283,7 +283,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public BooleanFieldAccessor()
-      : base(1, 1)
+      : base(1, 2)
     {
     }
   }
@@ -306,7 +306,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public FloatFieldAccessor()
-      : base(sizeof(float) * 8, 2)
+      : base(sizeof(float) * 8, 3)
     {
     }
   }
@@ -324,7 +324,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public DoubleFieldAccessor()
-      : base(sizeof(double) * 8, 3)
+      : base(sizeof(double) * 8, 4)
     {
     }
   }
@@ -342,7 +342,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public TimeSpanFieldAccessor()
-      : base(sizeof(long) * 8, 4)
+      : base(sizeof(long) * 8, 5)
     {
     }
   }
@@ -360,7 +360,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public DateTimeFieldAccessor()
-      : base(sizeof(long) * 8, 5)
+      : base(sizeof(long) * 8, 6)
     {
     }
   }
@@ -378,7 +378,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public ByteFieldAccessor()
-      : base(sizeof(byte) * 8, 6)
+      : base(sizeof(byte) * 8, 7)
     {
     }
   }
@@ -396,7 +396,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public SByteFieldAccessor()
-      : base(sizeof(sbyte) * 8, 7)
+      : base(sizeof(sbyte) * 8, 8)
     {
     }
   }
@@ -414,7 +414,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public ShortFieldAccessor()
-      : base(sizeof(short) * 8, 8)
+      : base(sizeof(short) * 8, 9)
     {
     }
   }
@@ -432,7 +432,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public UShortFieldAccessor()
-      : base(sizeof(ushort) * 8, 9)
+      : base(sizeof(ushort) * 8, 10)
     {
     }
   }
@@ -450,7 +450,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public IntFieldAccessor()
-      : base(sizeof(int) * 8, 10)
+      : base(sizeof(int) * 8, 11)
     {
     }
   }
@@ -468,7 +468,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public UIntFieldAccessor()
-      : base(sizeof(uint) * 8, 11)
+      : base(sizeof(uint) * 8, 12)
     {
     }
   }
@@ -486,7 +486,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public LongFieldAccessor()
-      : base(sizeof(long) * 8, 12)
+      : base(sizeof(long) * 8, 13)
     {
     }
   }
@@ -504,7 +504,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public ULongFieldAccessor()
-      : base(sizeof(ulong) * 8, 13)
+      : base(sizeof(ulong) * 8, 14)
     {
     }
   }
@@ -533,7 +533,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public GuidFieldAccessor()
-      : base(GetSize() * 8, 14)
+      : base(GetSize() * 8, 15)
     {
     }
   }
@@ -556,7 +556,7 @@ namespace Xtensive.Tuples.Packed
       }
     }
     public DecimalFieldAccessor()
-      : base(sizeof(decimal) * 8, 15)
+      : base(sizeof(decimal) * 8, 16)
     {
     }
   }
@@ -585,7 +585,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public DateTimeOffsetFieldAccessor()
-       : base(GetSize() * 8, 16)
+       : base(GetSize() * 8, 17)
     { }
   }
 }

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -242,24 +242,27 @@ namespace Xtensive.Tuples.Packed
 
     private void Store(PackedTuple tuple, ref PackedFieldDescriptor d, T value)
     {
+      var valueIndex = d.ValueIndex;
       if (Rank > 6) {
-        Encode(value, tuple.Values, d.ValueIndex);
+        Encode(value, tuple.Values, valueIndex);
         return;
       }
 
       var encoded = Encode(value);
-      var block = tuple.Values[d.ValueIndex];
-      var mask = ValueBitMask << d.ValueBitOffset;
-      tuple.Values[d.ValueIndex] = (block & ~mask) | ((encoded << d.ValueBitOffset) & mask);
+      var block = tuple.Values[valueIndex];
+      var valueBitOffset = d.ValueBitOffset;
+      var mask = ValueBitMask << valueBitOffset;
+      tuple.Values[valueIndex] = (block & ~mask) | ((encoded << valueBitOffset) & mask);
     }
 
     private T Load(PackedTuple tuple, ref PackedFieldDescriptor d)
     {
+      var valueIndex = d.ValueIndex;
       if (Rank > 6) {
-        return Decode(tuple.Values, d.ValueIndex);
+        return Decode(tuple.Values, valueIndex);
       }
 
-      var encoded = (tuple.Values[d.ValueIndex] >> d.ValueBitOffset) & ValueBitMask;
+      var encoded = (tuple.Values[valueIndex] >> d.ValueBitOffset) & ValueBitMask;
       return Decode(encoded);
     }
 

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2021 Xtensive LLC.
+// Copyright (C) 2013-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -10,6 +10,8 @@ namespace Xtensive.Tuples.Packed
 {
   internal abstract class PackedFieldAccessor
   {
+    public static readonly PackedFieldAccessor[] All = new PackedFieldAccessor[20];
+
     /// <summary>
     /// Getter delegate.
     /// </summary>
@@ -33,6 +35,7 @@ namespace Xtensive.Tuples.Packed
     public readonly int Rank;
     public readonly int ValueBitCount;
     protected readonly long ValueBitMask;
+    public readonly byte Index;
 
     public void SetValue<T>(PackedTuple tuple, ref PackedFieldDescriptor descriptor, bool isNullable, T value)
     {
@@ -70,9 +73,14 @@ namespace Xtensive.Tuples.Packed
 
     public abstract int GetValueHashCode(PackedTuple tuple, ref PackedFieldDescriptor descriptor);
 
-    protected PackedFieldAccessor(int rank)
+    protected PackedFieldAccessor(int rank, byte index)
     {
       Rank = rank;
+      Index = index;
+      if (All[Index] != null) {
+        throw new IndexOutOfRangeException($"Duplicated Index {Index} of PackedFieldAccessor instance");
+      }
+      All[Index] = this;
       ValueBitCount = 1 << Rank;
 
       // What we want here is to shift 1L by ValueBitCount to left and then subtract 1
@@ -128,7 +136,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public ObjectFieldAccessor()
-      : base(-1)
+      : base(-1, 19)
     { }
   }
 
@@ -146,8 +154,8 @@ namespace Xtensive.Tuples.Packed
       return rank;
     }
 
-    protected ValueFieldAccessor(int bitCount)
-      : base(GetRank(bitCount))
+    protected ValueFieldAccessor(int bitCount, byte index)
+      : base(GetRank(bitCount), index)
     {}
   }
 
@@ -255,8 +263,8 @@ namespace Xtensive.Tuples.Packed
       return Decode(encoded);
     }
 
-    protected ValueFieldAccessor(int bits)
-      : base(bits)
+    protected ValueFieldAccessor(int bits, byte index)
+      : base(bits, index)
     {
       FieldType = typeof(T);
       Getter = (GetValueDelegate<T>) GetValue;
@@ -280,7 +288,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public BooleanFieldAccessor()
-      : base(1)
+      : base(1, 1)
     {
     }
   }
@@ -303,7 +311,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public FloatFieldAccessor()
-      : base(sizeof(float) * 8)
+      : base(sizeof(float) * 8, 2)
     {
     }
   }
@@ -321,7 +329,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public DoubleFieldAccessor()
-      : base(sizeof(double) * 8)
+      : base(sizeof(double) * 8, 3)
     {
     }
   }
@@ -339,7 +347,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public TimeSpanFieldAccessor()
-      : base(sizeof(long) * 8)
+      : base(sizeof(long) * 8, 4)
     {
     }
   }
@@ -357,7 +365,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public DateTimeFieldAccessor()
-      : base(sizeof(long) * 8)
+      : base(sizeof(long) * 8, 5)
     {
     }
   }
@@ -375,7 +383,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public ByteFieldAccessor()
-      : base(sizeof(byte) * 8)
+      : base(sizeof(byte) * 8, 6)
     {
     }
   }
@@ -393,7 +401,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public SByteFieldAccessor()
-      : base(sizeof(sbyte) * 8)
+      : base(sizeof(sbyte) * 8, 7)
     {
     }
   }
@@ -411,7 +419,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public ShortFieldAccessor()
-      : base(sizeof(short) * 8)
+      : base(sizeof(short) * 8, 8)
     {
     }
   }
@@ -429,7 +437,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public UShortFieldAccessor()
-      : base(sizeof(ushort) * 8)
+      : base(sizeof(ushort) * 8, 9)
     {
     }
   }
@@ -447,7 +455,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public IntFieldAccessor()
-      : base(sizeof(int) * 8)
+      : base(sizeof(int) * 8, 10)
     {
     }
   }
@@ -465,7 +473,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public UIntFieldAccessor()
-      : base(sizeof(uint) * 8)
+      : base(sizeof(uint) * 8, 11)
     {
     }
   }
@@ -483,7 +491,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public LongFieldAccessor()
-      : base(sizeof(long) * 8)
+      : base(sizeof(long) * 8, 12)
     {
     }
   }
@@ -501,7 +509,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public ULongFieldAccessor()
-      : base(sizeof(ulong) * 8)
+      : base(sizeof(ulong) * 8, 13)
     {
     }
   }
@@ -530,7 +538,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public GuidFieldAccessor()
-      : base(GetSize() * 8)
+      : base(GetSize() * 8, 14)
     {
     }
   }
@@ -553,7 +561,7 @@ namespace Xtensive.Tuples.Packed
       }
     }
     public DecimalFieldAccessor()
-      : base(sizeof(decimal) * 8)
+      : base(sizeof(decimal) * 8, 15)
     {
     }
   }
@@ -582,7 +590,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public DateTimeOffsetFieldAccessor()
-       : base(GetSize() * 8)
+       : base(GetSize() * 8, 16)
     { }
   }
 }

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -5,6 +5,7 @@
 // Created:    2013.01.22
 
 using System;
+using System.Numerics;
 
 namespace Xtensive.Tuples.Packed
 {
@@ -144,15 +145,8 @@ namespace Xtensive.Tuples.Packed
   {
     public Type FieldType { get; protected set; }
 
-    private static int GetRank(int bitSize)
-    {
-      var rank = 0;
-      while ((bitSize >>= 1) > 0) {
-        rank++;
-      }
-
-      return rank;
-    }
+    private static int GetRank(int bitSize) =>
+      BitOperations.Log2((uint)bitSize);
 
     protected ValueFieldAccessor(int bitCount, byte index)
       : base(GetRank(bitCount), index)

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptor.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2003-2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.12.29
 
@@ -15,10 +15,12 @@ namespace Xtensive.Tuples.Packed
     private const int OffsetMask = (1 << OffsetBitCount) - 1;
 
     internal int DataPosition;
-    internal int StatePosition;
+    internal ushort StatePosition;
 
     [NonSerialized]
-    public PackedFieldAccessor Accessor;
+    internal byte AccessorIndex;
+
+    public PackedFieldAccessor Accessor => PackedFieldAccessor.All[AccessorIndex];
 
     public bool IsObjectField => Accessor.Rank < 0;
 

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -88,7 +88,7 @@ namespace Xtensive.Tuples.Packed
         throw new ArgumentOutOfRangeException(nameof(fieldState));
       }
 
-      SetFieldState(ref PackedDescriptor.FieldDescriptors[fieldIndex], fieldState);
+      SetFieldState(PackedDescriptor.FieldDescriptors[fieldIndex], fieldState);
     }
 
     public override object GetValue(int fieldIndex, out TupleFieldState fieldState)
@@ -100,10 +100,10 @@ namespace Xtensive.Tuples.Packed
     public override void SetValue(int fieldIndex, object fieldValue)
     {
       ref var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
-      descriptor.Accessor.SetUntypedValue(this, ref descriptor, fieldValue);
+      descriptor.Accessor.SetUntypedValue(this, descriptor, fieldValue);
     }
 
-    public void SetFieldState(ref PackedFieldDescriptor d, TupleFieldState fieldState)
+    public void SetFieldState(in PackedFieldDescriptor d, TupleFieldState fieldState)
     {
       var bits = (long) fieldState;
       ref var block = ref Values[d.StateIndex];

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.12.29
 
@@ -68,10 +68,9 @@ namespace Xtensive.Tuples.Packed
       int result = 0;
       for (int i = 0; i < count; i++) {
         ref var descriptor = ref fieldDescriptors[i];
-        var accessor = descriptor.Accessor;
-        var state = GetFieldState(ref fieldDescriptors[i]);
-        var fieldHash = state==TupleFieldState.Available
-          ? accessor.GetValueHashCode(this, ref descriptor)
+        var state = GetFieldState(ref descriptor);
+        var fieldHash = state == TupleFieldState.Available
+          ? descriptor.Accessor.GetValueHashCode(this, ref descriptor)
           : 0;
         result = HashCodeMultiplier * result ^ fieldHash;
       }

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2003-2012 Xtensive LLC.
+// Copyright (C) 2003-2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -107,8 +107,8 @@ namespace Xtensive.Tuples.Packed
     public void SetFieldState(ref PackedFieldDescriptor d, TupleFieldState fieldState)
     {
       var bits = (long) fieldState;
-      var block = Values[d.StateIndex];
-      Values[d.StateIndex] = (block & ~(3L << d.StateBitOffset)) | (bits << d.StateBitOffset);
+      ref var block = ref Values[d.StateIndex];
+      block = (block & ~(3L << d.StateBitOffset)) | (bits << d.StateBitOffset);
 
       if (fieldState!=TupleFieldState.Available && d.IsObjectField) {
         Objects[d.ObjectIndex] = null;

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -47,14 +47,14 @@ namespace Xtensive.Tuples.Packed
       var count = Count;
       for (int i = 0; i < count; i++) {
         ref var descriptor = ref fieldDescriptors[i];
-        var thisState = GetFieldState(ref descriptor);
-        var otherState = packedOther.GetFieldState(ref descriptor);
+        var thisState = GetFieldState(descriptor);
+        var otherState = packedOther.GetFieldState(descriptor);
         if (thisState!=otherState)
           return false;
         if (thisState!=TupleFieldState.Available)
           continue;
         var accessor = descriptor.Accessor;
-        if (!accessor.ValueEquals(this, ref descriptor, packedOther, ref descriptor))
+        if (!accessor.ValueEquals(this, descriptor, packedOther, descriptor))
           return false;
       }
 
@@ -68,9 +68,9 @@ namespace Xtensive.Tuples.Packed
       int result = 0;
       for (int i = 0; i < count; i++) {
         ref var descriptor = ref fieldDescriptors[i];
-        var state = GetFieldState(ref descriptor);
+        var state = GetFieldState(descriptor);
         var fieldHash = state == TupleFieldState.Available
-          ? descriptor.Accessor.GetValueHashCode(this, ref descriptor)
+          ? descriptor.Accessor.GetValueHashCode(this, descriptor)
           : 0;
         result = HashCodeMultiplier * result ^ fieldHash;
       }
@@ -79,7 +79,7 @@ namespace Xtensive.Tuples.Packed
 
     public override TupleFieldState GetFieldState(int fieldIndex)
     {
-      return GetFieldState(ref PackedDescriptor.FieldDescriptors[fieldIndex]);
+      return GetFieldState(PackedDescriptor.FieldDescriptors[fieldIndex]);
     }
 
     protected internal override void SetFieldState(int fieldIndex, TupleFieldState fieldState)
@@ -94,7 +94,7 @@ namespace Xtensive.Tuples.Packed
     public override object GetValue(int fieldIndex, out TupleFieldState fieldState)
     {
       ref var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
-      return descriptor.Accessor.GetUntypedValue(this, ref descriptor, out fieldState);
+      return descriptor.Accessor.GetUntypedValue(this, descriptor, out fieldState);
     }
 
     public override void SetValue(int fieldIndex, object fieldValue)
@@ -114,7 +114,7 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public TupleFieldState GetFieldState(ref PackedFieldDescriptor d)
+    public TupleFieldState GetFieldState(in PackedFieldDescriptor d)
     {
       var block = Values[d.StateIndex];
       return (TupleFieldState) ((block >> d.StateBitOffset) & 3);

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2021 Xtensive LLC.
+// Copyright (C) 2012-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -114,17 +114,17 @@ namespace Xtensive.Tuples.Packed
       descriptor.AccessorIndex = ((PackedFieldAccessor)ValueFieldAccessorResolver.GetValue(fieldType) ?? ObjectAccessor).Index;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ConfigureLen1(Type[] fieldTypes, ref PackedFieldDescriptor descriptor, out int valuesLength,
+    public static void ConfigureLen1(ref Type fieldType, ref PackedFieldDescriptor descriptor, out int valuesLength,
       out int objectsLength)
     {
-      var valueAccessor = ValueFieldAccessorResolver.GetValue(fieldTypes[0]);
+      var valueAccessor = ValueFieldAccessorResolver.GetValue(fieldType);
       if (valueAccessor != null) {
         descriptor.AccessorIndex = valueAccessor.Index;
         descriptor.DataPosition = Val064BitCount;
 
         valuesLength = (valueAccessor.ValueBitCount  + ((Val064BitCount * 2) - 1)) >> Val064Rank;
         objectsLength = 0;
-        fieldTypes[0] = valueAccessor.FieldType;
+        fieldType = valueAccessor.FieldType;
         return;
       }
 

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -236,13 +236,14 @@ namespace Xtensive.Tuples.Packed
     {
       descriptor.StatePosition = checked((ushort)(fieldIndex << 1));
 
-      var valueAccessor = ValueFieldAccessorResolver.GetValue(fieldTypes[fieldIndex]);
+      ref var fieldType = ref fieldTypes[fieldIndex];
+      var valueAccessor = ValueFieldAccessorResolver.GetValue(fieldType);
       if (valueAccessor != null) {
         descriptor.AccessorIndex = valueAccessor.Index;
 
         IncrementerByRank[valueAccessor.Rank].Invoke(ref counters);
 
-        fieldTypes[fieldIndex] = valueAccessor.FieldType;
+        fieldType = valueAccessor.FieldType;
         return;
       }
 

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -111,7 +111,7 @@ namespace Xtensive.Tuples.Packed
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ConfigureFieldAccessor(ref PackedFieldDescriptor descriptor, Type fieldType) =>
-      descriptor.Accessor = (PackedFieldAccessor) ValueFieldAccessorResolver.GetValue(fieldType) ?? ObjectAccessor;
+      descriptor.AccessorIndex = ((PackedFieldAccessor)ValueFieldAccessorResolver.GetValue(fieldType) ?? ObjectAccessor).Index;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ConfigureLen1(Type[] fieldTypes, ref PackedFieldDescriptor descriptor, out int valuesLength,
@@ -119,7 +119,7 @@ namespace Xtensive.Tuples.Packed
     {
       var valueAccessor = ValueFieldAccessorResolver.GetValue(fieldTypes[0]);
       if (valueAccessor != null) {
-        descriptor.Accessor = valueAccessor;
+        descriptor.AccessorIndex = valueAccessor.Index;
         descriptor.DataPosition = Val064BitCount;
 
         valuesLength = (valueAccessor.ValueBitCount  + ((Val064BitCount * 2) - 1)) >> Val064Rank;
@@ -128,7 +128,7 @@ namespace Xtensive.Tuples.Packed
         return;
       }
 
-      descriptor.Accessor = ObjectAccessor;
+      descriptor.AccessorIndex = ObjectAccessor.Index;
       valuesLength = 1;
       objectsLength = 1;
     }
@@ -234,11 +234,11 @@ namespace Xtensive.Tuples.Packed
     private static void ConfigureFieldPhase1(ref PackedFieldDescriptor descriptor, ref Counters counters,
       Type[] fieldTypes, int fieldIndex)
     {
-      descriptor.StatePosition = fieldIndex << 1;
+      descriptor.StatePosition = checked((ushort)(fieldIndex << 1));
 
       var valueAccessor = ValueFieldAccessorResolver.GetValue(fieldTypes[fieldIndex]);
       if (valueAccessor != null) {
-        descriptor.Accessor = valueAccessor;
+        descriptor.AccessorIndex = valueAccessor.Index;
 
         IncrementerByRank[valueAccessor.Rank].Invoke(ref counters);
 
@@ -246,7 +246,7 @@ namespace Xtensive.Tuples.Packed
         return;
       }
 
-      descriptor.Accessor = ObjectAccessor;
+      descriptor.AccessorIndex = ObjectAccessor.Index;
       descriptor.DataPosition = counters.ObjectCounter++;
     }
 

--- a/Orm/Xtensive.Orm/Tuples/Tuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Tuple.cs
@@ -112,13 +112,13 @@ namespace Xtensive.Tuples
 
       if (this is PackedTuple packedTuple) {
         ref var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
-        return descriptor.Accessor.GetValue<T>(packedTuple, ref descriptor, isNullable, out fieldState);
+        return descriptor.Accessor.GetValue<T>(packedTuple, descriptor, isNullable, out fieldState);
       }
 
       var mappedContainer = GetMappedContainer(fieldIndex, false);
       if (mappedContainer.First is PackedTuple mappedTuple) {
         ref var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
-        return descriptor.Accessor.GetValue<T>(mappedTuple, ref descriptor, isNullable, out fieldState);
+        return descriptor.Accessor.GetValue<T>(mappedTuple, descriptor, isNullable, out fieldState);
       }
 
       var value = GetValue(fieldIndex, out fieldState);

--- a/Orm/Xtensive.Orm/Tuples/Tuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Tuple.cs
@@ -187,14 +187,14 @@ namespace Xtensive.Tuples
 
       if (this is PackedTuple packedTuple) {
         ref var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
-        descriptor.Accessor.SetValue(packedTuple, ref descriptor, isNullable, fieldValue);
+        descriptor.Accessor.SetValue(packedTuple, descriptor, isNullable, fieldValue);
         return;
       }
 
       var mappedContainer = GetMappedContainer(fieldIndex, true);
       if (mappedContainer.First is PackedTuple mappedTuple) {
         ref var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
-        descriptor.Accessor.SetValue(mappedTuple, ref descriptor, isNullable, fieldValue);
+        descriptor.Accessor.SetValue(mappedTuple, descriptor, isNullable, fieldValue);
         return;
       }
 

--- a/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
@@ -276,7 +276,7 @@ namespace Xtensive.Tuples
         case 0:
           return;
         case 1:
-          TupleLayout.ConfigureLen1(FieldTypes,
+          TupleLayout.ConfigureLen1(ref FieldTypes[0],
             ref FieldDescriptors[0],
             out ValuesLength, out ObjectsLength);
           break;

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -35,13 +35,12 @@ namespace Xtensive.Tuples
     /// <param name="length">The number of elements to copy.</param>
     public static void CopyTo(this Tuple source, Tuple target, int startIndex, int targetStartIndex, int length)
     {
-      var packedSource = source as PackedTuple;
-      var packedTarget = target as PackedTuple;
-
-      if (packedSource!=null && packedTarget!=null)
+      if (source is PackedTuple packedSource && target is PackedTuple packedTarget) {
         PartiallyCopyTupleFast(packedSource, packedTarget, startIndex, targetStartIndex, length);
-      else
+      }
+      else {
         PartiallyCopyTupleSlow(source, target, startIndex, targetStartIndex, length);
+      }
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -438,7 +438,7 @@ namespace Xtensive.Tuples
       ref var sourceDescriptor = ref source.PackedDescriptor.FieldDescriptors[sourceIndex];
       ref var targetDescriptor = ref target.PackedDescriptor.FieldDescriptors[targetIndex];
 
-      var fieldState = source.GetFieldState(ref sourceDescriptor);
+      var fieldState = source.GetFieldState(sourceDescriptor);
       if (!fieldState.IsAvailable()) {
         return;
       }

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -457,7 +457,7 @@ namespace Xtensive.Tuples
       }
 
       target.SetFieldState(targetIndex, TupleFieldState.Available);
-      accessor.CopyValue(source, ref sourceDescriptor, target, ref targetDescriptor);
+      accessor.CopyValue(source, sourceDescriptor, target, targetDescriptor);
     }
 
     private static void PartiallyCopyTupleSlow(Tuple source, Tuple target, int sourceStartIndex, int targetStartIndex, int length)

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -483,7 +483,7 @@ namespace Xtensive.Tuples
 
     private static void CopyTupleWithMappingFast(PackedTuple source, PackedTuple target, IReadOnlyList<int> map)
     {
-      for (int targetIndex = 0; targetIndex < map.Count; targetIndex++) {
+      for (int targetIndex = 0, count = map.Count; targetIndex < count; targetIndex++) {
         var sourceIndex = map[targetIndex];
         if (sourceIndex >= 0)
           CopyPackedValue(source, sourceIndex, target, targetIndex);
@@ -503,7 +503,7 @@ namespace Xtensive.Tuples
 
     private static void CopyTupleArrayWithMappingFast(PackedTuple[] sources, PackedTuple target, Pair<int, int>[] map)
     {
-      for (int targetIndex = 0; targetIndex < map.Length; targetIndex++) {
+      for (int targetIndex = 0, length = map.Length; targetIndex < length; targetIndex++) {
         var sourceInfo = map[targetIndex];
         var sourceTupleIndex = sourceInfo.First;
         var sourceFieldIndex = sourceInfo.Second;
@@ -525,7 +525,7 @@ namespace Xtensive.Tuples
 
     private static void Copy3TuplesWithMappingFast(FixedList3<PackedTuple> sources, PackedTuple target, Pair<int, int>[] map)
     {
-      for (int targetIndex = 0; targetIndex < map.Length; targetIndex++) {
+      for (int targetIndex = 0, length = map.Length; targetIndex < length; targetIndex++) {
         var sourceInfo = map[targetIndex];
         var sourceTupleIndex = sourceInfo.First;
         var sourceFieldIndex = sourceInfo.Second;

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
@@ -474,7 +474,7 @@ namespace Xtensive.Tuples
 
     private static void CopyTupleWithMappingSlow(Tuple source, Tuple target, IReadOnlyList<int> map)
     {
-      for (int targetIndex = 0; targetIndex < map.Count; targetIndex++) {
+      for (int targetIndex = 0, count = map.Count; targetIndex < count; targetIndex++) {
         var sourceIndex = map[targetIndex];
         if (sourceIndex >= 0)
           CopyValue(source, sourceIndex, target, targetIndex);
@@ -492,7 +492,7 @@ namespace Xtensive.Tuples
 
     private static void CopyTupleArrayWithMappingSlow(Tuple[] sources, Tuple target, Pair<int, int>[] map)
     {
-      for (int targetIndex = 0; targetIndex < map.Length; targetIndex++) {
+      for (int targetIndex = 0, length = map.Length; targetIndex < length; targetIndex++) {
         var sourceInfo = map[targetIndex];
         var sourceTupleIndex = sourceInfo.First;
         var sourceFieldIndex = sourceInfo.Second;
@@ -514,7 +514,7 @@ namespace Xtensive.Tuples
 
     private static void Copy3TuplesWithMappingSlow(FixedList3<Tuple> sources, Tuple target, Pair<int, int>[] map)
     {
-      for (int targetIndex = 0; targetIndex < map.Length; targetIndex++) {
+      for (int targetIndex = 0, length = map.Length; targetIndex < length; targetIndex++) {
         var sourceInfo = map[targetIndex];
         var sourceTupleIndex = sourceInfo.First;
         var sourceFieldIndex = sourceInfo.Second;


### PR DESCRIPTION
Profiling shows huge consumption of memory by `PackedFieldDescriptor` arrays
![image](https://user-images.githubusercontent.com/1176609/158492388-f857046d-5cc6-4be3-a373-b3a21c13be52.png)

We can reduce `PackedFieldDescriptor.StatePosition` field to 16-bit ushort data type because all supported Databases allow max 4096 columns in SQL query (see https://docs.microsoft.com/en-us/sql/sql-server/maximum-capacity-specifications-for-sql-server?redirectedfrom=MSDN&view=sql-server-ver15).
Also we are replacing `Accessor` pointer to byte-size index of accessor in global accessor array.

Note that ushort is not enough for: `DataPosition`.
For example, assuming we have table of `decimal` or `GUID` fields. Every field takes 128 bits. So `ushort` allows max 512 fields.

Taking into account alignment rules we are reducing  `sizeof(PackedFieldDescriptor)`  from 16 bytes to 8

Also other optimizations:
* avoid double calculation .ValueIndex/.ValueBitOffset properties
* avoid double array-indexing by using `ref var`
* refactor to use `BitOperations.Log2()`
* use `in` argument modifier instead of `ref` where possible