### PR TITLE
Fix ambiguity in initializin WellKnownMembers.Queryable members because of new IQueryable extension overloads in .NET6

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/WellknownMembers.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellknownMembers.Queryable.cs
@@ -205,7 +205,7 @@ namespace Xtensive.Orm.Linq
                 case 1:
                   FirstOrDefault = methodInfo;
                   break;
-                case 2:
+                case 2 when parameters[1].ParameterType.IsAssignableTo(WellKnownTypes.Expression):
                   FirstOrDefaultWithPredicate = methodInfo;
                   break;
               }
@@ -264,7 +264,7 @@ namespace Xtensive.Orm.Linq
                 case 1:
                   LastOrDefault = methodInfo;
                   break;
-                case 2:
+                case 2 when parameters[1].ParameterType.IsAssignableTo(WellKnownTypes.Expression):
                   LastOrDefaultWithPredicate = methodInfo;
                   break;
               }
@@ -362,7 +362,7 @@ namespace Xtensive.Orm.Linq
                 case 1:
                   SingleOrDefault = methodInfo;
                   break;
-                case 2:
+                case 2 when parameters[1].ParameterType.IsAssignableTo(WellKnownTypes.Expression):
                   SingleOrDefaultWithPredicate = methodInfo;
                   break;
               }


### PR DESCRIPTION
We are getting errors like:
```
Expression of type 'System.Func`2[ServiceTitan.MasterModel.SupervisorUser,System.Boolean]' cannot be used for parameter of type 'ServiceTitan.MasterModel.SupervisorUser' of method 'ServiceTitan.MasterModel.SupervisorUser SingleOrDefault[SupervisorUser](System.Linq.IQueryable`1[ServiceTitan.MasterModel.SupervisorUser], ServiceTitan.MasterModel.SupervisorUser)' (Parameter 'arg1')
```

because of new .NET6 overload:
```[SingleOrDefault<TSource>(IQueryable<TSource>, TSource)](https://docs.microsoft.com/en-us/dotnet/api/system.linq.queryable.singleordefault?view=net-6.0#system-linq-queryable-singleordefault-1(system-linq-iqueryable((-0))-0))```

Discriminating MethodInfo only by number of arguments is ambiguous and results depend on how `.GetMethods()` orders them.
BTW on Windows & Linux the order is different.

