### PR TITLE
Consider DO_TargetFrameworks env var to multitargeting build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,7 +40,8 @@
   <PropertyGroup>
     <NoLogo>true</NoLogo>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DO_TargetFrameworks)' != ''">$(DO_TargetFrameworks)</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <SolutionDir Condition="$(SolutionDir) == ''">$([MSBuild]::EnsureTrailingSlash(
       $([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildThisFileDirectory)', 'Orm.sln'))))</SolutionDir>
@@ -48,7 +49,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <ArtifactsDir Condition="'$(ArtifactsDir)'==''">$(SolutionDir)_Build\</ArtifactsDir>
     <BaseIntermediateOutputPath>$(ArtifactsDir)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
     <BaseOutputPath>$(ArtifactsDir)bin\$(Configuration)\</BaseOutputPath>
     <BaseOutputPath Condition="$(MSBuildProjectName.Contains('Tests'))
       OR $(MSBuildProjectName) == 'TestCommon'
@@ -56,7 +57,7 @@
     <OutputPath>$(BaseOutputPath)lib\</OutputPath>
     <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
     <ProjectAssetsFile>$(MSBuildProjectExtensionsPath)project.assets.json</ProjectAssetsFile>
-    <ProjectAssetsCacheFile>$(MSBuildProjectExtensionsPath)$(MSBuildProjectName).assets.cache</ProjectAssetsCacheFile>
+    <ProjectAssetsCacheFile>$(MSBuildProjectExtensionsPath)$(TargetFramework)\$(MSBuildProjectName).assets.cache</ProjectAssetsCacheFile>
     <OrmKeyFile>$(SolutionDir)Orm\Orm.snk</OrmKeyFile>
   </PropertyGroup>
 

--- a/MSBuild/DataObjects.Net.targets
+++ b/MSBuild/DataObjects.Net.targets
@@ -12,7 +12,7 @@
   <CompileDependsOn>$(CompileDependsOn);XtensiveOrmBuild</CompileDependsOn>
   <XtensiveOrmPath Condition="'$(XtensiveOrmPath)'==''">$(MSBuildThisFileDirectory)</XtensiveOrmPath>
   <XtensiveOrmPath Condition="!HasTrailingSlash('$(XtensiveOrmPath)')">$(XtensiveOrmPath)\</XtensiveOrmPath>
-  <XtensiveOrmWeaver Condition="'$(XtensiveOrmWeaver)'==''">$(XtensiveOrmPath)tools\weaver\Xtensive.Orm.Weaver.dll</XtensiveOrmWeaver>
+  <XtensiveOrmWeaver Condition="'$(XtensiveOrmWeaver)'==''">$(XtensiveOrmPath)tools\weaver\$(TargetFramework)\Xtensive.Orm.Weaver.dll</XtensiveOrmWeaver>
   <XtensiveOrmBuildDependsOn>$(XtensiveOrmBuildDependsOn)</XtensiveOrmBuildDependsOn>
 </PropertyGroup>
 

--- a/Weaver/Xtensive.Orm.Weaver/Xtensive.Orm.Weaver.csproj
+++ b/Weaver/Xtensive.Orm.Weaver/Xtensive.Orm.Weaver.csproj
@@ -5,7 +5,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(OrmKeyFile)</AssemblyOriginatorKeyFile>
-    <OutputPath>$(BaseOutputPath)tools\weaver\</OutputPath>
+    <OutputPath>$(BaseOutputPath)tools\weaver\$(TargetFramework)\</OutputPath>
     <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
For effective usage of .NET6 optimization features (e.g. string interpolation) we need do build DO package .NET6.

With `DO_TargetFrameworks` environment variable we get possibility to tune build as we want:
* By default the solution builds for `net5.0` only as before

* To build for both .NET5 & .NET6 define `DO_TargetFrameworks`
```
SET  DO_TargetFrameworks=net5.0;net6.0
dotnet build   
```

* for development purposes it is recommended to define only single TargetFramework to minimize build time. And define both only for package deployment


