### PR TITLE
Optimization: Avoid copying PackedFieldDescriptor struct

### DIFF
--- a/Orm/Xtensive.Orm/Tuples/AccessorDelegates.cs
+++ b/Orm/Xtensive.Orm/Tuples/AccessorDelegates.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.09.17
 

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptiorExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptiorExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+namespace Xtensive.Tuples.Packed
+{
+  internal static class PackedFieldDescriptorExtensions
+  {
+    private const int OffsetBitCount = 6;
+    private const int OffsetMask = (1 << OffsetBitCount) - 1;
+
+    public static PackedFieldAccessor GetAccessor(in this PackedFieldDescriptor descriptor) => PackedFieldAccessor.All[descriptor.AccessorIndex];
+    public static bool IsObjectField(in this PackedFieldDescriptor descriptor) => descriptor.GetAccessor().Rank < 0;
+    public static int GetObjectIndex(in this PackedFieldDescriptor descriptor) => descriptor.DataPosition;
+    public static int GetValueIndex(in this PackedFieldDescriptor descriptor) => descriptor.DataPosition >> OffsetBitCount;
+    public static int GetValueBitOffset(in this PackedFieldDescriptor descriptor) => descriptor.DataPosition & OffsetMask;
+    public static int GetStateIndex(in this PackedFieldDescriptor descriptor) => descriptor.StatePosition >> OffsetBitCount;
+    public static int GetStateBitOffset(in this PackedFieldDescriptor descriptor) => descriptor.StatePosition & OffsetMask;
+  }
+}

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptor.cs
@@ -11,25 +11,10 @@ namespace Xtensive.Tuples.Packed
   [Serializable]
   internal struct PackedFieldDescriptor
   {
-    private const int OffsetBitCount = 6;
-    private const int OffsetMask = (1 << OffsetBitCount) - 1;
-
     internal int DataPosition;
     internal ushort StatePosition;
 
     [NonSerialized]
     internal byte AccessorIndex;
-
-    public PackedFieldAccessor Accessor => PackedFieldAccessor.All[AccessorIndex];
-
-    public bool IsObjectField => Accessor.Rank < 0;
-
-    public int ObjectIndex => DataPosition;
-
-    public int ValueIndex => DataPosition >> OffsetBitCount;
-    public int ValueBitOffset => DataPosition & OffsetMask;
-
-    public int StateIndex => StatePosition >> OffsetBitCount;
-    public int StateBitOffset => StatePosition & OffsetMask;
   }
 }

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -146,21 +146,21 @@ namespace Xtensive.Tuples.Packed
           valuesLength = 1;
           return;
         case 1: {
-          if (descriptor1.IsObjectField) {
+          if (descriptor1.IsObjectField()) {
             descriptor2.DataPosition = Val064BitCount;
-            val1BitCount = descriptor2.Accessor.ValueBitCount;
+            val1BitCount = descriptor2.GetAccessor().ValueBitCount;
           }
           else {
             descriptor1.DataPosition = Val064BitCount;
-            val1BitCount = descriptor1.Accessor.ValueBitCount;
+            val1BitCount = descriptor1.GetAccessor().ValueBitCount;
           }
           valuesLength = (val1BitCount  + ((Val064BitCount * 2) - 1)) >> Val064Rank;
           return;
         }
       }
       // Both descriptors are value descriptors
-      val1BitCount = descriptor1.Accessor.ValueBitCount;
-      val2BitCount = descriptor2.Accessor.ValueBitCount;
+      val1BitCount = descriptor1.GetAccessor().ValueBitCount;
+      val2BitCount = descriptor2.GetAccessor().ValueBitCount;
       if (val2BitCount > val1BitCount) {
         descriptor2.DataPosition = Val064BitCount;
         descriptor1.DataPosition = Val064BitCount + val2BitCount;
@@ -212,11 +212,11 @@ namespace Xtensive.Tuples.Packed
 
       for (var fieldIndex = 0; fieldIndex < fieldCount; fieldIndex++) {
         ref var descriptor = ref fieldDescriptors[fieldIndex];
-        if (descriptor.IsObjectField) {
+        if (descriptor.IsObjectField()) {
           continue;
         }
 
-        PositionUpdaterByRank[descriptor.Accessor.Rank].Invoke(ref descriptor, ref counters);
+        PositionUpdaterByRank[descriptor.GetAccessor().Rank].Invoke(ref descriptor, ref counters);
       }
 
       valuesLength = (totalBitCount + (Val064BitCount - 1)) >> Val064Rank;
@@ -227,7 +227,7 @@ namespace Xtensive.Tuples.Packed
     private static void UpdateDescriptorPosition(ref PackedFieldDescriptor descriptor, ref int bitCounter)
     {
       descriptor.DataPosition = bitCounter;
-      bitCounter += descriptor.Accessor.ValueBitCount;
+      bitCounter += descriptor.GetAccessor().ValueBitCount;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Orm/Xtensive.Orm/Tuples/Tuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Tuple.cs
@@ -111,13 +111,13 @@ namespace Xtensive.Tuples
       var isNullable = null==default(T); // Is nullable value type or class
 
       if (this is PackedTuple packedTuple) {
-        ref var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
+        ref readonly var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
         return descriptor.Accessor.GetValue<T>(packedTuple, descriptor, isNullable, out fieldState);
       }
 
       var mappedContainer = GetMappedContainer(fieldIndex, false);
       if (mappedContainer.First is PackedTuple mappedTuple) {
-        ref var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
+        ref readonly var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
         return descriptor.Accessor.GetValue<T>(mappedTuple, descriptor, isNullable, out fieldState);
       }
 
@@ -186,14 +186,14 @@ namespace Xtensive.Tuples
       var isNullable = null==default(T); // Is nullable value type or class
 
       if (this is PackedTuple packedTuple) {
-        ref var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
+        ref readonly var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
         descriptor.Accessor.SetValue(packedTuple, descriptor, isNullable, fieldValue);
         return;
       }
 
       var mappedContainer = GetMappedContainer(fieldIndex, true);
       if (mappedContainer.First is PackedTuple mappedTuple) {
-        ref var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
+        ref readonly var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
         descriptor.Accessor.SetValue(mappedTuple, descriptor, isNullable, fieldValue);
         return;
       }

--- a/Orm/Xtensive.Orm/Tuples/Tuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Tuple.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2020 Xtensive LLC.
+// Copyright (C) 2007-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
@@ -112,17 +112,17 @@ namespace Xtensive.Tuples
 
       if (this is PackedTuple packedTuple) {
         ref readonly var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
-        return descriptor.Accessor.GetValue<T>(packedTuple, descriptor, isNullable, out fieldState);
+        return descriptor.GetAccessor().GetValue<T>(packedTuple, descriptor, isNullable, out fieldState);
       }
 
       var mappedContainer = GetMappedContainer(fieldIndex, false);
       if (mappedContainer.First is PackedTuple mappedTuple) {
         ref readonly var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
-        return descriptor.Accessor.GetValue<T>(mappedTuple, descriptor, isNullable, out fieldState);
+        return descriptor.GetAccessor().GetValue<T>(mappedTuple, descriptor, isNullable, out fieldState);
       }
 
       var value = GetValue(fieldIndex, out fieldState);
-      return value!=null ? (T) value : default(T);
+      return value != null ? (T) value : default(T);
     }
 
     /// <summary>
@@ -187,14 +187,14 @@ namespace Xtensive.Tuples
 
       if (this is PackedTuple packedTuple) {
         ref readonly var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
-        descriptor.Accessor.SetValue(packedTuple, descriptor, isNullable, fieldValue);
+        descriptor.GetAccessor().SetValue(packedTuple, descriptor, isNullable, fieldValue);
         return;
       }
 
       var mappedContainer = GetMappedContainer(fieldIndex, true);
       if (mappedContainer.First is PackedTuple mappedTuple) {
         ref readonly var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
-        descriptor.Accessor.SetValue(mappedTuple, descriptor, isNullable, fieldValue);
+        descriptor.GetAccessor().SetValue(mappedTuple, descriptor, isNullable, fieldValue);
         return;
       }
 

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -23,10 +23,10 @@ namespace Xtensive.Tuples
     #region Copy methods
 
     /// <summary>
-    /// Copies a range of elements from <paramref name="source"/> <see cref="Tuple"/> 
-    /// starting at the specified source index 
-    /// and pastes them to <paramref name="target"/> <see cref="Tuple"/> 
-    /// starting at the specified target index. 
+    /// Copies a range of elements from <paramref name="source"/> <see cref="Tuple"/>
+    /// starting at the specified source index
+    /// and pastes them to <paramref name="target"/> <see cref="Tuple"/>
+    /// starting at the specified target index.
     /// </summary>
     /// <param name="source">Source tuple to copy.</param>
     /// <param name="target">Tuple that receives the data.</param>
@@ -44,10 +44,10 @@ namespace Xtensive.Tuples
     }
 
     /// <summary>
-    /// Copies a range of elements from <paramref name="source"/> <see cref="Tuple"/> 
-    /// starting at the specified source index 
-    /// and pastes them to <paramref name="target"/> <see cref="Tuple"/> 
-    /// starting at the first element. 
+    /// Copies a range of elements from <paramref name="source"/> <see cref="Tuple"/>
+    /// starting at the specified source index
+    /// and pastes them to <paramref name="target"/> <see cref="Tuple"/>
+    /// starting at the first element.
     /// </summary>
     /// <param name="source">Source tuple to copy.</param>
     /// <param name="target">Tuple that receives the data.</param>
@@ -59,10 +59,10 @@ namespace Xtensive.Tuples
     }
 
     /// <summary>
-    /// Copies a range of elements from <paramref name="source"/> <see cref="Tuple"/> 
+    /// Copies a range of elements from <paramref name="source"/> <see cref="Tuple"/>
     /// starting at the <paramref name="startIndex"/>
-    /// and pastes them into <paramref name="target"/> <see cref="Tuple"/> 
-    /// starting at the first element. 
+    /// and pastes them into <paramref name="target"/> <see cref="Tuple"/>
+    /// starting at the first element.
     /// </summary>
     /// <param name="source">Source tuple to copy.</param>
     /// <param name="target">Tuple that receives the data.</param>
@@ -73,9 +73,9 @@ namespace Xtensive.Tuples
     }
 
     /// <summary>
-    /// Copies all the elements from <paramref name="source"/> <see cref="Tuple"/> 
+    /// Copies all the elements from <paramref name="source"/> <see cref="Tuple"/>
     /// starting at the first element
-    /// and pastes them into <paramref name="target"/> <see cref="Tuple"/> 
+    /// and pastes them into <paramref name="target"/> <see cref="Tuple"/>
     /// starting at the first element.
     /// </summary>
     /// <param name="source">Source tuple to copy.</param>
@@ -86,8 +86,8 @@ namespace Xtensive.Tuples
     }
 
     /// <summary>
-    /// Copies a set of elements from <paramref name="source"/> <see cref="Tuple"/> 
-    /// to <paramref name="target"/> <see cref="Tuple"/> using 
+    /// Copies a set of elements from <paramref name="source"/> <see cref="Tuple"/>
+    /// to <paramref name="target"/> <see cref="Tuple"/> using
     /// specified target-to-source field index <paramref name="map"/>.
     /// </summary>
     /// <param name="source">Source tuple to copy.</param>
@@ -106,7 +106,7 @@ namespace Xtensive.Tuples
 
     /// <summary>
     /// Copies a set of elements from <paramref name="sources"/> <see cref="Tuple"/>s
-    /// to <paramref name="target"/> <see cref="Tuple"/> using 
+    /// to <paramref name="target"/> <see cref="Tuple"/> using
     /// specified target-to-source field index <paramref name="map"/>.
     /// </summary>
     /// <param name="sources">Source tuples to copy.</param>
@@ -138,7 +138,7 @@ namespace Xtensive.Tuples
 
     /// <summary>
     /// Copies a set of elements from <paramref name="sources"/> <see cref="Tuple"/>s
-    /// to <paramref name="target"/> <see cref="Tuple"/> using 
+    /// to <paramref name="target"/> <see cref="Tuple"/> using
     /// specified target-to-source field index <paramref name="map"/>.
     /// </summary>
     /// <param name="sources">Source tuples to copy.</param>
@@ -219,7 +219,7 @@ namespace Xtensive.Tuples
     /// <param name="difference">Tuple with differences to merge with.</param>
     /// <param name="startIndex">The index in the <paramref name="difference"/> tuple at which merging begins.</param>
     /// <param name="length">The number of elements to process.</param>
-    /// <param name="behavior">The merge behavior that will be used to resolve conflicts when both values 
+    /// <param name="behavior">The merge behavior that will be used to resolve conflicts when both values
     /// from <paramref name="difference"/> and <paramref name="origin"/> are available.</param>
     /// <exception cref="ArgumentException">Tuple descriptors mismatch.</exception>
     public static void MergeWith(this Tuple origin, Tuple difference, int startIndex, int length, MergeBehavior behavior)
@@ -274,7 +274,7 @@ namespace Xtensive.Tuples
     /// <param name="origin">Tuple containing original values and receiving the data.</param>
     /// <param name="difference">Tuple with differences to merge with.</param>
     /// <param name="startIndex">The index in the <paramref name="difference"/> tuple at which merging begins.</param>
-    /// <param name="behavior">The merge behavior that will be used to resolve conflicts when both values 
+    /// <param name="behavior">The merge behavior that will be used to resolve conflicts when both values
     /// from <paramref name="difference"/> and <paramref name="origin"/> are available.</param>
     public static void MergeWith(this Tuple origin, Tuple difference, int startIndex, MergeBehavior behavior)
     {
@@ -301,7 +301,7 @@ namespace Xtensive.Tuples
     /// </summary>
     /// <param name="origin">Tuple containing original values and receiving the data.</param>
     /// <param name="difference">Tuple with differences to merge with.</param>
-    /// <param name="behavior">The merge behavior that will be used to resolve conflicts when both values 
+    /// <param name="behavior">The merge behavior that will be used to resolve conflicts when both values
     /// from <paramref name="difference"/> and <paramref name="origin"/> are available.</param>
     public static void MergeWith(this Tuple origin, Tuple difference, MergeBehavior behavior)
     {
@@ -444,8 +444,8 @@ namespace Xtensive.Tuples
         return;
       }
 
-      var accessor = sourceDescriptor.Accessor;
-      if (accessor != targetDescriptor.Accessor) {
+      var accessor = sourceDescriptor.GetAccessor();
+      if (accessor != targetDescriptor.GetAccessor()) {
         throw new InvalidOperationException(string.Format(
           Strings.ExInvalidCast,
           source.PackedDescriptor[sourceIndex],

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -444,8 +444,7 @@ namespace Xtensive.Tuples
         return;
       }
 
-      var accessor = sourceDescriptor.GetAccessor();
-      if (accessor != targetDescriptor.GetAccessor()) {
+      if (sourceDescriptor.AccessorIndex != targetDescriptor.AccessorIndex) {
         throw new InvalidOperationException(string.Format(
           Strings.ExInvalidCast,
           source.PackedDescriptor[sourceIndex],
@@ -453,7 +452,7 @@ namespace Xtensive.Tuples
       }
 
       target.SetFieldState(targetIndex, TupleFieldState.Available);
-      accessor.CopyValue(source, sourceDescriptor, target, targetDescriptor);
+      sourceDescriptor.GetAccessor().CopyValue(source, sourceDescriptor, target, targetDescriptor);
     }
 
     private static void PartiallyCopyTupleSlow(Tuple source, Tuple target, int sourceStartIndex, int targetStartIndex, int length)


### PR DESCRIPTION
* use `ref readonly var`
* Replace properties by extension methods

This PR is based on https://github.com/DataObjects-NET/dataobjects-net/commit/40b5c3f231e8571b0a5e829e62ef3333013d0f7a