### PR TITLE
Fix AttributeSearchOptions.InheritFromAllBase flag value

### DIFF
--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -104,7 +104,7 @@ namespace Xtensive.Reflection
         }
       }
 
-      if ((options & AttributeSearchOptions.InheritFromAllBase) != 0
+      if ((options & AttributeSearchOptions.InheritFromAllBase) == AttributeSearchOptions.InheritFromAllBase
           && member.DeclaringType != WellKnownTypes.Object
           && member.GetBaseMember() is MemberInfo bm2) {
         attributes.AddRange(GetAttributes(bm2, attributeType, options));

--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -97,9 +97,10 @@ namespace Xtensive.Reflection
           attributes = poe.GetAttributes(attributeType).ToList();
         }
         if ((options & AttributeSearchOptions.InheritFromBase) != 0
-            && (options & AttributeSearchOptions.InheritFromAllBase) == 0
+            && (options & AttributeSearchOptions.InheritRecursively) == 0
             && member.GetBaseMember() is MemberInfo bm) {
           attributes.AddRange(GetAttributes(bm, attributeType, options));
+          return attributes;
         }
       }
 

--- a/Orm/Xtensive.Orm/Reflection/AttributeSearchOptions.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeSearchOptions.cs
@@ -31,7 +31,7 @@ namespace Xtensive.Reflection
     /// <summary>
     /// Attributes from all the bases should be inherited.
     /// </summary>
-    InheritFromAllBase = 3,
+    InheritFromAllBase = 2,
     /// <summary>
     /// If no attributes are found on the specified method,
     /// attributes from the property or event it belongs to should be inherited.

--- a/Orm/Xtensive.Orm/Reflection/AttributeSearchOptions.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeSearchOptions.cs
@@ -29,9 +29,13 @@ namespace Xtensive.Reflection
     /// </summary>
     InheritFromBase = 1,
     /// <summary>
+    /// Attributes inherit recursively.
+    /// </summary>
+    InheritRecursively = 2,
+    /// <summary>
     /// Attributes from all the bases should be inherited.
     /// </summary>
-    InheritFromAllBase = 2,
+    InheritFromAllBase = InheritFromBase | InheritRecursively,
     /// <summary>
     /// If no attributes are found on the specified method,
     /// attributes from the property or event it belongs to should be inherited.


### PR DESCRIPTION
Flags values should be powers of 2

If `AttributeSearchOptions.InheritFromAllBase == 3`  then following condition is never true:
https://github.com/DataObjects-NET/dataobjects-net/blob/master/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs#L99:

when `options & AttributeSearchOptions.InheritFromBase` == 1 then
`(options & AttributeSearchOptions.InheritFromAllBase) == 0` is always false


BTW no DO code invokes `.GetAttributes(AttributeSearchOptions.InheritFromBase)`, so the behaviour will not change after the fix