### PR TITLE
Optimization: avoid Lambda JITing for typical case of invoking Bulk Set() with value

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/BulkExtensions.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/BulkExtensions.cs
@@ -78,11 +78,14 @@ namespace Xtensive.Orm.BulkOperations
     /// <returns>Instance of <see cref=" IUpdatable&lt;T&gt;"/>.</returns>
     [Pure]
     public static IUpdatable<T> Set<T, TResult>(this IQueryable<T> query, Expression<Func<T, TResult>> field,
-        TResult value) where T: IEntity =>
-      Set(query,
-        field,
-        Expression.Lambda<Func<T, TResult>>(Expression.Constant(value, typeof(TResult)), Expression.Parameter(typeof(T), "a"))   // Manually constructed expression is simpler than `a => value`
-      );
+      TResult value) where T: IEntity
+    {
+      // Manually constructed expression is simpler than `a => value`
+      var valueFunc = Expression.Lambda<Func<T, TResult>>(Expression.Constant(value, typeof(TResult)),
+        Expression.Parameter(typeof(T), "a"));
+
+      return Set(query, field, valueFunc);
+    }
 
     /// <summary>
     /// Executes bulk update of entities specified by the query.

--- a/Extensions/Xtensive.Orm.BulkOperations/BulkExtensions.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/BulkExtensions.cs
@@ -78,8 +78,11 @@ namespace Xtensive.Orm.BulkOperations
     /// <returns>Instance of <see cref=" IUpdatable&lt;T&gt;"/>.</returns>
     [Pure]
     public static IUpdatable<T> Set<T, TResult>(this IQueryable<T> query, Expression<Func<T, TResult>> field,
-      TResult value) where T: IEntity =>
-      Set(query, field, a => value);
+        TResult value) where T: IEntity =>
+      Set(query,
+        field,
+        Expression.Lambda<Func<T, TResult>>(Expression.Constant(value), Expression.Parameter(typeof(T), "a"))   // Manually constructed expression is simpler than `a => value`
+      );
 
     /// <summary>
     /// Executes bulk update of entities specified by the query.

--- a/Extensions/Xtensive.Orm.BulkOperations/BulkExtensions.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/BulkExtensions.cs
@@ -81,7 +81,7 @@ namespace Xtensive.Orm.BulkOperations
         TResult value) where T: IEntity =>
       Set(query,
         field,
-        Expression.Lambda<Func<T, TResult>>(Expression.Constant(value), Expression.Parameter(typeof(T), "a"))   // Manually constructed expression is simpler than `a => value`
+        Expression.Lambda<Func<T, TResult>>(Expression.Constant(value, typeof(TResult)), Expression.Parameter(typeof(T), "a"))   // Manually constructed expression is simpler than `a => value`
       );
 
     /// <summary>

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/AddValueContext.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/AddValueContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
+using Xtensive.Linq;
 using Xtensive.Orm.Model;
 using Xtensive.Sql.Dml;
 
@@ -16,5 +17,10 @@ namespace Xtensive.Orm.BulkOperations
     public FieldInfo Field { get; set; }
 
     public bool SubqueryExists { get; set; }
+
+    public object EvalLambdaBody() =>
+      Lambda.Body is ConstantExpression ce
+        ? ce.Value
+        : FastExpression.Lambda(Lambda.Body).Compile().DynamicInvoke();
   }
 }

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
@@ -146,10 +146,7 @@ namespace Xtensive.Orm.BulkOperations
     private void AddConstantValue(AddValueContext addContext)
     {
       SqlTableColumn column = SqlDml.TableColumn(addContext.Statement.Table, addContext.Field.Column.Name);
-      var constant =
-        addContext.Lambda.Body is ConstantExpression ce
-          ? ce.Value
-          : FastExpression.Lambda(addContext.Lambda.Body).Compile().DynamicInvoke();
+      var constant = addContext.EvalLambdaBody();
       SqlExpression value;
       if (constant == null) {
         value = SqlDml.Null;
@@ -227,9 +224,7 @@ namespace Xtensive.Orm.BulkOperations
         }
       }
       i = -1;
-      var entity = (IEntity) (addContext.Lambda.Body is ConstantExpression ce
-          ? ce.Value
-          : FastExpression.Lambda(addContext.Lambda.Body).Compile().DynamicInvoke());
+      var entity = (IEntity)addContext.EvalLambdaBody();
 
       foreach (ColumnInfo column in addContext.Field.Columns) {
         i++;

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
@@ -227,7 +227,10 @@ namespace Xtensive.Orm.BulkOperations
         }
       }
       i = -1;
-      var entity = (IEntity) FastExpression.Lambda(addContext.Lambda.Body).Compile().DynamicInvoke();
+      var entity = (IEntity) (addContext.Lambda.Body is ConstantExpression ce
+          ? ce.Value
+          : FastExpression.Lambda(addContext.Lambda.Body).Compile().DynamicInvoke());
+
       foreach (ColumnInfo column in addContext.Field.Columns) {
         i++;
         SqlExpression value;

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
@@ -136,7 +136,7 @@ namespace Xtensive.Orm.BulkOperations
       var sqlSelect = request.Query;
       SqlExpression ex = sqlSelect.OrderBy[0].Expression;
       parent.Bindings.AddRange(request.ParameterBindings);
-      
+
       if(parent.JoinedTableRef!=null)
         ex.AcceptVisitor(new ComputedExpressionSqlVisitor(sqlSelect.From, parent.JoinedTableRef));
 
@@ -146,10 +146,14 @@ namespace Xtensive.Orm.BulkOperations
     private void AddConstantValue(AddValueContext addContext)
     {
       SqlTableColumn column = SqlDml.TableColumn(addContext.Statement.Table, addContext.Field.Column.Name);
+      var constant =
+        addContext.Lambda.Body is ConstantExpression ce
+          ? ce.Value
+          : FastExpression.Lambda(addContext.Lambda.Body).Compile().DynamicInvoke();
       SqlExpression value;
-      object constant = FastExpression.Lambda(addContext.Lambda.Body).Compile().DynamicInvoke();
-      if (constant==null)
+      if (constant == null) {
         value = SqlDml.Null;
+      }
       else {
         QueryParameterBinding binding = parent.QueryBuilder.CreateParameterBinding(constant.GetType(), context => constant);
         parent.Bindings.Add(binding);


### PR DESCRIPTION
Following code snippet:
```
session.Query.All<User>().Set(u => u.UpdateTime, now).Update();
```
compiles and executes expression lambda `a => now`, while `now` value is already known.
It is significant overhead. We see it in Profiler