### PR TITLE
DateTimeOffsetAccessor.GetSize() returns the same size on both x86 and x64 architectures

### DIFF
--- a/ChangeLog/6.0.10_dev.txt
+++ b/ChangeLog/6.0.10_dev.txt
@@ -1,0 +1,1 @@
+[main] Fixed NotSupportedException appeared on x86 architecture when DateTimeOffset is used in entites

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -578,7 +578,11 @@ namespace Xtensive.Tuples.Packed
 
     private static unsafe int GetSize()
     {
-      return sizeof(DateTimeOffset);
+      // Depending on architecture, x86 or x64, the size of DateTimeOffset is either 12 or 16 respectively.
+      // Due to the fact that Rank calculation algorithm expects sizes to be equal to one of the power of two
+      // it returns wrong rank value for size 12 (bitsize = 96) which causes wrong choice of Encode/Decode methods.
+      // Setting it to 16 helps to solve Rank problem.
+      return sizeof(long) * 2;
     }
 
     public DateTimeOffsetFieldAccessor()


### PR DESCRIPTION
DateTimeOffsetAccessor appeared in 6.0.8 and brought a problem on x86 - DateTimeOffset size is 12 bytes instead of 16 which led to DateTimeOffsetAccessor.Rank became 6 instead of 7 and caused using wrong Encode/Decode methods.