### PR TITLE
Optimization: make event arguments readonly structs

### DIFF
--- a/Extensions/Xtensive.Orm.Reprocessing/DomainBuildErrorEventArgs.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/DomainBuildErrorEventArgs.cs
@@ -1,12 +1,24 @@
-﻿using System;
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+using System;
 
 namespace Xtensive.Orm.Reprocessing
 {
   /// <summary>
   /// Contains <see cref="ReprocessableDomainBuilder.Error"/> event data.
   /// </summary>
-  public class DomainBuildErrorEventArgs : EventArgs
+  public readonly struct DomainBuildErrorEventArgs
   {
+    /// <summary>
+    /// Gets the exception.
+    /// </summary>
+    public Exception Exception { get; }
+    /// <summary>
+    /// Gets the attempt number.
+    /// </summary>
+    public int Attempt { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DomainBuildErrorEventArgs"/> class.
     /// </summary>
@@ -17,14 +29,5 @@ namespace Xtensive.Orm.Reprocessing
       Exception = exception;
       Attempt = attempt;
     }
-
-    /// <summary>
-    /// Gets the exception.
-    /// </summary>
-    public Exception Exception { get; private set; }
-    /// <summary>
-    /// Gets the attempt number.
-    /// </summary>
-    public int Attempt { get; private set; }
   }
 }

--- a/Extensions/Xtensive.Orm.Reprocessing/ExecuteErrorEventArgs.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/ExecuteErrorEventArgs.cs
@@ -1,31 +1,35 @@
-﻿using System;
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
 
 namespace Xtensive.Orm.Reprocessing
 {
   /// <summary>
   /// Provides data for the <see cref="IExecuteActionStrategy.Error"/> event
   /// </summary>
-  public class ExecuteErrorEventArgs : EventArgs
+  public readonly struct ExecuteErrorEventArgs
   {
     /// <summary>
     /// Gets the attempt number of this task.
     /// </summary>
-    public int Attempt { get; private set; }
+    public int Attempt { get; }
 
     /// <summary>
     /// Gets the exception of this task.
     /// </summary>
-    public Exception Exception { get; private set; }
+    public Exception Exception { get; }
 
     /// <summary>
     /// Gets the session of this task. Session will have outer transaction.
     /// </summary>
-    public Session Session { get; private set; }
+    public Session Session { get; }
 
     /// <summary>
     /// Gets the transaction of this task.
     /// </summary>
-    public Transaction Transaction { get; private set; }
+    public Transaction Transaction { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ExecuteErrorEventArgs"/> class.

--- a/Extensions/Xtensive.Orm.Tracking/TrackingCompletedEventArgs.cs
+++ b/Extensions/Xtensive.Orm.Tracking/TrackingCompletedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2019-2020 Xtensive LLC.
+// Copyright (C) 2019-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
@@ -10,17 +10,17 @@ namespace Xtensive.Orm.Tracking
   /// <summary>
   /// Event arguments for <see cref="ITrackingMonitor.TrackingCompleted"/> event.
   /// </summary>
-  public sealed class TrackingCompletedEventArgs : EventArgs
+  public readonly struct TrackingCompletedEventArgs
   {
     /// <summary>
     /// Gets session this changes occured in.
     /// </summary>
-    public Session Session { get; private set; }
+    public Session Session { get; }
 
     /// <summary>
     /// Gets the changes.
     /// </summary>
-    public IEnumerable<ITrackingItem> Changes { get; private set; }
+    public IEnumerable<ITrackingItem> Changes { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TrackingCompletedEventArgs"/> class.
@@ -30,13 +30,8 @@ namespace Xtensive.Orm.Tracking
     /// <param name="changes">The changes.</param>
     public TrackingCompletedEventArgs(Session session, IEnumerable<ITrackingItem> changes)
     {
-      if (session==null)
-        throw new ArgumentNullException("session");
-      if (changes == null)
-        throw new ArgumentNullException("changes");
-
-      Session = session;
-      Changes = changes;
+      Session = session ?? throw new ArgumentNullException("session");
+      Changes = changes ?? throw new ArgumentNullException("changes");
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/SessionEventsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/SessionEventsTest.cs
@@ -32,14 +32,14 @@ namespace Xtensive.Orm.Tests.Storage.SessionEventsTestModel
   {
     private readonly bool throwExceptionOnCommit;
 
-    public TransactionEventArgs TransactionOpenArgs;
+    public TransactionEventArgs? TransactionOpenArgs;
 
-    public TransactionEventArgs TransactionPrecommitingArgs;
-    public TransactionEventArgs TransactionCommitingArgs;
-    public TransactionEventArgs TransactionCommitedArgs;
+    public TransactionEventArgs? TransactionPrecommitingArgs;
+    public TransactionEventArgs? TransactionCommitingArgs;
+    public TransactionEventArgs? TransactionCommitedArgs;
 
-    public TransactionEventArgs TransactionRollbackingArgs;
-    public TransactionEventArgs TransactionRollbackedArgs;
+    public TransactionEventArgs? TransactionRollbackingArgs;
+    public TransactionEventArgs? TransactionRollbackedArgs;
 
     public EventArgs PersistingArgs;
     public EventArgs PersistedArgs;
@@ -56,11 +56,11 @@ namespace Xtensive.Orm.Tests.Storage.SessionEventsTestModel
     public EntityFieldValueEventArgs EntityFieldValueSettingArgs;
     public EntityFieldValueSetEventArgs EntityFieldValueSetArgs;
 
-    public QueryEventArgs QueryExecuting;
-    public QueryEventArgs QueryExecuted;
+    public QueryEventArgs? QueryExecuting;
+    public QueryEventArgs? QueryExecuted;
 
-    public DbCommandEventArgs DbCommandExecuting;
-    public DbCommandEventArgs DbCommandExecuted;
+    public DbCommandEventArgs? DbCommandExecuting;
+    public DbCommandEventArgs? DbCommandExecuted;
 
     public void ResetEventArgs()
     {
@@ -209,7 +209,7 @@ namespace Xtensive.Orm.Tests.Storage
       using (var eventInfo = new EventInfo(session)) {
         using (var transactionScope = session.OpenTransaction()) {
           Assert.IsNotNull(eventInfo.TransactionOpenArgs);
-          Assert.AreSame(Transaction.Current, eventInfo.TransactionOpenArgs.Transaction);
+          Assert.AreSame(Transaction.Current, eventInfo.TransactionOpenArgs?.Transaction);
 
           var megaEntity = new MegaEntity { Value = 1 };
           transactionScope.Complete();
@@ -232,7 +232,7 @@ namespace Xtensive.Orm.Tests.Storage
       using (var eventInfo = new EventInfo(session)) {
         using (var transactionScope = session.OpenTransaction()) {
           Assert.IsNotNull(eventInfo.TransactionOpenArgs);
-          Assert.AreSame(Transaction.Current, eventInfo.TransactionOpenArgs.Transaction);
+          Assert.AreSame(Transaction.Current, eventInfo.TransactionOpenArgs?.Transaction);
 
           var megaEntity = new MegaEntity { Value = 1 };
         }
@@ -253,7 +253,7 @@ namespace Xtensive.Orm.Tests.Storage
       using (var eventInfo = new EventInfo(session, true)) {
         var transactionScope = session.OpenTransaction();
         Assert.IsNotNull(eventInfo.TransactionOpenArgs);
-        Assert.AreSame(Transaction.Current, eventInfo.TransactionOpenArgs.Transaction);
+        Assert.AreSame(Transaction.Current, eventInfo.TransactionOpenArgs?.Transaction);
 
         var megaEntity = new MegaEntity { Value = 1 };
 
@@ -336,14 +336,14 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.QueryExecuted.Exception);
+        Assert.IsNull(eventInfo.QueryExecuted?.Exception);
 
-        Assert.AreEqual(eventInfo.QueryExecuting.Expression, expression);
-        Assert.AreEqual(eventInfo.QueryExecuted.Expression, eventInfo.QueryExecuting.Expression);
+        Assert.AreEqual(eventInfo.QueryExecuting?.Expression, expression);
+        Assert.AreEqual(eventInfo.QueryExecuted?.Expression, eventInfo.QueryExecuting?.Expression);
 
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
       }
     }
 
@@ -365,14 +365,14 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.QueryExecuted.Exception);
+        Assert.IsNull(eventInfo.QueryExecuted?.Exception);
 
-        Assert.AreEqual(eventInfo.QueryExecuting.Expression, expression);
-        Assert.AreEqual(eventInfo.QueryExecuted.Expression, eventInfo.QueryExecuting.Expression);
+        Assert.AreEqual(eventInfo.QueryExecuting?.Expression, expression);
+        Assert.AreEqual(eventInfo.QueryExecuted?.Expression, eventInfo.QueryExecuting?.Expression);
 
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -388,14 +388,14 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.QueryExecuted.Exception);
+        Assert.IsNull(eventInfo.QueryExecuted?.Exception);
 
-        Assert.AreEqual(eventInfo.QueryExecuting.Expression, expression);
-        Assert.AreEqual(eventInfo.QueryExecuted.Expression, eventInfo.QueryExecuting.Expression);
+        Assert.AreEqual(eventInfo.QueryExecuting?.Expression, expression);
+        Assert.AreEqual(eventInfo.QueryExecuted?.Expression, eventInfo.QueryExecuting?.Expression);
 
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
       }
     }
 
@@ -415,12 +415,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -435,12 +435,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -455,12 +455,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -476,12 +476,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -496,12 +496,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -517,12 +517,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -537,12 +537,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -558,12 +558,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
       }
     }
 
@@ -584,12 +584,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -605,12 +605,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -625,12 +625,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -646,12 +646,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -666,12 +666,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -687,12 +687,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -707,12 +707,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -728,12 +728,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
       }
     }
 
@@ -768,12 +768,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -802,12 +802,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -836,12 +836,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -870,12 +870,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
       }
     }
 
@@ -910,12 +910,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -944,12 +944,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -978,12 +978,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
 
         eventInfo.ResetEventArgs();
 
@@ -1012,12 +1012,12 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.IsNotNull(eventInfo.DbCommandExecuting);
         Assert.IsNotNull(eventInfo.DbCommandExecuted);
 
-        Assert.IsNull(eventInfo.DbCommandExecuting.Exception);
-        Assert.IsNull(eventInfo.DbCommandExecuted.Exception);
-        Assert.IsNotNull(eventInfo.DbCommandExecuting.Command);
-        Assert.IsNotNull(eventInfo.DbCommandExecuted.Command);
+        Assert.IsNull(eventInfo.DbCommandExecuting?.Exception);
+        Assert.IsNull(eventInfo.DbCommandExecuted?.Exception);
+        Assert.IsNotNull(eventInfo.DbCommandExecuting?.Command);
+        Assert.IsNotNull(eventInfo.DbCommandExecuted?.Command);
 
-        Assert.AreEqual(eventInfo.DbCommandExecuting.Command, eventInfo.DbCommandExecuted.Command);
+        Assert.AreEqual(eventInfo.DbCommandExecuting?.Command, eventInfo.DbCommandExecuted?.Command);
       }
     }
 

--- a/Orm/Xtensive.Orm/Collections/ChangeNotifierEventArgs.cs
+++ b/Orm/Xtensive.Orm/Collections/ChangeNotifierEventArgs.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2007.10.15
 
@@ -13,18 +13,13 @@ namespace Xtensive.Collections
   /// Represents a set of information describing <see cref="IChangeNotifier"/> change.
   /// </summary>
   [Serializable]
-  public sealed class ChangeNotifierEventArgs: EventArgs
+  public readonly struct ChangeNotifierEventArgs
   {
-    private readonly object changeInfo;
-
     /// <summary>
     /// Gets the object representing some additional change information.
     /// </summary>
     /// <value>The info.</value>
-    public object ChangeInfo
-    {
-      get { return changeInfo; }
-    }
+    public object ChangeInfo { get; }
 
     /// <summary>
     /// Initializes a new instance of this type.
@@ -32,14 +27,7 @@ namespace Xtensive.Collections
     /// <param name="changeInfo">The info.</param>
     public ChangeNotifierEventArgs(object changeInfo)
     {
-      this.changeInfo = changeInfo;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of this type.
-    /// </summary>
-    public ChangeNotifierEventArgs()
-    {
+      ChangeInfo = changeInfo;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Building/Definitions/HierarchyDefCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Definitions/HierarchyDefCollection.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2008.01.11
 
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace Xtensive.Orm.Building.Definitions
 {
-  public sealed class HierarchyDefCollectionChangedEventArgs: EventArgs
+  public readonly struct HierarchyDefCollectionChangedEventArgs
   {
     public HierarchyDef Item { get; }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDefCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDefCollection.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2021 Xtensive LLC.
+// Copyright (C) 2007-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -13,7 +13,7 @@ using Xtensive.Reflection;
 
 namespace Xtensive.Orm.Building.Definitions
 {
-  public sealed class TypeDefCollectionChangedEventArgs: EventArgs
+  public readonly struct TypeDefCollectionChangedEventArgs
   {
     public TypeDef Item { get; }
 
@@ -23,7 +23,7 @@ namespace Xtensive.Orm.Building.Definitions
     }
   }
 
-  public sealed class TypeDefCollectionClearedEventArgs: EventArgs {}
+  public readonly struct TypeDefCollectionClearedEventArgs {}
 
   /// <summary>
   /// A collection of <see cref="TypeDef"/> items.

--- a/Orm/Xtensive.Orm/Orm/DbCommandEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/DbCommandEventArgs.cs
@@ -1,4 +1,8 @@
-﻿using System;
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
@@ -11,17 +15,17 @@ namespace Xtensive.Orm
   /// Events args for <see cref="SessionEventAccessor.DbCommandExecuting"/>
   /// and <see cref="SessionEventAccessor.DbCommandExecuted"/>.
   /// </summary>
-  public class DbCommandEventArgs : EventArgs
+  public readonly struct DbCommandEventArgs
   {
     /// <summary>
     /// Gets executed command.
     /// </summary>
-    public DbCommand Command { get; private set; }
+    public DbCommand Command { get; }
 
     /// <summary>
     /// Gets exception, thrown during command execution. <see langword="null" /> if command executed successfully.
     /// </summary>
-    public Exception Exception { get; private set; }
+    public Exception Exception { get; }
 
     /// <summary>
     /// Initializes a new instance of this class.

--- a/Orm/Xtensive.Orm/Orm/EntityEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityEventArgs.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2009.06.04
 
@@ -17,7 +17,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the entity to which this event is related.
     /// </summary>
-    public Entity Entity { get; private set; }
+    public Entity Entity { get; }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/EntityFieldEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityFieldEventArgs.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Kofman
 // Created:    2009.10.08
 
@@ -17,7 +17,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the field to which this event is related.
     /// </summary>
-    public FieldInfo Field { get; private  set; }
+    public FieldInfo Field { get; }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/EntityRemoveCompletedEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityRemoveCompletedEventArgs.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.10.22
 
@@ -17,7 +17,7 @@ namespace Xtensive.Orm
     /// Gets the exception.
     /// </summary>
     /// <value>The exception.</value>
-    public Exception Exception { get; private set; }
+    public Exception Exception { get; }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/EntityRemovingEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityRemovingEventArgs.cs
@@ -19,7 +19,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the entity remove reason.
     /// </summary>
-    public EntityRemoveReason Reason { get; private set; }
+    public EntityRemoveReason Reason { get; }
 
     // Constructors
     public EntityRemovingEventArgs(Entity entity, EntityRemoveReason reason)

--- a/Orm/Xtensive.Orm/Orm/KeyEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/KeyEventArgs.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.11.19
 
@@ -14,12 +14,12 @@ namespace Xtensive.Orm
   /// Arguments for <see cref="Key"/>-related events.
   /// </summary>
   [Serializable]
-  public sealed class KeyEventArgs : EventArgs
+  public readonly struct KeyEventArgs
   {
     /// <summary>
     /// Gets the key.
     /// </summary>
-    public Key Key { get; private set; }
+    public Key Key { get; }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Operations/OperationEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/OperationEventArgs.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2020 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
 // Created:    2009.11.23
 
@@ -19,7 +19,7 @@ namespace Xtensive.Orm.Operations
     /// <summary>
     /// Gets the operation.
     /// </summary>
-    public IOperation Operation { get; private set; }
+    public IOperation Operation { get; }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/QueryEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEventArgs.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+using System;
 using System.Linq.Expressions;
 
 
@@ -8,17 +11,17 @@ namespace Xtensive.Orm
   /// Event args for <see cref="SessionEventAccessor.QueryExecuting"/>
   /// and <see cref="SessionEventAccessor.QueryExecuted"/>.
   /// </summary>
-  public class QueryEventArgs : EventArgs
+  public readonly struct QueryEventArgs
   {
     /// <summary>
     /// Gets executed expression.
     /// </summary>
-    public Expression Expression { get; set; }
+    public Expression Expression { get; }
 
     /// <summary>
     /// Gets exception, thrown during expression execution. <see langword="null" /> if expression executed successfully.
     /// </summary>
-    public Exception Exception { get; private set; }
+    public Exception Exception { get; }
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/QueryEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEventArgs.cs
@@ -11,12 +11,12 @@ namespace Xtensive.Orm
   /// Event args for <see cref="SessionEventAccessor.QueryExecuting"/>
   /// and <see cref="SessionEventAccessor.QueryExecuted"/>.
   /// </summary>
-  public readonly struct QueryEventArgs
+  public class QueryEventArgs : EventArgs
   {
     /// <summary>
     /// Gets executed expression.
     /// </summary>
-    public Expression Expression { get; }
+    public Expression Expression { get; set; }
 
     /// <summary>
     /// Gets exception, thrown during expression execution. <see langword="null" /> if expression executed successfully.

--- a/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
@@ -245,15 +245,12 @@ namespace Xtensive.Orm
 
     internal void NotifyDbCommandExecuting(DbCommand command)
     {
-      if (DbCommandExecuting!=null)
-        DbCommandExecuting(this, new DbCommandEventArgs(command));
+      DbCommandExecuting?.Invoke(this, new DbCommandEventArgs(command));
     }
 
     internal void NotifyDbCommandExecuted(DbCommand command, Exception exception = null)
     {
-      if(DbCommandExecuted!=null)
-        DbCommandExecuted(this, new DbCommandEventArgs(command, exception));
-
+      DbCommandExecuted?.Invoke(this, new DbCommandEventArgs(command, exception));
     }
 
     internal Expression NotifyQueryExecuting(Expression expression)

--- a/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2020 Xtensive LLC.
+// Copyright (C) 2010-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alex Yakunin
@@ -256,22 +256,18 @@ namespace Xtensive.Orm
     internal Expression NotifyQueryExecuting(Expression expression)
     {
       var args = new QueryEventArgs(expression);
-      if (QueryExecuting!=null) {
-        QueryExecuting(this, args);
-      }
+      QueryExecuting?.Invoke(this, args);
       return args.Expression;
     }
 
     internal void NotifyQueryExecuted(Expression expression, Exception exception = null)
     {
-      if (QueryExecuted!=null)
-        QueryExecuted(this, new QueryEventArgs(expression, exception));
+      QueryExecuted?.Invoke(this, new QueryEventArgs(expression, exception));
     }
 
     internal void NotifyDisposing()
     {
-      if (Disposing!=null)
-        Disposing(this, EventArgs.Empty);
+      Disposing?.Invoke(this, EventArgs.Empty);
     }
 
     internal void NotifyPersisting()

--- a/Orm/Xtensive.Orm/Orm/SessionEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventArgs.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2009.06.04
 
@@ -12,12 +12,12 @@ namespace Xtensive.Orm
   /// <summary>
   /// Provides data for <see cref="Domain.SessionOpen"/> event.
   /// </summary>
-  public sealed class SessionEventArgs : EventArgs
+  public readonly struct SessionEventArgs
   {
     /// <summary>
     /// Gets the session.
     /// </summary>
-    public Session Session { get; private set; }
+    public Session Session { get; }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/TransactionEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/TransactionEventArgs.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2009.06.04
 
@@ -12,12 +12,12 @@ namespace Xtensive.Orm
   /// <summary>
   /// Provides data for <see cref="Session"/> transaction-related events.
   /// </summary>
-  public sealed class TransactionEventArgs : EventArgs
+  public readonly struct TransactionEventArgs
   {
     /// <summary>
     /// Gets the transaction.
     /// </summary>
-    public Transaction Transaction { get; private set; }
+    public Transaction Transaction { get; }
 
 
     // Constructors


### PR DESCRIPTION
The "Updated .NET Event pattern" (https://docs.microsoft.com/en-us/dotnet/csharp/modern-events)  does not require event args to be inherited from `EventArgs`
It means they often (when they are sealed classes without hierarchy) can be converted into readonly structs to save GC work.

Also:
* Refactor event invocation to `?.Invoke(` syntax