### PR TITLE
Upgrade BitFaster.Caching to 1.0.7

### DIFF
--- a/Orm/Xtensive.Orm/Xtensive.Orm.csproj
+++ b/Orm/Xtensive.Orm/Xtensive.Orm.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   <ItemGroup Label="Packages">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="BitFaster.Caching" Version="1.0.4" />
+    <PackageReference Include="BitFaster.Caching" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup Label="T4 templates">
     <None Include="Arithmetic\Internal\PrimitiveArithmetics.tt">


### PR DESCRIPTION
Packages `BitFaster.Caching` `1.0.7` & `1.0.4` are binary incompatible.
In such situation it is better to choose latest version to allow `1.0.7` in dependent projects