### PR TITLE
Optimize logging

### DIFF
--- a/Extensions/Xtensive.Orm.Logging.NLog/Log.cs
+++ b/Extensions/Xtensive.Orm.Logging.NLog/Log.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013-2020 Xtensive LLC.
+// Copyright (C) 2013-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -40,7 +40,7 @@ namespace Xtensive.Orm.Logging.NLog
     }
 
     /// <inheritdoc/>
-    public override void Write(LogEventInfo info)
+    public override void Write(in LogEventInfo info)
     {
       if (info.Exception!=null)
         target.Log(ConvertLevel(info.Level), info.Exception, info.FormattedMessage);

--- a/Extensions/Xtensive.Orm.Logging.log4net/Log.cs
+++ b/Extensions/Xtensive.Orm.Logging.log4net/Log.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2014-2020 Xtensive LLC.
+// Copyright (C) 2014-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
@@ -43,7 +43,7 @@ namespace Xtensive.Orm.Logging.log4net
     }
 
     /// <inheritdoc />
-    public override void Write(LogEventInfo info)
+    public override void Write(in LogEventInfo info)
     {
       target.Logger.Log(target.Logger.GetType(), ConvertLevel(info.Level), info.FormattedMessage, info.Exception);
     }

--- a/Orm/Xtensive.Orm.Tests.Core/DotNetFramework/NewTupleLogicTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/DotNetFramework/NewTupleLogicTest.cs
@@ -145,12 +145,18 @@ namespace Xtensive.Orm.Tests.Core.DotNetFramework
 
     private void Test(int count)
     {
-      using (warmup ? new Disposable(delegate { }) :
-        TestLog.InfoRegion("With boxing"))
+      if (warmup) {
         TestTupleAccess(new BoxingTuple(), count);
-      using (warmup ? new Disposable(delegate { }) :
-        TestLog.InfoRegion("Without boxing"))
         TestTupleAccess(new NonBoxingTuple(), count);
+      }
+      else {
+        using(TestLog.InfoRegion("With boxing")) {
+          TestTupleAccess(new BoxingTuple(), count);
+        }
+        using (TestLog.InfoRegion("Without boxing")) {
+          TestTupleAccess(new NonBoxingTuple(), count);
+        }
+      }
     }
 
     private void TestTupleAccess(TestTuple tuple, int count)

--- a/Orm/Xtensive.Orm.Tests.Core/DotNetFramework/ThreadingTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/DotNetFramework/ThreadingTest.cs
@@ -219,13 +219,24 @@ namespace Xtensive.Orm.Tests.Core.DotNetFramework
         passCountBase /= 10;
 
       TestHelper.CollectGarbage();
-      using (warmup ? null : TestLog.InfoRegion(string.Format("{0} threads", threadCount))) {
+      if (warmup) {
         ThreadedTest(target, passCountBase,     target.ExecuteLock);
         ThreadedTest(target, passCountBase,     target.ExecuteReadLock);
         ThreadedTest(target, passCountBase,     target.ExecuteWriteLock);
         if (threadCount>1) {
           ThreadedTest(target, passCountBase / 200, target.ExecuteWaitLock);
           ThreadedTest(target, passCountBase / 400, target.ExecuteSleepLock);
+        }
+      }
+      else {
+        using (TestLog.InfoRegion(string.Format("{0} threads", threadCount))) {
+          ThreadedTest(target, passCountBase,     target.ExecuteLock);
+          ThreadedTest(target, passCountBase,     target.ExecuteReadLock);
+          ThreadedTest(target, passCountBase,     target.ExecuteWriteLock);
+          if (threadCount>1) {
+            ThreadedTest(target, passCountBase / 200, target.ExecuteWaitLock);
+            ThreadedTest(target, passCountBase / 400, target.ExecuteSleepLock);
+          }
         }
       }
     }
@@ -240,8 +251,13 @@ namespace Xtensive.Orm.Tests.Core.DotNetFramework
         passCountBase /= 10;
 
       TestHelper.CollectGarbage();
-      using (warmup ? null : TestLog.InfoRegion(string.Format("{0} threads", threadCount))) {
+      if (warmup) {
         ThreadedTest(target, passCountBase/100, target.ExecuteInvokeAsync);
+      }
+      else {
+        using (TestLog.InfoRegion(string.Format("{0} threads", threadCount))) {
+          ThreadedTest(target, passCountBase/100, target.ExecuteInvokeAsync);
+        }
       }
     }
 

--- a/Orm/Xtensive.Orm/Comparison/ComparerProvider.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparerProvider.cs
@@ -66,7 +66,7 @@ namespace Xtensive.Comparison
       // the comparer.
       var comparer = base.CreateAssociate<TKey, IAdvancedComparerBase>(out foundFor);
       if (foundFor == null) {
-        CoreLog.Warning(Strings.LogCantFindAssociateFor,
+        CoreLog.Warning(nameof(Strings.LogCantFindAssociateFor),
           TypeSuffixes.ToDelimitedString(" \\ "),
           typeof(TAssociate).GetShortName(),
           typeof(TKey).GetShortName());
@@ -77,7 +77,7 @@ namespace Xtensive.Comparison
       }
       associate = BaseComparerWrapperType.Activate(new[] { typeof(TKey), foundFor }, ConstructorParams) as TAssociate;
       if (associate != null) {
-        CoreLog.Warning(Strings.LogGenericAssociateIsUsedFor,
+        CoreLog.Warning(nameof(Strings.LogGenericAssociateIsUsedFor),
           BaseComparerWrapperType.GetShortName(),
           typeof (TKey).GetShortName(),
           foundFor.GetShortName(),
@@ -85,7 +85,7 @@ namespace Xtensive.Comparison
         return associate;
       }
       else {
-        CoreLog.Warning(Strings.LogGenericAssociateCreationHasFailedFor,
+        CoreLog.Warning(nameof(Strings.LogGenericAssociateCreationHasFailedFor),
           BaseComparerWrapperType.GetShortName(),
           typeof (TKey).GetShortName(),
           foundFor.GetShortName(),

--- a/Orm/Xtensive.Orm/Core/AsyncFutureResult.cs
+++ b/Orm/Xtensive.Orm/Core/AsyncFutureResult.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Core
         Get();
       }
       catch (Exception exception) {
-        logger?.Warning(Strings.LogAsyncOperationError, exception: exception);
+        logger?.Warning(nameof(Strings.LogAsyncOperationError), exception: exception);
       }
     }
 
@@ -67,7 +67,7 @@ namespace Xtensive.Core
         await GetAsync().ConfigureAwait(false);
       }
       catch (Exception exception) {
-        logger?.Warning(Strings.LogAsyncOperationError, exception: exception);
+        logger?.Warning(nameof(Strings.LogAsyncOperationError), exception: exception);
       }
     }
 

--- a/Orm/Xtensive.Orm/InternalLogs.cs
+++ b/Orm/Xtensive.Orm/InternalLogs.cs
@@ -17,24 +17,18 @@ namespace Xtensive
       return instance.IsLogged(type);
     }
 
-    public static IDisposable DebugRegion(string format, params object[] args)
-    {
-      return instance.DebugRegion(format, args);
-    }
+    public static IndentManager.IndentScope DebugRegion(string messageId, params object[] args) =>
+      instance.DebugRegion(messageId, args);
 
-    public static IDisposable InfoRegion(string format, params object[] args)
-    {
-      return instance.InfoRegion(format, args);
-    }
+    public static IndentManager.IndentScope InfoRegion(string messageId, params object[] args) =>
+      instance.InfoRegion(messageId, args);
 
-    public static void Debug(string format, params object[] args)
-    {
-      instance.Debug(format, args);
-    }
+    public static void Debug(string messageId, params object[] args) =>
+      instance.Debug(messageId, args);
 
-    public static Exception Debug(Exception exception, string format, params object[] args)
+    public static Exception Debug(Exception exception, string messageId, params object[] args)
     {
-      instance.Debug(format, args, exception);
+      instance.Debug(messageId, args, exception);
       return exception;
     }
 
@@ -44,14 +38,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Info(string format, params object[] args)
-    {
-      instance.Info(format, args);
-    }
+    public static void Info(string messageId, params object[] args) =>
+      instance.Info(messageId, args);
 
-    public static Exception Info(Exception exception, string format, params object[] args)
+    public static Exception Info(Exception exception, string messageId, params object[] args)
     {
-      instance.Info(format, args, exception);
+      instance.Info(messageId, args, exception);
       return exception;
     }
 
@@ -61,14 +53,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Warning(string format, params object[] args)
-    {
-      instance.Warning(format, args);
-    }
+    public static void Warning(string messageId, params object[] args) =>
+      instance.Warning(messageId, args);
 
-    public static Exception Warning(Exception exception, string format, params object[] args)
+    public static Exception Warning(Exception exception, string messageId, params object[] args)
     {
-      instance.Warning(format, args, exception);
+      instance.Warning(messageId, args, exception);
       return exception;
     }
 
@@ -78,14 +68,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Error(string format, params object[] args)
-    {
-      instance.Error(format, args);
-    }
+    public static void Error(string messageId, params object[] args) =>
+      instance.Error(messageId, args);
 
-    public static Exception Error(Exception exception, string format, params object[] args)
+    public static Exception Error(Exception exception, string messageId, params object[] args)
     {
-      instance.Error(format, args, exception);
+      instance.Error(messageId, args, exception);
       return exception;
     }
 
@@ -95,14 +83,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void FatalError(string format, params object[] args)
-    {
-      instance.FatalError(format, args);
-    }
+    public static void FatalError(string messageId, params object[] args) =>
+      instance.FatalError(messageId, args);
 
-    public static Exception FatalError(Exception exception, string format, params object[] args)
+    public static Exception FatalError(Exception exception, string messageId, params object[] args)
     {
-      instance.FatalError(format, args, exception);
+      instance.FatalError(messageId, args, exception);
       return exception;
     }
 
@@ -133,24 +119,18 @@ namespace Xtensive
       return instance.IsLogged(type);
     }
 
-    public static IDisposable DebugRegion(string format, params object[] args)
-    {
-      return instance.DebugRegion(format, args);
-    }
+    public static IndentManager.IndentScope DebugRegion(string messageId, params object[] args) =>
+      instance.DebugRegion(messageId, args);
 
-    public static IDisposable InfoRegion(string format, params object[] args)
-    {
-      return instance.InfoRegion(format, args);
-    }
+    public static IndentManager.IndentScope InfoRegion(string messageId, params object[] args) =>
+      instance.InfoRegion(messageId, args);
 
-    public static void Debug(string format, params object[] args)
-    {
-      instance.Debug(format, args);
-    }
+    public static void Debug(string messageId, params object[] args) =>
+      instance.Debug(messageId, args);
 
-    public static Exception Debug(Exception exception, string format, params object[] args)
+    public static Exception Debug(Exception exception, string messageId, params object[] args)
     {
-      instance.Debug(format, args, exception);
+      instance.Debug(messageId, args, exception);
       return exception;
     }
 
@@ -160,14 +140,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Info(string format, params object[] args)
-    {
-      instance.Info(format, args);
-    }
+    public static void Info(string messageId, params object[] args) =>
+      instance.Info(messageId, args);
 
-    public static Exception Info(Exception exception, string format, params object[] args)
+    public static Exception Info(Exception exception, string messageId, params object[] args)
     {
-      instance.Info(format, args, exception);
+      instance.Info(messageId, args, exception);
       return exception;
     }
 
@@ -177,14 +155,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Warning(string format, params object[] args)
-    {
-      instance.Warning(format, args);
-    }
+    public static void Warning(string messageId, params object[] args) =>
+      instance.Warning(messageId, args);
 
-    public static Exception Warning(Exception exception, string format, params object[] args)
+    public static Exception Warning(Exception exception, string messageId, params object[] args)
     {
-      instance.Warning(format, args, exception);
+      instance.Warning(messageId, args, exception);
       return exception;
     }
 
@@ -249,20 +225,14 @@ namespace Xtensive
       return instance.IsLogged(type);
     }
 
-    public static IDisposable DebugRegion(string format, params object[] args)
-    {
-      return instance.DebugRegion(format, args);
-    }
+    public static IndentManager.IndentScope DebugRegion(string messageId, params object[] args) =>
+      instance.DebugRegion(messageId, args);
 
-    public static IDisposable InfoRegion(string format, params object[] args)
-    {
-      return instance.InfoRegion(format, args);
-    }
+    public static IndentManager.IndentScope InfoRegion(string messageId, params object[] args) =>
+      instance.InfoRegion(messageId, args);
 
-    public static void Debug(string format, params object[] args)
-    {
-      instance.Debug(format, args);
-    }
+    public static void Debug(string messageId, params object[] args) =>
+      instance.Debug(messageId, args);
 
     public static Exception Debug(Exception exception, string format, params object[] args)
     {
@@ -276,14 +246,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Info(string format, params object[] args)
-    {
-      instance.Info(format, args);
-    }
+    public static void Info(string messageId, params object[] args) =>
+      instance.Info(messageId, args);
 
-    public static Exception Info(Exception exception, string format, params object[] args)
+    public static Exception Info(Exception exception, string messageId, params object[] args)
     {
-      instance.Info(format, args, exception);
+      instance.Info(messageId, args, exception);
       return exception;
     }
 
@@ -293,14 +261,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Warning(string format, params object[] args)
-    {
-      instance.Warning(format, args);
-    }
+    public static void Warning(string messageId, params object[] args) =>
+      instance.Warning(messageId, args);
 
-    public static Exception Warning(Exception exception, string format, params object[] args)
+    public static Exception Warning(Exception exception, string messageId, params object[] args)
     {
-      instance.Warning(format, args, exception);
+      instance.Warning(messageId, args, exception);
       return exception;
     }
 
@@ -310,14 +276,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Error(string format, params object[] args)
-    {
-      instance.Error(format, args);
-    }
+    public static void Error(string messageId, params object[] args) =>
+      instance.Error(messageId, args);
 
-    public static Exception Error(Exception exception, string format, params object[] args)
+    public static Exception Error(Exception exception, string messageId, params object[] args)
     {
-      instance.Error(format, args, exception);
+      instance.Error(messageId, args, exception);
       return exception;
     }
 
@@ -327,14 +291,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void FatalError(string format, params object[] args)
-    {
-      instance.FatalError(format, args);
-    }
+    public static void FatalError(string messageId, params object[] args) =>
+      instance.FatalError(messageId, args);
 
-    public static Exception FatalError(Exception exception, string format, params object[] args)
+    public static Exception FatalError(Exception exception, string messageId, params object[] args)
     {
-      instance.FatalError(format, args, exception);
+      instance.FatalError(messageId, args, exception);
       return exception;
     }
 
@@ -365,24 +327,18 @@ namespace Xtensive
       return instance.IsLogged(type);
     }
 
-    public static IDisposable DebugRegion(string format, params object[] args)
-    {
-      return instance.DebugRegion(format, args);
-    }
+    public static IndentManager.IndentScope DebugRegion(string messageId, params object[] args) =>
+      instance.DebugRegion(messageId, args);
 
-    public static IDisposable InfoRegion(string format, params object[] args)
-    {
-      return instance.InfoRegion(format, args);
-    }
+    public static IndentManager.IndentScope InfoRegion(string messageId, params object[] args) =>
+      instance.InfoRegion(messageId, args);
 
-    public static void Debug(string format, params object[] args)
-    {
-      instance.Debug(format, args);
-    }
+    public static void Debug(string messageId, params object[] args) =>
+      instance.Debug(messageId, args);
 
-    public static Exception Debug(Exception exception, string format, params object[] args)
+    public static Exception Debug(Exception exception, string messageId, params object[] args)
     {
-      instance.Debug(format, args, exception);
+      instance.Debug(messageId, args, exception);
       return exception;
     }
 
@@ -392,14 +348,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Info(string format, params object[] args)
-    {
-      instance.Info(format, args);
-    }
+    public static void Info(string messageId, params object[] args) =>
+      instance.Info(messageId, args);
 
-    public static Exception Info(Exception exception, string format, params object[] args)
+    public static Exception Info(Exception exception, string messageId, params object[] args)
     {
-      instance.Info(format, args, exception);
+      instance.Info(messageId, args, exception);
       return exception;
     }
 
@@ -409,14 +363,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Warning(string format, params object[] args)
-    {
-      instance.Warning(format, args);
-    }
+    public static void Warning(string messageId, params object[] args) =>
+      instance.Warning(messageId, args);
 
-    public static Exception Warning(Exception exception, string format, params object[] args)
+    public static Exception Warning(Exception exception, string messageId, params object[] args)
     {
-      instance.Warning(format, args, exception);
+      instance.Warning(messageId, args, exception);
       return exception;
     }
 
@@ -426,14 +378,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Error(string format, params object[] args)
-    {
-      instance.Error(format, args);
-    }
+    public static void Error(string messageId, params object[] args) =>
+      instance.Error(messageId, args);
 
-    public static Exception Error(Exception exception, string format, params object[] args)
+    public static Exception Error(Exception exception, string messageId, params object[] args)
     {
-      instance.Error(format, args, exception);
+      instance.Error(messageId, args, exception);
       return exception;
     }
 
@@ -443,14 +393,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void FatalError(string format, params object[] args)
-    {
-      instance.FatalError(format, args);
-    }
+    public static void FatalError(string messageId, params object[] args) =>
+      instance.FatalError(messageId, args);
 
-    public static Exception FatalError(Exception exception, string format, params object[] args)
+    public static Exception FatalError(Exception exception, string messageId, params object[] args)
     {
-      instance.FatalError(format, args, exception);
+      instance.FatalError(messageId, args, exception);
       return exception;
     }
 
@@ -481,24 +429,18 @@ namespace Xtensive
       return instance.IsLogged(type);
     }
 
-    public static IDisposable DebugRegion(string format, params object[] args)
-    {
-      return instance.DebugRegion(format, args);
-    }
+    public static IndentManager.IndentScope DebugRegion(string messageId, params object[] args) =>
+      instance.DebugRegion(messageId, args);
 
-    public static IDisposable InfoRegion(string format, params object[] args)
-    {
-      return instance.InfoRegion(format, args);
-    }
+    public static IndentManager.IndentScope InfoRegion(string messageId, params object[] args) =>
+      instance.InfoRegion(messageId, args);
 
-    public static void Debug(string format, params object[] args)
-    {
-      instance.Debug(format, args);
-    }
+    public static void Debug(string messageId, params object[] args) =>
+      instance.Debug(messageId, args);
 
-    public static Exception Debug(Exception exception, string format, params object[] args)
+    public static Exception Debug(Exception exception, string messageId, params object[] args)
     {
-      instance.Debug(format, args, exception);
+      instance.Debug(messageId, args, exception);
       return exception;
     }
 
@@ -508,14 +450,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Info(string format, params object[] args)
-    {
-      instance.Info(format, args);
-    }
+    public static void Info(string messageId, params object[] args) =>
+      instance.Info(messageId, args);
 
-    public static Exception Info(Exception exception, string format, params object[] args)
+    public static Exception Info(Exception exception, string messageId, params object[] args)
     {
-      instance.Info(format, args, exception);
+      instance.Info(messageId, args, exception);
       return exception;
     }
 
@@ -525,14 +465,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Warning(string format, params object[] args)
-    {
-      instance.Warning(format, args);
-    }
+    public static void Warning(string messageId, params object[] args) =>
+      instance.Warning(messageId, args);
 
-    public static Exception Warning(Exception exception, string format, params object[] args)
+    public static Exception Warning(Exception exception, string messageId, params object[] args)
     {
-      instance.Warning(format, args, exception);
+      instance.Warning(messageId, args, exception);
       return exception;
     }
 
@@ -542,14 +480,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Error(string format, params object[] args)
-    {
-      instance.Error(format, args);
-    }
+    public static void Error(string messageId, params object[] args) =>
+      instance.Error(messageId, args);
 
-    public static Exception Error(Exception exception, string format, params object[] args)
+    public static Exception Error(Exception exception, string messageId, params object[] args)
     {
-      instance.Error(format, args, exception);
+      instance.Error(messageId, args, exception);
       return exception;
     }
 
@@ -597,24 +533,18 @@ namespace Xtensive
       return instance.IsLogged(type);
     }
 
-    public static IDisposable DebugRegion(string format, params object[] args)
-    {
-      return instance.DebugRegion(format, args);
-    }
+    public static IndentManager.IndentScope DebugRegion(string messageId, params object[] args) =>
+      instance.DebugRegion(messageId, args);
 
-    public static IDisposable InfoRegion(string format, params object[] args)
-    {
-      return instance.InfoRegion(format, args);
-    }
+    public static IndentManager.IndentScope InfoRegion(string messageId, params object[] args) =>
+      instance.InfoRegion(messageId, args);
 
-    public static void Debug(string format, params object[] args)
-    {
-      instance.Debug(format, args);
-    }
+    public static void Debug(string messageId, params object[] args) =>
+      instance.Debug(messageId, args);
 
-    public static Exception Debug(Exception exception, string format, params object[] args)
+    public static Exception Debug(Exception exception, string messageId, params object[] args)
     {
-      instance.Debug(format, args, exception);
+      instance.Debug(messageId, args, exception);
       return exception;
     }
 
@@ -624,14 +554,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Info(string format, params object[] args)
-    {
-      instance.Info(format, args);
-    }
+    public static void Info(string messageId, params object[] args) =>
+      instance.Info(messageId, args);
 
-    public static Exception Info(Exception exception, string format, params object[] args)
+    public static Exception Info(Exception exception, string messageId, params object[] args)
     {
-      instance.Info(format, args, exception);
+      instance.Info(messageId, args, exception);
       return exception;
     }
 
@@ -658,14 +586,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void Error(string format, params object[] args)
-    {
-      instance.Error(format, args);
-    }
+    public static void Error(string messageId, params object[] args) =>
+      instance.Error(messageId, args);
 
-    public static Exception Error(Exception exception, string format, params object[] args)
+    public static Exception Error(Exception exception, string messageId, params object[] args)
     {
-      instance.Error(format, args, exception);
+      instance.Error(messageId, args, exception);
       return exception;
     }
 
@@ -675,14 +601,12 @@ namespace Xtensive
       return exception;
     }
 
-    public static void FatalError(string format, params object[] args)
-    {
-      instance.FatalError(format, args);
-    }
+    public static void FatalError(string messageId, params object[] args) =>
+      instance.FatalError(messageId, args);
 
-    public static Exception FatalError(Exception exception, string format, params object[] args)
+    public static Exception FatalError(Exception exception, string messageId, params object[] args)
     {
-      instance.FatalError(format, args, exception);
+      instance.FatalError(messageId, args, exception);
       return exception;
     }
 

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Upgrader.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Upgrader.cs
@@ -160,15 +160,15 @@ namespace Xtensive.Modelling.Comparison
             .ForEach(validationHints.Add);
           var diff = comparer.Compare(CurrentModel, TargetModel, validationHints);
           if (diff != null) {
-            CoreLog.InfoRegion(Strings.LogAutomaticUpgradeSequenceValidation);
-            CoreLog.Info(Strings.LogValidationFailed);
-            CoreLog.Info(Strings.LogItemFormat, Strings.Difference);
+            CoreLog.InfoRegion(nameof(Strings.LogAutomaticUpgradeSequenceValidation));
+            CoreLog.Info(nameof(Strings.LogValidationFailed));
+            CoreLog.Info(nameof(Strings.LogItemFormat), Strings.Difference);
             CoreLog.Info("{0}", diff);
             CoreLog.Info(Strings.LogItemFormat + "\r\n{1}", Strings.UpgradeSequence,
               new ActionSequence() { actions });
-            CoreLog.Info(Strings.LogItemFormat, Strings.ExpectedTargetModel);
+            CoreLog.Info(nameof(Strings.LogItemFormat), Strings.ExpectedTargetModel);
             TargetModel.Dump();
-            CoreLog.Info(Strings.LogItemFormat, Strings.ActualTargetModel);
+            CoreLog.Info(nameof(Strings.LogItemFormat), Strings.ActualTargetModel);
             CurrentModel.Dump();
             throw new InvalidOperationException(Strings.ExUpgradeSequenceValidationFailure);
           }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/AttributeProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/AttributeProcessor.cs
@@ -367,7 +367,7 @@ namespace Xtensive.Orm.Building.Builders
       context.Validator.ValidateName(mappingName, rule);
 
       if (Comparer.Equals(node.MappingName, mappingName)) {
-        BuildLog.Warning(Strings.ExplicitMappingNameSettingIsRedundantTheSameNameXWillBeGeneratedAutomatically,
+        BuildLog.Warning(nameof(Strings.ExplicitMappingNameSettingIsRedundantTheSameNameXWillBeGeneratedAutomatically),
           node.MappingName);
       }
       else {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Building.Builders
 
     public static void Run(BuildingContext context)
     {
-      using (BuildLog.InfoRegion(Strings.LogCalculatingDatabaseDependencies)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogCalculatingDatabaseDependencies))) {
         new DatabaseDependencyBuilder(context).Run();
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/DomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/DomainBuilder.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Building.Builders
       ArgumentValidator.EnsureArgumentNotNull(builderConfiguration, nameof(builderConfiguration));
 
       var context = new BuildingContext(builderConfiguration);
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, typeof(Domain).GetShortName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), typeof(Domain).GetShortName())) {
         new DomainBuilder(context).Run();
       }
 
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void CreateDomain()
     {
-      using (BuildLog.InfoRegion(Strings.LogCreatingX, typeof(Domain).GetShortName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogCreatingX), typeof(Domain).GetShortName())) {
         var services = context.BuilderConfiguration.Services;
         var useSingleConnection =
           services.ProviderInfo.Supports(ProviderFeatures.SingleConnection)
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Building.Builders
       var handlers = context.Domain.Handlers;
       var services = context.BuilderConfiguration.Services;
 
-      using (BuildLog.InfoRegion(Strings.LogCreatingX, typeof(DomainHandler).GetShortName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogCreatingX), typeof(DomainHandler).GetShortName())) {
         // HandlerFactory
         handlers.Factory = services.HandlerFactory;
 
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void CreateServices()
     {
-      using (BuildLog.InfoRegion(Strings.LogCreatingX, typeof(IServiceContainer).GetShortName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogCreatingX), typeof(IServiceContainer).GetShortName())) {
         var domain = context.Domain;
         var configuration = domain.Configuration;
         var userContainerType = configuration.ServiceContainerType ?? typeof(ServiceContainer);
@@ -107,7 +107,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void BuildModel()
     {
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, Strings.Model)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), Strings.Model)) {
         ModelBuilder.Run(context);
         var model = context.Model;
         model.Lock(true);
@@ -119,7 +119,7 @@ namespace Xtensive.Orm.Building.Builders
     {
       var domain = context.Domain;
 
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, Strings.KeyGenerators)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), Strings.KeyGenerators)) {
         var generators = domain.KeyGenerators;
         var keysToProcess = domain.Model.Hierarchies
           .Select(h => h.Key)
@@ -145,7 +145,7 @@ namespace Xtensive.Orm.Building.Builders
         generators.Lock();
       }
 
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, Strings.Validators)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), Strings.Validators)) {
         foreach (var type in domain.Model.Types) {
           foreach (var validator in type.Validators) {
             validator.Configure(domain, type);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Orm.Building.Builders
 
     public static void BuildIndexes(BuildingContext context)
     {
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, Strings.Indexes)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), Strings.Indexes)) {
         new IndexBuilder(context).BuildAll();
       }
     }
@@ -289,7 +289,7 @@ namespace Xtensive.Orm.Building.Builders
     /// <exception cref="DomainBuilderException">Something went wrong.</exception>
     private IndexInfo BuildIndex(TypeInfo typeInfo, IndexDef indexDef, bool buildAbstract)
     {
-      BuildLog.Info(Strings.LogBuildingIndexX, indexDef.Name);
+      BuildLog.Info(nameof(Strings.LogBuildingIndexX), indexDef.Name);
       var attributes = !buildAbstract ? indexDef.Attributes : indexDef.Attributes | IndexAttributes.Abstract;
 
       if (typeInfo.IsInterface && !typeInfo.IsMaterialized)
@@ -403,7 +403,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private IndexInfo BuildInheritedIndex(TypeInfo reflectedType, IndexInfo ancestorIndex, bool buildAbstract)
     {
-      BuildLog.Info(Strings.LogBuildingIndexX, ancestorIndex.Name);
+      BuildLog.Info(nameof(Strings.LogBuildingIndexX), ancestorIndex.Name);
       var attributes = IndexAttributes.None;
 
       if (reflectedType.IsInterface && !reflectedType.IsMaterialized)

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -101,9 +101,9 @@ namespace Xtensive.Orm.Building.Builders
 
     private void BuildModelDefinition()
     {
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, Strings.ModelDefinition)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), Strings.ModelDefinition)) {
         context.ModelDef = new DomainModelDef(modelDefBuilder, context.Validator);
-        using (BuildLog.InfoRegion(Strings.LogDefiningX, Strings.Types))
+        using (BuildLog.InfoRegion(nameof(Strings.LogDefiningX), Strings.Types))
           modelDefBuilder.ProcessTypes();
       }
     }
@@ -124,7 +124,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void ApplyCustomDefinitions()
     {
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, Strings.CustomDefinitions))
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), Strings.CustomDefinitions))
       using (new BuildingScope(context)) { // Activate context for compatibility with previous versions
         foreach (var module in context.Modules)
           module.OnDefinitionsBuilt(context, context.ModelDef);
@@ -141,7 +141,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void BuildModel()
     {
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, Strings.ActualModel)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), Strings.ActualModel)) {
         context.Model = new DomainModel();
         BuildTypes(GetTypeBuildSequence());
         BuildAssociations();
@@ -184,13 +184,13 @@ namespace Xtensive.Orm.Building.Builders
 
     private void BuildTypes(IEnumerable<TypeDef> typeDefs)
     {
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, Strings.Types)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), Strings.Types)) {
         // Building types, system fields and hierarchies
         foreach (var typeDef in typeDefs) {
           typeBuilder.BuildType(typeDef);
         }
       }
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, "Fields"))
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), "Fields"))
         foreach (var typeDef in typeDefs) {
           var typeInfo = context.Model.Types[typeDef.UnderlyingType];
           typeBuilder.BuildFields(typeDef, typeInfo);
@@ -301,7 +301,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void BuildAssociations()
     {
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, Strings.Associations)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), Strings.Associations)) {
         PreprocessAssociations();
         foreach (var pair in context.PairedAssociations) {
           if (context.DiscardedAssociations.Contains(pair.First))

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelDefBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelDefBuilder.cs
@@ -73,7 +73,7 @@ namespace Xtensive.Orm.Building.Builders
         return typeDef;
       }
 
-      using (BuildLog.InfoRegion(Strings.LogDefiningX, type.GetFullName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogDefiningX), type.GetFullName())) {
         typeDef = DefineType(type);
         if (modelDef.Types.Contains(typeDef.Name)) {
           throw new DomainBuilderException(string.Format(Strings.ExTypeWithNameXIsAlreadyDefined, typeDef.Name));
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Building.Builders
         }
 
         if (hierarchyDef != null) {
-          BuildLog.Info(Strings.LogHierarchyX, typeDef.Name);
+          BuildLog.Info(nameof(Strings.LogHierarchyX), typeDef.Name);
           modelDef.Hierarchies.Add(hierarchyDef);
         }
 
@@ -160,7 +160,7 @@ namespace Xtensive.Orm.Building.Builders
         // Declared & inherited fields must be processed for hierarchy root
         if (hierarchyDef != null) {
           typeDef.Fields.Add(field);
-          BuildLog.Info(Strings.LogFieldX, field.Name);
+          BuildLog.Info(nameof(Strings.LogFieldX), field.Name);
 
           var keyAttributes = propertyInfo.GetAttribute<KeyAttribute>(AttributeSearchOptions.InheritAll);
           if (keyAttributes != null) {
@@ -170,7 +170,7 @@ namespace Xtensive.Orm.Building.Builders
         // Only declared properties must be processed in other cases
         else if (propertyInfo.DeclaringType == propertyInfo.ReflectedType) {
           typeDef.Fields.Add(field);
-          BuildLog.Info(Strings.LogFieldX, field.Name);
+          BuildLog.Info(nameof(Strings.LogFieldX), field.Name);
         }
 
         // Checking whether property type is registered in model
@@ -204,7 +204,7 @@ namespace Xtensive.Orm.Building.Builders
         }
 
         typeDef.Indexes.Add(index);
-        BuildLog.Info(Strings.LogIndexX, index.Name);
+        BuildLog.Info(nameof(Strings.LogIndexX), index.Name);
       }
 
       //process indexes which inherited from base classes
@@ -224,7 +224,7 @@ namespace Xtensive.Orm.Building.Builders
 
         index.IsInherited = true;
         typeDef.Indexes.Add(index);
-        BuildLog.Info(Strings.LogIndexX, index.Name);
+        BuildLog.Info(nameof(Strings.LogIndexX), index.Name);
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
@@ -80,7 +80,7 @@ namespace Xtensive.Orm.Building.Builders
 
     public static void Run(BuildingContext context)
     {
-      using (BuildLog.InfoRegion(Strings.LogProcessingMappingRules)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogProcessingMappingRules))) {
         new StorageMappingBuilder(context).ProcessAll();
       }
     }
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Building.Builders
       foreach (var type in typesToProcess) {
         var underlyingType = type.UnderlyingType;
         if (verbose)
-          BuildLog.Info(Strings.LogProcessingX, underlyingType.GetShortName());
+          BuildLog.Info(nameof(Strings.LogProcessingX), underlyingType.GetShortName());
         var request = new MappingRequest(underlyingType.Assembly, underlyingType.Namespace);
         MappingResult result;
         if (!mappingCache.TryGetValue(request, out result)) {
@@ -102,7 +102,7 @@ namespace Xtensive.Orm.Building.Builders
         }
         else {
           if (verbose)
-            BuildLog.Info(Strings.LogReusingCachedMappingInformationForX, underlyingType.GetShortName());
+            BuildLog.Info(nameof(Strings.LogReusingCachedMappingInformationForX), underlyingType.GetShortName());
         }
         type.MappingDatabase = result.MappingDatabase;
         type.MappingSchema = result.MappingSchema;
@@ -117,7 +117,7 @@ namespace Xtensive.Orm.Building.Builders
       var resultSchema = !string.IsNullOrEmpty(rule.Schema) ? rule.Schema : defaultSchema;
 
       if (verbose)
-        BuildLog.Info(Strings.ApplyingRuleXToY, rule, type.GetShortName());
+        BuildLog.Info(nameof(Strings.ApplyingRuleXToY), rule, type.GetShortName());
 
       return new MappingResult(resultDatabase, resultSchema);
     }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingValidator.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingValidator.cs
@@ -22,7 +22,7 @@ namespace Xtensive.Orm.Building.Builders
 
     public static void Run(BuildingContext context)
     {
-      using (BuildLog.InfoRegion(Strings.LogValidatingMappingConfiguration)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogValidatingMappingConfiguration))) {
         new StorageMappingValidator(context).ValidateAll();
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm.Building.Builders
     /// <param name="typeDef"><see cref="TypeDef"/> instance.</param>
     public TypeInfo BuildType(TypeDef typeDef)
     {
-      using (BuildLog.InfoRegion(Strings.LogBuildingX, typeDef.UnderlyingType.GetShortName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), typeDef.UnderlyingType.GetShortName())) {
 
         var typeInfo = new TypeInfo(context.Model, typeDef.Attributes) {
           UnderlyingType = typeDef.UnderlyingType,
@@ -230,7 +230,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private FieldInfo BuildDeclaredField(TypeInfo type, FieldDef fieldDef)
     {
-      BuildLog.Info(Strings.LogBuildingDeclaredFieldXY, type.Name, fieldDef.Name);
+      BuildLog.Info(nameof(Strings.LogBuildingDeclaredFieldXY), type.Name, fieldDef.Name);
 
       var fieldInfo = new FieldInfo(type, fieldDef.Attributes) {
         UnderlyingProperty = fieldDef.UnderlyingProperty,
@@ -323,7 +323,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void BuildInheritedField(TypeInfo type, FieldInfo inheritedField)
     {
-      BuildLog.Info(Strings.LogBuildingInheritedFieldXY, type.Name, inheritedField.Name);
+      BuildLog.Info(nameof(Strings.LogBuildingInheritedFieldXY), type.Name, inheritedField.Name);
       var field = inheritedField.Clone();
       type.Fields.Add(field);
       field.ReflectedType = type;
@@ -401,7 +401,7 @@ namespace Xtensive.Orm.Building.Builders
           }
 
           typeDef.Indexes.Add(index);
-          BuildLog.Info(Strings.LogIndexX, index.Name);
+          BuildLog.Info(nameof(Strings.LogIndexX), index.Name);
         }
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Building/FixupActionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/FixupActionProcessor.cs
@@ -27,9 +27,9 @@ namespace Xtensive.Orm.Building
 
     private void ProcessAll()
     {
-      using (BuildLog.InfoRegion(Strings.LogProcessingFixupActions))
+      using (BuildLog.InfoRegion(nameof(Strings.LogProcessingFixupActions)))
         while (context.ModelInspectionResult.Actions.TryDequeue(out var action)) {
-          BuildLog.Info(string.Format(Strings.LogExecutingActionX, action));
+          BuildLog.Info(nameof(Strings.LogExecutingActionX), action);
           action.Run(this);
         }
     }

--- a/Orm/Xtensive.Orm/Orm/Building/ModelInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/ModelInspector.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Orm.Building
   {
     public static void Run(BuildingContext context)
     {
-      using (BuildLog.InfoRegion(Strings.LogInspectingModelDefinition)) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogInspectingModelDefinition))) {
         InspectHierarchies(context);
         InspectTypes(context);
         InspectInterfaces(context);
@@ -183,7 +183,7 @@ namespace Xtensive.Orm.Building
     public static void Inspect(BuildingContext context, HierarchyDef hierarchyDef)
     {
       var root = hierarchyDef.Root;
-      BuildLog.Info(Strings.LogInspectingHierarchyX, root.Name);
+      BuildLog.Info(nameof(Strings.LogInspectingHierarchyX), root.Name);
       context.Validator.ValidateHierarchy(hierarchyDef);
       // Skip open generic hierarchies
       if (root.IsGenericTypeDefinition) {
@@ -215,7 +215,7 @@ namespace Xtensive.Orm.Building
 
     public static void Inspect(BuildingContext context, TypeDef typeDef)
     {
-      BuildLog.Info(Strings.LogInspectingTypeX, typeDef.Name);
+      BuildLog.Info(nameof(Strings.LogInspectingTypeX), typeDef.Name);
 
       if (typeDef.IsInterface) {
         // Remove open generic interface

--- a/Orm/Xtensive.Orm/Orm/Building/SystemModule.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/SystemModule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2003-2010 Xtensive LLC.
+// Copyright (C) 2003-2010 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Andrey Turkov
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Building
 
     private static void ApplyModelFixesForMySql(DomainModelDef model)
     {
-      BuildLog.Info("Applying changes to Metadata-related types for MySQL");
+      BuildLog.Info(nameof(Strings.ApplyingChangesToMetadata));
 
       // Fixing length of Assembly.Name field
       TypeDef type = model.Types.TryGetValue(typeof (Assembly));

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -227,7 +227,7 @@ namespace Xtensive.Orm
       configuration.Lock(true);
 
       if (isDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogOpeningSessionX, configuration);
+        OrmLog.Debug(nameof(Strings.LogOpeningSessionX), configuration);
       }
 
       Session session;
@@ -326,7 +326,7 @@ namespace Xtensive.Orm
       configuration.Lock(true);
 
       if (isDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogOpeningSessionX, configuration);
+        OrmLog.Debug(nameof(Strings.LogOpeningSessionX), configuration);
       }
 
       Session session;
@@ -427,7 +427,7 @@ namespace Xtensive.Orm
       }
 
       if (isDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogDomainIsDisposing);
+        OrmLog.Debug(nameof(Strings.LogDomainIsDisposing));
       }
 
       NotifyDisposing();

--- a/Orm/Xtensive.Orm/Orm/Entity.cs
+++ b/Orm/Xtensive.Orm/Orm/Entity.cs
@@ -486,7 +486,7 @@ namespace Xtensive.Orm
     internal void SystemBeforeRemove(EntityRemoveReason reason)
     {
       if (Session.IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXRemovingKeyY, Session, Key);
+        OrmLog.Debug(nameof(Strings.LogSessionXRemovingKeyY), Session, Key);
       }
 
       Session.SystemEvents.NotifyEntityRemoving(this, reason);
@@ -533,7 +533,7 @@ namespace Xtensive.Orm
     {
       State.Entity = this;
       if (Session.IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXMaterializingYKeyZ, Session, GetType().GetShortName(), State.Key);
+        OrmLog.Debug(nameof(Strings.LogSessionXMaterializingYKeyZ), Session, GetType().GetShortName(), State.Key);
       }
 
       if (Session.IsSystemLogicOnly || materialize)
@@ -621,7 +621,7 @@ namespace Xtensive.Orm
       if (!Session.Configuration.Supports(SessionOptions.ReadRemovedObjects))
         EnsureNotRemoved();
       if (Session.IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXGettingValueKeyYFieldZ, Session, Key, field);
+        OrmLog.Debug(nameof(Strings.LogSessionXGettingValueKeyYFieldZ), Session, Key, field);
       }
 
       EnsureIsFetched(field);
@@ -673,7 +673,7 @@ namespace Xtensive.Orm
       EnsureNotRemoved();
 
       if (Session.IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXSettingValueKeyYFieldZ, Session, Key, field);
+        OrmLog.Debug(nameof(Strings.LogSessionXSettingValueKeyYFieldZ), Session, Key, field);
       }
 
       if (field.IsPrimaryKey)

--- a/Orm/Xtensive.Orm/Orm/Key.cs
+++ b/Orm/Xtensive.Orm/Orm/Key.cs
@@ -120,7 +120,7 @@ namespace Xtensive.Orm
         return TypeReference.Type;
 
       if (session.IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXResolvingKeyYExactTypeIsUnknownFetchIsRequired, session, this);
+        OrmLog.Debug(nameof(Strings.LogSessionXResolvingKeyYExactTypeIsUnknownFetchIsRequired), session, this);
       }
 
       var entityState = session.Handler.FetchEntityState(this);

--- a/Orm/Xtensive.Orm/Orm/Logging/IndentManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Logging/IndentManager.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2013-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2013.11.11
 
@@ -14,9 +14,9 @@ namespace Xtensive.Orm.Logging
   /// </summary>
   public static class IndentManager
   {
-    private sealed class IndentScope : IDisposable
+    public struct IndentScope : IDisposable
     {
-      private readonly string oldIndent;
+      private readonly int oldIndent;
       private readonly Action endAction;
       private bool disposed;
 
@@ -26,34 +26,34 @@ namespace Xtensive.Orm.Logging
           return;
         disposed = true;
         CurrentIndentValueAsync.Value = oldIndent;
-        if (endAction!=null)
-          endAction.Invoke();
+        endAction?.Invoke();
       }
 
-      public IndentScope(string oldIndent, Action endAction)
+      public IndentScope(int oldIndent, Action endAction)
       {
         this.oldIndent = oldIndent;
         this.endAction = endAction;
+        disposed = false;
       }
     }
 
-    private const string SingleIndent = "  ";
+    private const int SingleIndent = 2;
     
-    private static readonly AsyncLocal<string> CurrentIndentValueAsync = new AsyncLocal<string>();
+    private static readonly AsyncLocal<int> CurrentIndentValueAsync = new();
 
     /// <summary>
     /// Gets indentation for current thread.
     /// </summary>
-    public static string CurrentIdent { get { return CurrentIndentValueAsync.Value ?? string.Empty; } }
+    public static int CurrentIdent => CurrentIndentValueAsync.Value;
 
     /// <summary>
     /// Increases indentation for current thread.
     /// </summary>
     /// <returns>Indentation scope.</returns>
-    public static IDisposable IncreaseIndent(Action endAction = null)
+    public static IndentScope IncreaseIndent(Action endAction = null)
     {
       var oldIndent = CurrentIndentValueAsync.Value;
-      CurrentIndentValueAsync.Value = oldIndent==null ? SingleIndent : oldIndent + SingleIndent;
+      CurrentIndentValueAsync.Value = oldIndent + SingleIndent;
       return new IndentScope(oldIndent, endAction);
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Logging/Internals/ConsoleWriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Logging/Internals/ConsoleWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Kulakov
@@ -11,7 +11,7 @@ namespace Xtensive.Orm.Logging
   internal sealed class ConsoleWriter : LogWriter
   {
     /// <inheritdoc/>
-    public override void Write(LogEventInfo logEvent)
+    public override void Write(in LogEventInfo logEvent)
     {
       Console.Out.WriteLine(logEvent);
     }

--- a/Orm/Xtensive.Orm/Orm/Logging/Internals/DebugOnlyConsoleWriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Logging/Internals/DebugOnlyConsoleWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Kulakov
@@ -16,7 +16,7 @@ namespace Xtensive.Orm.Logging
     private Timer debuggerAttachedRenewTimer;
 
     /// <inheritdoc/>
-    public override void Write(LogEventInfo logEvent)
+    public override void Write(in LogEventInfo logEvent)
     {
       if (debuggerIsAttached)
         Console.Out.WriteLine(logEvent);

--- a/Orm/Xtensive.Orm/Orm/Logging/Internals/FileWriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Logging/Internals/FileWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Kulakov
@@ -14,7 +14,7 @@ namespace Xtensive.Orm.Logging
     private readonly object syncRoot = new object();
 
     /// <inheritdoc/>
-    public override void Write(LogEventInfo logEvent)
+    public override void Write(in LogEventInfo logEvent)
     {
       lock (syncRoot) {
         using (var streamWriter = new StreamWriter(fileName, true)) {

--- a/Orm/Xtensive.Orm/Orm/Logging/Internals/InternalLog.cs
+++ b/Orm/Xtensive.Orm/Orm/Logging/Internals/InternalLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Kulakov
@@ -17,7 +17,7 @@ namespace Xtensive.Orm.Logging
       return true;
     }
 
-    public override void Write(LogEventInfo info)
+    public override void Write(in LogEventInfo info)
     {
       writer.Write(info);
     }

--- a/Orm/Xtensive.Orm/Orm/Logging/Internals/LogWriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Logging/Internals/LogWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Kulakov
@@ -8,6 +8,6 @@ namespace Xtensive.Orm.Logging
 {
   internal abstract class LogWriter
   {
-    public abstract void Write(LogEventInfo logEvent);
+    public abstract void Write(in LogEventInfo logEvent);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Logging/Internals/NullLog.cs
+++ b/Orm/Xtensive.Orm/Orm/Logging/Internals/NullLog.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Logging
     {
     }
 
-    public override void Write(LogEventInfo info)
+    public override void Write(in LogEventInfo info)
     {
     }
 

--- a/Orm/Xtensive.Orm/Orm/Logging/LogEventInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Logging/LogEventInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Kulakov
@@ -13,27 +13,27 @@ namespace Xtensive.Orm.Logging
   /// <summary>
   /// Represent information to write to target of log.
   /// </summary>
-  public sealed class LogEventInfo
+  public readonly struct LogEventInfo
   {
     /// <summary>
     /// Gets source of this event.
     /// </summary>
-    public string Source { get; private set; }
+    public string Source { get; }
 
     /// <summary>
     /// Gets log level for this event.
     /// </summary>
-    public LogLevel Level { get; private set; }
+    public LogLevel Level { get; }
 
     /// <summary>
     /// Gets log message for this event.
     /// </summary>
-    public string FormattedMessage { get; private set; }
+    public string FormattedMessage { get; }
 
     /// <summary>
     /// Gets exception for this event.
     /// </summary>
-    public Exception Exception { get; private set; }
+    public Exception Exception { get; }
 
     /// <inheritdoc/>
     public override string ToString()
@@ -68,7 +68,7 @@ namespace Xtensive.Orm.Logging
       if (string.IsNullOrEmpty(message))
         return message;
       var indent = IndentManager.CurrentIdent;
-      return indent.Length > 0 ? indent + message : message;
+      return indent > 0 ? new string(' ', indent) + message : message;
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -782,7 +782,7 @@ namespace Xtensive.Orm.Model
             tuple.SetValue(i, column.DefaultValue);
           }
           catch (Exception e) {
-            OrmLog.Error(e, Strings.LogExErrorSettingDefaultValueXForColumnYInTypeZ,
+            OrmLog.Error(e, nameof(Strings.LogExErrorSettingDefaultValueXForColumnYInTypeZ),
               column.DefaultValue, column.Name, Name);
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Operations/Internals/OperationRegistrationScope.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/Internals/OperationRegistrationScope.cs
@@ -66,7 +66,7 @@ namespace Xtensive.Orm.Operations
       IdentifierByKey.Add(key, identifier);
 
       if (Owner.Session.IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXEntityWithKeyYIdentifiedAsZ, Owner.Session, key, identifier);
+        OrmLog.Debug(nameof(Strings.LogSessionXEntityWithKeyYIdentifiedAsZ), Owner.Session, key, identifier);
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Operations/ValidateVersionOperation.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/ValidateVersionOperation.cs
@@ -64,7 +64,7 @@ namespace Xtensive.Orm.Operations
       var entity = session.Query.Single(Key);
       if (entity.VersionInfo != Version) {
         if (OrmLog.IsLogged(LogLevel.Info))
-          OrmLog.Info(Strings.LogSessionXVersionValidationFailedKeyYVersionZExpected3,
+          OrmLog.Info(nameof(Strings.LogSessionXVersionValidationFailedKeyYVersionZExpected3),
             session, Key, entity.VersionInfo, Version);
         throw new VersionConflictException(
           string.Format(Strings.ExVersionOfEntityWithKeyXDiffersFromTheExpectedOne, Key));

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Orm.Providers
     public SqlConnection CreateConnection(Session session)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXCreatingConnection, session.ToStringSafely());
+        SqlLog.Info(nameof(Strings.LogSessionXCreatingConnection), session.ToStringSafely());
       }
 
       SqlConnection connection;
@@ -73,7 +73,7 @@ namespace Xtensive.Orm.Providers
     public void OpenConnection(Session session, SqlConnection connection)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXOpeningConnectionY, session.ToStringSafely(), connection.ConnectionInfo);
+        SqlLog.Info(nameof(Strings.LogSessionXOpeningConnectionY), session.ToStringSafely(), connection.ConnectionInfo);
       }
 
       var script = connection.Extensions.Get<InitializationSqlExtension>()?.Script;
@@ -98,7 +98,7 @@ namespace Xtensive.Orm.Providers
       CancellationToken cancellationToken)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXOpeningConnectionY, session.ToStringSafely(), connection.ConnectionInfo);
+        SqlLog.Info(nameof(Strings.LogSessionXOpeningConnectionY), session.ToStringSafely(), connection.ConnectionInfo);
       }
 
       var script = connection.Extensions.Get<InitializationSqlExtension>()?.Script;
@@ -141,7 +141,7 @@ namespace Xtensive.Orm.Providers
       }
 
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXClosingConnectionY, session.ToStringSafely(), connection.ConnectionInfo);
+        SqlLog.Info(nameof(Strings.LogSessionXClosingConnectionY), session.ToStringSafely(), connection.ConnectionInfo);
       }
 
       try {
@@ -159,7 +159,7 @@ namespace Xtensive.Orm.Providers
       }
 
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXClosingConnectionY, session.ToStringSafely(), connection.ConnectionInfo);
+        SqlLog.Info(nameof(Strings.LogSessionXClosingConnectionY), session.ToStringSafely(), connection.ConnectionInfo);
       }
 
       try {
@@ -173,7 +173,7 @@ namespace Xtensive.Orm.Providers
     public void DisposeConnection(Session session, SqlConnection connection)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXDisposingConnection, session.ToStringSafely());
+        SqlLog.Info(nameof(Strings.LogSessionXDisposingConnection), session.ToStringSafely());
       }
 
       try {
@@ -187,7 +187,7 @@ namespace Xtensive.Orm.Providers
     public async Task DisposeConnectionAsync(Session session, SqlConnection connection)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXDisposingConnection, session.ToStringSafely());
+        SqlLog.Info(nameof(Strings.LogSessionXDisposingConnection), session.ToStringSafely());
       }
 
       try {
@@ -201,7 +201,7 @@ namespace Xtensive.Orm.Providers
     public void BeginTransaction(Session session, SqlConnection connection, IsolationLevel? isolationLevel)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXBeginningTransactionWithYIsolationLevel, session.ToStringSafely(),
+        SqlLog.Info(nameof(Strings.LogSessionXBeginningTransactionWithYIsolationLevel), session.ToStringSafely(),
           isolationLevel);
       }
 
@@ -219,7 +219,7 @@ namespace Xtensive.Orm.Providers
       Session session, SqlConnection connection, IsolationLevel? isolationLevel, CancellationToken token = default)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXBeginningTransactionWithYIsolationLevel, session.ToStringSafely(),
+        SqlLog.Info(nameof(Strings.LogSessionXBeginningTransactionWithYIsolationLevel), session.ToStringSafely(),
           isolationLevel);
       }
 
@@ -236,7 +236,7 @@ namespace Xtensive.Orm.Providers
     public void CommitTransaction(Session session, SqlConnection connection)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXCommitTransaction, session.ToStringSafely());
+        SqlLog.Info(nameof(Strings.LogSessionXCommitTransaction), session.ToStringSafely());
       }
 
       try {
@@ -251,7 +251,7 @@ namespace Xtensive.Orm.Providers
       Session session, SqlConnection connection, CancellationToken token = default)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXCommitTransaction, session.ToStringSafely());
+        SqlLog.Info(nameof(Strings.LogSessionXCommitTransaction), session.ToStringSafely());
       }
 
       try {
@@ -265,7 +265,7 @@ namespace Xtensive.Orm.Providers
     public void RollbackTransaction(Session session, SqlConnection connection)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXRollbackTransaction, session.ToStringSafely());
+        SqlLog.Info(nameof(Strings.LogSessionXRollbackTransaction), session.ToStringSafely());
       }
 
       try {
@@ -280,7 +280,7 @@ namespace Xtensive.Orm.Providers
       Session session, SqlConnection connection, CancellationToken token = default)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXRollbackTransaction, session.ToStringSafely());
+        SqlLog.Info(nameof(Strings.LogSessionXRollbackTransaction), session.ToStringSafely());
       }
 
       try {
@@ -294,7 +294,7 @@ namespace Xtensive.Orm.Providers
     public void MakeSavepoint(Session session, SqlConnection connection, string name)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXMakeSavepointY, session.ToStringSafely(), name);
+        SqlLog.Info(nameof(Strings.LogSessionXMakeSavepointY), session.ToStringSafely(), name);
       }
 
       if (!hasSavepoints) {
@@ -313,7 +313,7 @@ namespace Xtensive.Orm.Providers
       Session session, SqlConnection connection, string name, CancellationToken token = default)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXMakeSavepointY, session.ToStringSafely(), name);
+        SqlLog.Info(nameof(Strings.LogSessionXMakeSavepointY), session.ToStringSafely(), name);
       }
 
       if (!hasSavepoints) {
@@ -331,7 +331,7 @@ namespace Xtensive.Orm.Providers
     public void RollbackToSavepoint(Session session, SqlConnection connection, string name)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXRollbackToSavepointY, session.ToStringSafely(), name);
+        SqlLog.Info(nameof(Strings.LogSessionXRollbackToSavepointY), session.ToStringSafely(), name);
       }
 
       if (!hasSavepoints) {
@@ -350,7 +350,7 @@ namespace Xtensive.Orm.Providers
       Session session, SqlConnection connection, string name, CancellationToken token = default)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXRollbackToSavepointY, session.ToStringSafely(), name);
+        SqlLog.Info(nameof(Strings.LogSessionXRollbackToSavepointY), session.ToStringSafely(), name);
       }
 
       if (!hasSavepoints) {
@@ -368,7 +368,7 @@ namespace Xtensive.Orm.Providers
     public void ReleaseSavepoint(Session session, SqlConnection connection, string name)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXReleaseSavepointY, session.ToStringSafely(), name);
+        SqlLog.Info(nameof(Strings.LogSessionXReleaseSavepointY), session.ToStringSafely(), name);
       }
 
       try {
@@ -383,7 +383,7 @@ namespace Xtensive.Orm.Providers
       Session session, SqlConnection connection, string name, CancellationToken token = default)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXReleaseSavepointY, session.ToStringSafely(), name);
+        SqlLog.Info(nameof(Strings.LogSessionXReleaseSavepointY), session.ToStringSafely(), name);
       }
 
       try {
@@ -433,7 +433,7 @@ namespace Xtensive.Orm.Providers
       Session session, DbCommand command, CommandBehavior commandBehavior, Func<DbCommand, CommandBehavior, TResult> action)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXQueryY, session.ToStringSafely(), command.ToHumanReadableString());
+        SqlLog.Info(nameof(Strings.LogSessionXQueryY), session.ToStringSafely(), command.ToHumanReadableString());
       }
 
       session?.Events.NotifyDbCommandExecuting(command);
@@ -458,7 +458,7 @@ namespace Xtensive.Orm.Providers
       CancellationToken cancellationToken, Func<DbCommand, CommandBehavior, CancellationToken, Task<TResult>> action)
     {
       if (isLoggingEnabled) {
-        SqlLog.Info(Strings.LogSessionXQueryY, session.ToStringSafely(), command.ToHumanReadableString());
+        SqlLog.Info(nameof(Strings.LogSessionXQueryY), session.ToStringSafely(), command.ToHumanReadableString());
       }
 
       cancellationToken.ThrowIfCancellationRequested();

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -292,7 +292,7 @@ namespace Xtensive.Orm
         EntityState state;
         if (!session.LookupStateInCache(key, out state)) {
           if (session.IsDebugEventLoggingEnabled) {
-            OrmLog.Debug(Strings.LogSessionXResolvingKeyYExactTypeIsZ, session, key, key.HasExactType ? Strings.Known : Strings.Unknown);
+            OrmLog.Debug(nameof(Strings.LogSessionXResolvingKeyYExactTypeIsZ), session, key, key.HasExactType ? Strings.Known : Strings.Unknown);
           }
 
           state = session.Handler.FetchEntityState(key);

--- a/Orm/Xtensive.Orm/Orm/Session.Cache.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Cache.cs
@@ -34,7 +34,7 @@ namespace Xtensive.Orm
     internal void Invalidate()
     {
       if (IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXInvalidate, this);
+        OrmLog.Debug(nameof(Strings.LogSessionXInvalidate), this);
       }
 
       ClearChangeRegistry();
@@ -75,7 +75,7 @@ namespace Xtensive.Orm
           Invalidate();
         }
         if (IsDebugEventLoggingEnabled) {
-          OrmLog.Debug(Strings.LogSessionXRemappingEntityKeys, this);
+          OrmLog.Debug(nameof(Strings.LogSessionXRemappingEntityKeys), this);
         }
 
         foreach (var entityState in EntityChangeRegistry.GetItems(PersistenceState.New)) {
@@ -133,7 +133,7 @@ namespace Xtensive.Orm
       EntityStateCache.Add(result);
 
       if (IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXCachingY, this, result);
+        OrmLog.Debug(nameof(Strings.LogSessionXCachingY), this, result);
       }
     }
 
@@ -179,7 +179,7 @@ namespace Xtensive.Orm
       }
 
       if (IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXCachingY, this, result);
+        OrmLog.Debug(nameof(Strings.LogSessionXCachingY), this, result);
       }
 
       return result;
@@ -230,7 +230,7 @@ namespace Xtensive.Orm
         result.Update(tuple);
         result.IsStale = isStale;
         if (IsDebugEventLoggingEnabled) {
-          OrmLog.Debug(Strings.LogSessionXUpdatingCacheY, this, result);
+          OrmLog.Debug(nameof(Strings.LogSessionXUpdatingCacheY), this, result);
         }
       }
       return result;
@@ -266,7 +266,7 @@ namespace Xtensive.Orm
       };
       EntityStateCache.Add(result);
       if (IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXCachingY, this, result);
+        OrmLog.Debug(nameof(Strings.LogSessionXCachingY), this, result);
       }
 
       return result;

--- a/Orm/Xtensive.Orm/Orm/Session.Persist.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Persist.cs
@@ -142,7 +142,7 @@ namespace Xtensive.Orm
         using (OpenSystemLogicOnlyRegion()) {
           DemandTransaction();
           if (IsDebugEventLoggingEnabled) {
-            OrmLog.Debug(Strings.LogSessionXPersistingReasonY, this, reason);
+            OrmLog.Debug(nameof(Strings.LogSessionXPersistingReasonY), this, reason);
           }
 
           EntityChangeRegistry itemsToPersist;
@@ -204,7 +204,7 @@ namespace Xtensive.Orm
             }
 
             if (IsDebugEventLoggingEnabled) {
-              OrmLog.Debug(Strings.LogSessionXPersistCompleted, this);
+              OrmLog.Debug(nameof(Strings.LogSessionXPersistCompleted), this);
             }
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
@@ -242,7 +242,7 @@ namespace Xtensive.Orm
     internal async ValueTask CommitTransaction(Transaction transaction, bool isAsync)
     {
       if (IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXCommittingTransaction, this);
+        OrmLog.Debug(nameof(Strings.LogSessionXCommittingTransaction), this);
       }
 
       SystemEvents.NotifyTransactionPrecommitting(transaction);
@@ -283,7 +283,7 @@ namespace Xtensive.Orm
     {
       try {
         if (IsDebugEventLoggingEnabled) {
-          OrmLog.Debug(Strings.LogSessionXRollingBackTransaction, this);
+          OrmLog.Debug(nameof(Strings.LogSessionXRollingBackTransaction), this);
         }
 
         SystemEvents.NotifyTransactionRollbacking(transaction);
@@ -366,7 +366,7 @@ namespace Xtensive.Orm
       switch (transaction.State) {
       case TransactionState.Committed:
         if (IsDebugEventLoggingEnabled) {
-          OrmLog.Debug(Strings.LogSessionXCommittedTransaction, this);
+          OrmLog.Debug(nameof(Strings.LogSessionXCommittedTransaction), this);
         }
 
         SystemEvents.NotifyTransactionCommitted(transaction);
@@ -374,7 +374,7 @@ namespace Xtensive.Orm
         break;
       case TransactionState.RolledBack:
         if (IsDebugEventLoggingEnabled) {
-          OrmLog.Debug(Strings.LogSessionXRolledBackTransaction, this);
+          OrmLog.Debug(nameof(Strings.LogSessionXRolledBackTransaction), this);
         }
 
         SystemEvents.NotifyTransactionRollbacked(transaction);
@@ -453,7 +453,7 @@ namespace Xtensive.Orm
       Transaction transaction, bool isAsync, CancellationToken token = default)
     {
       if (IsDebugEventLoggingEnabled) {
-        OrmLog.Debug(Strings.LogSessionXOpeningTransaction, this);
+        OrmLog.Debug(nameof(Strings.LogSessionXOpeningTransaction), this);
       }
 
       SystemEvents.NotifyTransactionOpening(transaction);
@@ -469,7 +469,7 @@ namespace Xtensive.Orm
 
       IDisposable logIndentScope = null;
       if (IsDebugEventLoggingEnabled) {
-        logIndentScope = OrmLog.DebugRegion(Strings.LogSessionXTransaction, this);
+        logIndentScope = OrmLog.DebugRegion(nameof(Strings.LogSessionXTransaction), this);
       }
 
       SystemEvents.NotifyTransactionOpened(transaction);

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -633,7 +633,7 @@ namespace Xtensive.Orm
 
       try {
         if (IsDebugEventLoggingEnabled) {
-          OrmLog.Debug(Strings.LogSessionXDisposing, this);
+          OrmLog.Debug(nameof(Strings.LogSessionXDisposing), this);
         }
 
         SystemEvents.NotifyDisposing();

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/DomainModelConverter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/DomainModelConverter.cs
@@ -263,7 +263,7 @@ namespace Xtensive.Orm.Upgrade
     protected override IPathNode VisitFullTextIndexInfo(FullTextIndexInfo fullTextIndex)
     {
       if (!providerInfo.Supports(ProviderFeatures.FullText)) {
-        UpgradeLog.Warning(Strings.LogFullTextIndexesAreNotSupportedByCurrentStorageIgnoringIndexX, fullTextIndex.Name);
+        UpgradeLog.Warning(nameof(Strings.LogFullTextIndexesAreNotSupportedByCurrentStorageIgnoringIndexX), fullTextIndex.Name);
         return null;
       }
 
@@ -278,7 +278,7 @@ namespace Xtensive.Orm.Upgrade
             typeColumn = table.Columns[fullTextColumn.TypeColumn.Name].Name;
         }
         else
-          UpgradeLog.Warning(Strings.LogSpecificationOfTypeColumnForFulltextColumnIsNotSupportedByCurrentStorageIgnoringTypeColumnSpecificationForColumnX, fullTextColumn.Column.Name);
+          UpgradeLog.Warning(nameof(Strings.LogSpecificationOfTypeColumnForFulltextColumnIsNotSupportedByCurrentStorageIgnoringTypeColumnSpecificationForColumnX), fullTextColumn.Column.Name);
         new FullTextColumnRef(ftIndex, column, fullTextColumn.Configuration, typeColumn);
       }
       

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
@@ -698,7 +698,7 @@ namespace Xtensive.Orm.Upgrade
         return true;
       }
 
-      UpgradeLog.Warning(Strings.ExTableXIsNotFound, nodeName);
+      UpgradeLog.Warning(nameof(Strings.ExTableXIsNotFound), nodeName);
       return false;
     }
 
@@ -713,7 +713,7 @@ namespace Xtensive.Orm.Upgrade
         return true;
       }
 
-      UpgradeLog.Warning(Strings.ExColumnXIsNotFoundInTableY, actualFieldName, nodeName);
+      UpgradeLog.Warning(nameof(Strings.ExColumnXIsNotFoundInTableY), actualFieldName, nodeName);
       return false;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaUpgrader.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaUpgrader.cs
@@ -104,7 +104,7 @@ namespace Xtensive.Orm.Upgrade
     private void LogStatements(IEnumerable<string> statements)
     {
       SqlLog.Info(
-        Strings.LogSessionXSchemaUpgradeScriptY,
+        nameof(Strings.LogSessionXSchemaUpgradeScriptY),
         session.ToStringSafely(),
         driver.BuildBatch(statements.ToArray()).Trim());
     }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlWorker.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlWorker.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Upgrade
           }
         }
         catch (Exception exception) {
-          UpgradeLog.Warning(Strings.LogFailedToExtractMetadataFromXYZ, metadataTask.Catalog, metadataTask.Schema, exception);
+          UpgradeLog.Warning(nameof(Strings.LogFailedToExtractMetadataFromXYZ), metadataTask.Catalog, metadataTask.Schema, exception);
         }
       }
       result.Metadata = set;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/SystemUpgradeHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/SystemUpgradeHandler.cs
@@ -269,7 +269,7 @@ namespace Xtensive.Orm.Upgrade
         }
 
         if (!found) {
-          UpgradeLog.Info(Strings.LogDomainModelIsNotFoundInStorage);
+          UpgradeLog.Info(nameof(Strings.LogDomainModelIsNotFoundInStorage));
           return;
         }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -548,7 +548,7 @@ namespace Xtensive.Orm.Upgrade
           context.SchemaHints.Add(schemaHint);
         }
         catch (Exception error) {
-          UpgradeLog.Warning(Strings.LogFailedToAddSchemaHintXErrorY, schemaHint, error);
+          UpgradeLog.Warning(nameof(Strings.LogFailedToAddSchemaHintXErrorY), schemaHint, error);
         }
       }
     }
@@ -556,7 +556,7 @@ namespace Xtensive.Orm.Upgrade
     private void SynchronizeSchema(
       Domain domain, SchemaUpgrader upgrader, SchemaExtractor extractor, SchemaUpgradeMode schemaUpgradeMode)
     {
-      using (UpgradeLog.InfoRegion(Strings.LogSynchronizingSchemaInXMode, schemaUpgradeMode)) {
+      using (UpgradeLog.InfoRegion(nameof(Strings.LogSynchronizingSchemaInXMode), schemaUpgradeMode)) {
         StorageModel targetSchema = null;
         if (schemaUpgradeMode==SchemaUpgradeMode.Skip) {
           if (context.ParentDomain==null) {
@@ -566,7 +566,7 @@ namespace Xtensive.Orm.Upgrade
             targetSchema = GetTargetModel(domain);
             context.TargetStorageModel = targetSchema;
             if (UpgradeLog.IsLogged(LogLevel.Info)) {
-              UpgradeLog.Info(Strings.LogTargetSchema);
+              UpgradeLog.Info(nameof(Strings.LogTargetSchema));
               targetSchema.Dump();
             }
           }
@@ -586,9 +586,9 @@ namespace Xtensive.Orm.Upgrade
         var hints = triplet.Item2;
         if (UpgradeLog.IsLogged(LogLevel.Info))
         {
-          UpgradeLog.Info(Strings.LogExtractedSchema);
+          UpgradeLog.Info(nameof(Strings.LogExtractedSchema));
           extractedSchema.Dump();
-          UpgradeLog.Info(Strings.LogTargetSchema);
+          UpgradeLog.Info(nameof(Strings.LogTargetSchema));
           targetSchema.Dump();
         }
         OnSchemaReady();
@@ -601,7 +601,7 @@ namespace Xtensive.Orm.Upgrade
           UpgradeLog.Info(result.ToString());
 
         if (UpgradeLog.IsLogged(LogLevel.Info))
-          UpgradeLog.Info(Strings.LogComparisonResultX, result);
+          UpgradeLog.Info(nameof(Strings.LogComparisonResultX), result);
 
         context.SchemaDifference = (NodeDifference) result.Difference;
         context.SchemaUpgradeActions = result.UpgradeActions;
@@ -641,7 +641,7 @@ namespace Xtensive.Orm.Upgrade
     private async Task SynchronizeSchemaAsync(
       Domain domain, SchemaUpgrader upgrader, SchemaExtractor extractor, SchemaUpgradeMode schemaUpgradeMode, CancellationToken token)
     {
-      using (UpgradeLog.InfoRegion(Strings.LogSynchronizingSchemaInXMode, schemaUpgradeMode)) {
+      using (UpgradeLog.InfoRegion(nameof(Strings.LogSynchronizingSchemaInXMode), schemaUpgradeMode)) {
         StorageModel targetSchema = null;
         if (schemaUpgradeMode==SchemaUpgradeMode.Skip) {
           if (context.ParentDomain==null) {
@@ -651,7 +651,7 @@ namespace Xtensive.Orm.Upgrade
             targetSchema = GetTargetModel(domain);
             context.TargetStorageModel = targetSchema;
             if (UpgradeLog.IsLogged(LogLevel.Info)) {
-              UpgradeLog.Info(Strings.LogTargetSchema);
+              UpgradeLog.Info(nameof(Strings.LogTargetSchema));
               targetSchema.Dump();
             }
           }
@@ -671,9 +671,9 @@ namespace Xtensive.Orm.Upgrade
         var hints = triplet.Item2;
         if (UpgradeLog.IsLogged(LogLevel.Info))
         {
-          UpgradeLog.Info(Strings.LogExtractedSchema);
+          UpgradeLog.Info(nameof(Strings.LogExtractedSchema));
           extractedSchema.Dump();
-          UpgradeLog.Info(Strings.LogTargetSchema);
+          UpgradeLog.Info(nameof(Strings.LogTargetSchema));
           targetSchema.Dump();
         }
         await OnSchemaReadyAsync(token).ConfigureAwait(false);
@@ -686,7 +686,7 @@ namespace Xtensive.Orm.Upgrade
           UpgradeLog.Info(result.ToString());
 
         if (UpgradeLog.IsLogged(LogLevel.Info))
-          UpgradeLog.Info(Strings.LogComparisonResultX, result);
+          UpgradeLog.Info(nameof(Strings.LogComparisonResultX), result);
 
         context.SchemaDifference = (NodeDifference) result.Difference;
         context.SchemaUpgradeActions = result.UpgradeActions;

--- a/Orm/Xtensive.Orm/Orm/VersionSet.cs
+++ b/Orm/Xtensive.Orm/Orm/VersionSet.cs
@@ -158,7 +158,7 @@ namespace Xtensive.Orm
       var result = Validate(key, version);
       if (throwOnFailure && !result) {
         if (OrmLog.IsLogged(LogLevel.Info))
-          OrmLog.Info(Strings.LogSessionXVersionValidationFailedKeyYVersionZExpected3,
+          OrmLog.Info(nameof(Strings.LogSessionXVersionValidationFailedKeyYVersionZExpected3),
             "None (VersionSet)", key, version, Get(key));
         throw new VersionConflictException(string.Format(
           Strings.ExVersionOfEntityWithKeyXDiffersFromTheExpectedOne, key));

--- a/Orm/Xtensive.Orm/Orm/VersionValidator.cs
+++ b/Orm/Xtensive.Orm/Orm/VersionValidator.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Orm
       var result = ValidateVersion(key, version);
       if (throwOnFailure && !result) {
         if (OrmLog.IsLogged(LogLevel.Info))
-          OrmLog.Info(Strings.LogSessionXVersionValidationFailedKeyYVersionZExpected3,
+          OrmLog.Info(nameof(Strings.LogSessionXVersionValidationFailedKeyYVersionZExpected3),
             Session, key, version, expectedVersionProvider.Invoke(key));
         throw new VersionConflictException(string.Format(
           Strings.ExVersionOfEntityWithKeyXDiffersFromTheExpectedOne, key));

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Xtensive {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -93,6 +93,15 @@ namespace Xtensive {
         internal static string AnyCulture {
             get {
                 return ResourceManager.GetString("AnyCulture", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Applying changes to Metadata-related types for MySQL.
+        /// </summary>
+        internal static string ApplyingChangesToMetadata {
+            get {
+                return ResourceManager.GetString("ApplyingChangesToMetadata", resourceCulture);
             }
         }
         
@@ -5031,6 +5040,15 @@ namespace Xtensive {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to IQueryable.DistinctBy() extension is not supported. Use &apos;.AsEnumerable().DistinctBy()&apos; instead..
+        /// </summary>
+        internal static string ExUnsupportedDistinctBy {
+            get {
+                return ResourceManager.GetString("ExUnsupportedDistinctBy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unsupported expression type: &apos;{0}&apos;..
         /// </summary>
         internal static string ExUnsupportedExpressionType {
@@ -7387,12 +7405,6 @@ namespace Xtensive {
         internal static string ZeroAssemblyVersion {
             get {
                 return ResourceManager.GetString("ZeroAssemblyVersion", resourceCulture);
-            }
-        }
-
-        internal static string ExUnsupportedDistinctBy {
-            get {
-                return ResourceManager.GetString("ExUnsupportedDistinctBy", resourceCulture);
             }
         }
     }

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -2576,4 +2576,7 @@ Error: {1}</value>
   <data name="ExUnsupportedDistinctBy" xml:space="preserve">
     <value>IQueryable.DistinctBy() extension is not supported. Use '.AsEnumerable().DistinctBy()' instead.</value>
   </data>
+  <data name="ApplyingChangesToMetadata" xml:space="preserve">
+    <value>Applying changes to Metadata-related types for MySQL</value>
+  </data>
 </root>


### PR DESCRIPTION
Currently even when we use `NullLog`  the log messages are resolved from resources.

Suggested optimization:
* Pass message ID to logger. Heavy `ResourceManager.GetString()` is called only for real logging. If the message id not found then `messageId` is used as message - it gurantees compatibility with existing code
* `IndentScope` converted to `struct` to decrease memory allocations
* `Indent` parameter converted from string to int, and indenting string is generated on demand.