### PR TITLE
Adds ability to ignore indexes as well as columns

### DIFF
--- a/ChangeLog/7.1.0-Beta-2-dev.txt
+++ b/ChangeLog/7.1.0-Beta-2-dev.txt
@@ -12,6 +12,8 @@
 [main] SqlCustomFunctionCall and SqlFunctionCall share one base type
 [main] SqlFunctionCall.Arguments property is IReadOnlyList now and parameters can't be changed after instance creation
 [main] Xtensive.Sql.Dml.Extensions.IsNullReference() extension method is marked obsolete, use 'is null' operator instead
+[main] IgnoreRule now has only one public constructor - parameterless
+[main] IgnoreRule supports indexes
 [main] BitFaster.Caching package reference is updated to 1.0.7
 [main] No error caused by ambiguity due to new IQueryable extension methods of .Net 6
 [reprocessing] DomainBuildErrorEventArgs (not sealed) became read-only structure

--- a/Orm/Xtensive.Orm.Tests/App.config
+++ b/Orm/Xtensive.Orm.Tests/App.config
@@ -125,15 +125,22 @@
         <ignoreRules>
           <rule database="Other-DO40-Tests" schema="some-schema1" table="table1"/>
           <rule database="some-database" schema="some-schema2" column="column2"/>
+          <rule database="some-database" schema="some-schema2" index="index2"/>
           <rule database="some-database" schema="some-schema3" table="table2" column="col3"/>
+          <rule database="some-database" schema="some-schema3" table="table2" index="index3"/>
           <rule database="another-some-database" table="some-table" />
           <rule database="database1" column ="some-column"/>
+          <rule database="database1" index ="some-index"/>
           <rule schema="schema1" table="table1"/>
           <rule schema="schema1" column="column2"/>
+          <rule schema="schema1" index="index2" />
           <rule schema="schema1" table="table2" column="column3"/>
+          <rule schema="schema1" table="table2" index="index3"/>
           <rule table="table4" column="column3"/>
+          <rule table="table4" index ="index2" />
           <rule table="single-table"/>
           <rule column="single-column"/>
+          <rule index ="single-index" />
         </ignoreRules>
         <databases>
           <database name="main" realName="DO40-Tests" />

--- a/Orm/Xtensive.Orm.Tests/Configuration/AppConfigTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Configuration/AppConfigTest.cs
@@ -203,8 +203,8 @@ namespace Xtensive.Orm.Tests.Configuration
 
       var good = configuration.Clone();
       good.IgnoreRules.Clear();
-      good.IgnoreRules.IgnoreTable("ignored-table").WhenDatabase("Other-DO40-Test").WhenSchema("dbo");
-      good.IgnoreRules.IgnoreColumn("ignored-column");
+      _ = good.IgnoreRules.IgnoreTable("ignored-table").WhenDatabase("Other-DO40-Test").WhenSchema("dbo");
+      _ = good.IgnoreRules.IgnoreColumn("ignored-column");
       good.Lock();
     }
 
@@ -382,13 +382,136 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       Assert.That(configuration.DefaultDatabase, Is.EqualTo("main"));
       Assert.That(configuration.DefaultSchema, Is.EqualTo("dbo"));
-      Assert.That(configuration.IgnoreRules.Count, Is.EqualTo(11));
-      var rule = configuration.IgnoreRules[0];
+
+      var rules = configuration.IgnoreRules;
+      Assert.That(rules.Count, Is.EqualTo(18));
+
+      var rule = rules[0];
       Assert.That(rule.Database, Is.EqualTo("Other-DO40-Tests"));
-      var rule2 = configuration.IgnoreRules[2];
-      Assert.That(rule2.Schema, Is.EqualTo("some-schema3"));
-      Assert.That(rule2.Table, Is.EqualTo("table2"));
-      Assert.That(rule2.Column, Is.EqualTo("col3"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema1"));
+      Assert.That(rule.Table, Is.EqualTo("table1"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[1];
+      Assert.That(rule.Database, Is.EqualTo("some-database"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema2"));
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.EqualTo("column2"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[2];
+      Assert.That(rule.Database, Is.EqualTo("some-database"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema2"));
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index2"));
+
+      rule = rules[3];
+      Assert.That(rule.Database, Is.EqualTo("some-database"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema3"));
+      Assert.That(rule.Table, Is.EqualTo("table2"));
+      Assert.That(rule.Column, Is.EqualTo("col3"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[4];
+      Assert.That(rule.Database, Is.EqualTo("some-database"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema3"));
+      Assert.That(rule.Table, Is.EqualTo("table2"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index3"));
+
+      rule = rules[5];
+      Assert.That(rule.Database, Is.EqualTo("another-some-database"));
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.EqualTo("some-table"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[6];
+      Assert.That(rule.Database, Is.EqualTo("database1"));
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.EqualTo("some-column"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[7];
+      Assert.That(rule.Database, Is.EqualTo("database1"));
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("some-index"));
+
+      rule = rules[8];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.EqualTo("table1"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[9];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.EqualTo("column2"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[10];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index2"));
+
+      rule = rules[11];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.EqualTo("table2"));
+      Assert.That(rule.Column, Is.EqualTo("column3"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[12];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.EqualTo("table2"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index3"));
+
+      rule = rules[13];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.EqualTo("table4"));
+      Assert.That(rule.Column, Is.EqualTo("column3"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[14];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.EqualTo("table4"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index2"));
+
+      rule = rules[15];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.EqualTo("single-table"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[16];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.EqualTo("single-column"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[17];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("single-index"));
+
       var databases = configuration.Databases;
       Assert.That(databases.Count, Is.EqualTo(2));
       Assert.That(databases[0].Name, Is.EqualTo("main"));

--- a/Orm/Xtensive.Orm.Tests/Configuration/SchemaTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Configuration/SchemaTest.cs
@@ -1,11 +1,10 @@
-﻿// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2013-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alena Mikshina
 // Created:    2013.10.04
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Xml;
@@ -18,13 +17,13 @@ namespace Xtensive.Orm.Tests.Configuration
   [TestFixture]
   public class SchemaTest
   {
-    private const string originalConfigFileName = "Xtensive.Orm.Tests.dll.config";
-    private const string xsdFileName = "Xtensive.Orm.xsd";
-    private const string xsdInLowerCaseFileName = "Test.xsd";
-    private const string configFileName = "Test.config";
-    private const string originalRootElementName = "AppConfigTest";
-    private const string rootElementName = "Xtensive.Orm";
-    private const string configXmlNamespace = "http://dataobjects.net/schemas/appconfig/";
+    private const string OriginalConfigFileName = "Xtensive.Orm.Tests.dll.config";
+    private const string XsdFileName = "Xtensive.Orm.xsd";
+    private const string XsdInLowerCaseFileName = "Test.xsd";
+    private const string ConfigFileName = "Test.config";
+    private const string OriginalRootElementName = "AppConfigTest";
+    private const string RootElementName = "Xtensive.Orm";
+    private const string ConfigXmlNamespace = "http://dataobjects.net/schemas/appconfig/";
     private bool hasErrors;
 
     [Test]
@@ -32,36 +31,32 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       hasErrors = false;
 
-      XElement segmentConfig = XElement.Load(originalConfigFileName).Element(originalRootElementName);
-      Debug.Assert(segmentConfig!=null, "segmentConfig != null");
-      segmentConfig.Name = rootElementName;
+      var segmentConfig = XElement.Load(OriginalConfigFileName).Element(OriginalRootElementName);
+      Debug.Assert(segmentConfig != null, "segmentConfig != null");
+      segmentConfig.Name = RootElementName;
 
-      foreach (XElement element in segmentConfig.DescendantsAndSelf())
-        element.Name = (XNamespace) configXmlNamespace + element.Name.LocalName;
+      foreach (var element in segmentConfig.DescendantsAndSelf()) {
+        element.Name = (XNamespace) ConfigXmlNamespace + element.Name.LocalName;
+      }
 
-      using (StreamWriter segmentConfigWriter = File.CreateText(configFileName))
+      using (var segmentConfigWriter = File.CreateText(ConfigFileName)) {
         segmentConfigWriter.Write(segmentConfig.ToString().ToLower());
+      }
 
       ChangeXsdElementsToLowerCase();
 
       try {
-        XmlReaderSettings schemaSettings = new XmlReaderSettings();
-        schemaSettings.Schemas.Add(configXmlNamespace, xsdInLowerCaseFileName);
+        var schemaSettings = new XmlReaderSettings();
+        _ = schemaSettings.Schemas.Add(ConfigXmlNamespace, XsdInLowerCaseFileName);
         schemaSettings.ValidationType = ValidationType.Schema;
         schemaSettings.ValidationEventHandler += new ValidationEventHandler(ValidationHandler);
 
-        XmlReader configReader = XmlReader.Create(configFileName, schemaSettings);
+        var configReader = XmlReader.Create(ConfigFileName, schemaSettings);
         while (configReader.Read()) {
         }
         configReader.Close();
       }
       catch (XmlException exception) {
-        hasErrors = true;
-        Console.WriteLine("{0}: {1}", exception.GetType(), exception.Message);
-        Console.WriteLine("LineNumber = {0}", exception.LineNumber);
-        Console.WriteLine("LinePosition = {0}", exception.LinePosition);
-      }
-      catch (XmlSchemaValidationException exception) {
         hasErrors = true;
         Console.WriteLine("{0}: {1}", exception.GetType(), exception.Message);
         Console.WriteLine("LineNumber = {0}", exception.LineNumber);
@@ -86,33 +81,39 @@ namespace Xtensive.Orm.Tests.Configuration
         Console.WriteLine("{0}: {1}", exception.GetType(), exception.Message);
       }
       finally {
-        File.Delete(configFileName);
-        File.Delete(xsdInLowerCaseFileName);
+        File.Delete(ConfigFileName);
+        File.Delete(XsdInLowerCaseFileName);
       }
 
       Assert.IsFalse(hasErrors);
     }
 
-    public void ValidationHandler(object sender, ValidationEventArgs exception)
+    public void ValidationHandler(object sender, ValidationEventArgs validationEventArgs)
     {
       hasErrors = true;
-      Console.WriteLine("({0}) {1}: {2}", exception.Severity, exception.GetType(), exception.Message);
+      var exception = validationEventArgs.Exception;
+      Console.WriteLine($"({validationEventArgs.Severity}) {exception.GetType()}: {validationEventArgs.Message}");
+      Console.WriteLine($"LineNumber = {exception.LineNumber}");
+      Console.WriteLine($"LinePosition = {exception.LinePosition}");
     }
 
     private static void ChangeXsdElementsToLowerCase()
     {
-      var elementsUsedInXsd = new List<string> {"element", "complexType", "attribute", "simpleType", "restriction", "enumeration", "pattern"};
+      var elementsUsedInXsd = new string[] { "element", "complexType", "attribute", "simpleType", "restriction", "enumeration", "pattern" };
 
-      XNamespace namespaceXsd = XNamespace.Get("http://www.w3.org/2001/XMLSchema");
-      XElement xsdWithElementsToLowerCase = XElement.Load(xsdFileName);
+      var namespaceXsd = XNamespace.Get("http://www.w3.org/2001/XMLSchema");
+      var xsdWithElementsToLowerCase = XElement.Load(XsdFileName);
 
-      foreach (var element in elementsUsedInXsd)
-        foreach (var attributes in xsdWithElementsToLowerCase.Descendants(namespaceXsd + element))
-          foreach (var attribute in attributes.Attributes())
+      foreach (var element in elementsUsedInXsd) {
+        foreach (var attributes in xsdWithElementsToLowerCase.Descendants(namespaceXsd + element)) {
+          foreach (var attribute in attributes.Attributes()) {
             attribute.Value = attribute.Value.ToLower();
+          }
+        }
+      }
 
-      using (StreamWriter xElementXsdWriter = File.CreateText(xsdInLowerCaseFileName))
-        xElementXsdWriter.Write(xsdWithElementsToLowerCase);
+      using var xElementXsdWriter = File.CreateText(XsdInLowerCaseFileName);
+      xElementXsdWriter.Write(xsdWithElementsToLowerCase);
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/IgnoreRulesConfigureTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/IgnoreRulesConfigureTest.cs
@@ -9,7 +9,7 @@ using Xtensive.Orm.Configuration;
 namespace Xtensive.Orm.Tests.Storage
 {
   [TestFixture]
-  public class IngoreRulesConfigureTest
+  public class IgnoreRulesConfigureTest
   {
     [Test]
     public void NoColumnOrTableIgnoredTest()

--- a/Orm/Xtensive.Orm.Tests/Storage/IgnoreRulesHandlerTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/IgnoreRulesHandlerTest.cs
@@ -1,0 +1,1276 @@
+// Copyright (C) 2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Linq;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Providers;
+using Xtensive.Sql;
+using Xtensive.Sql.Model;
+using Xtensive.Orm.Upgrade;
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  [TestFixture]
+  public class IgnoreRulesHandlerTest
+  {
+    private readonly struct TestSetting
+    {
+      public SchemaExtractionResult ExtractionResult { get; init; }
+      public DomainConfiguration DomainConfiguration { get; init; }
+      public MappingResolver MappingResolver { get; init; }
+    }
+
+    #region Ignore Table
+
+    [Test]
+    public void Test01()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(original.Catalogs[0].DefaultSchema.Tables.Any(t => t.Name == "prefix-table"), Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreTable("prefix-table");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(processingResults.Catalogs[0].DefaultSchema.Tables.Any(t => t.Name == "prefix-table"), Is.False);
+    }
+
+    [Test]
+    public void Test02()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(original.Catalogs[0].Schemas["dbo"].Tables.Any(t => t.Name == "prefix-table"), Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreTable("prefix-table").WhenSchema("dbo");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(processingResults.Catalogs[0].Schemas["dbo"].Tables.Any(t => t.Name == "prefix-table"), Is.False);
+    }
+
+    [Test]
+    public void Test03()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(original.Catalogs["prefix-db"].DefaultSchema.Tables.Any(t => t.Name == "prefix-table"), Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreTable("prefix-table").WhenDatabase("prefix-db");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(processingResults.Catalogs["prefix-db"].DefaultSchema.Tables.Any(t => t.Name == "prefix-table"), Is.False);
+    }
+
+    [Test]
+    public void Test04()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db-suffix"].Schemas["prefix-dbo"].Tables.Any(t => t.Name == "prefix-table"),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreTable("prefix-table").WhenDatabase("prefix-db-suffix").WhenSchema("prefix-dbo");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs["prefix-db-suffix"].Schemas["prefix-dbo"].Tables.Any(t => t.Name == "prefix-table"),
+        Is.False);
+    }
+
+    [Test]
+    public void Test05()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].Schemas["dbo"].Tables.Any(t => t.Name.StartsWith("prefix-") || t.Name.EndsWith("-suffix")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreTable("prefix-*");
+      _ = ignoreCollection.IgnoreTable("*-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].DefaultSchema.Tables.Any(t => t.Name.StartsWith("prefix-") || t.Name.EndsWith("-suffix")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test06()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].Schemas["dbo"].Tables.Any(t => t.Name.StartsWith("prefix-") || t.Name.EndsWith("-suffix")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreTable("prefix-*").WhenSchema("dbo");
+      _ = ignoreCollection.IgnoreTable("*-suffix").WhenSchema("dbo");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].Schemas["dbo"].Tables.Any(t => t.Name.StartsWith("prefix-") || t.Name.EndsWith("-suffix")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test07()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db"].DefaultSchema.Tables.Any(t => t.Name.StartsWith("prefix-") || t.Name.EndsWith("-suffix")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreTable("prefix-*").WhenDatabase("prefix-db");
+      _ = ignoreCollection.IgnoreTable("*-suffix").WhenDatabase("prefix-db");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs["prefix-db"].DefaultSchema.Tables.Any(t => t.Name.StartsWith("prefix-") || t.Name.EndsWith("-suffix")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test08()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db-suffix"].Schemas["prefix-dbo"].Tables.Any(t => t.Name.StartsWith("prefix-") || t.Name.EndsWith("-suffix")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreTable("prefix-*").WhenDatabase("prefix-db-suffix").WhenSchema("prefix-dbo");
+      _ = ignoreCollection.IgnoreTable("*-suffix").WhenDatabase("prefix-db-suffix").WhenSchema("prefix-dbo");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs["prefix-db-suffix"].Schemas["prefix-dbo"].Tables.Any(t => t.Name.StartsWith("prefix-") || t.Name.EndsWith("-suffix")),
+        Is.False);
+    }
+
+    #endregion
+
+    #region Ignore columns
+
+    [Test]
+    public void Test09()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables["prefix-table"].Columns.Any(c => c.Name.StartsWith("prefix-")),
+        Is.True);
+      Assert.That(
+        original.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables["table-suffix"].Columns.Any(c => c.Name.EndsWith("-suffix")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreColumn("prefix-*").WhenTable("prefix-table").WhenSchema("prefix-dbo").WhenDatabase("prefix-db");
+      _ = ignoreCollection.IgnoreColumn("*-suffix").WhenTable("table-suffix").WhenSchema("dbo-suffix").WhenDatabase("db-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables["prefix-table"].Columns.Any(c => c.Name.StartsWith("prefix-")),
+        Is.False);
+      Assert.That(
+        processingResults.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables["table-suffix"].Columns.Any(c => c.Name.EndsWith("-suffix")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test10()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Columns)
+          .Any(c => c.Name.StartsWith("prefix-")),
+        Is.True);
+      Assert.That(
+        original.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables
+          .Where(t => t.Name.EndsWith("-suffix"))
+          .SelectMany(t => t.Columns).Any(c => c.Name.EndsWith("-suffix")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreColumn("prefix-*").WhenTable("prefix-*").WhenSchema("prefix-dbo").WhenDatabase("prefix-db");
+      _ = ignoreCollection.IgnoreColumn("*-suffix").WhenTable("*-suffix").WhenSchema("dbo-suffix").WhenDatabase("db-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables
+          .Where(t =>t.Name.StartsWith("prefix-"))
+          .SelectMany(t=>t.Columns)
+          .Any(c => c.Name.StartsWith("prefix-")),
+        Is.False);
+      Assert.That(
+        processingResults.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables
+          .Where(t => t.Name.EndsWith("-suffix"))
+          .SelectMany(t =>t.Columns).Any(c => c.Name.EndsWith("-suffix")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test11()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables
+          .Where(t => t.Name.StartsWith("prefix-")).SelectMany(t => t.Columns)
+          .Any(c => c.Name == "prefix-column"),
+        Is.True);
+      Assert.That(
+        original.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables
+          .Where(t => t.Name.EndsWith("-suffix")).SelectMany(t => t.Columns)
+          .Any(c => c.Name == "column-suffix"),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreColumn("prefix-column").WhenTable("prefix-*").WhenSchema("prefix-dbo").WhenDatabase("prefix-db");
+      _ = ignoreCollection.IgnoreColumn("column-suffix").WhenTable("*-suffix").WhenSchema("dbo-suffix").WhenDatabase("db-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables
+          .Where(t => t.Name.StartsWith("prefix-")).SelectMany(t => t.Columns)
+          .Any(c => c.Name == "prefix-column"),
+        Is.False);
+      Assert.That(
+        processingResults.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables
+          .Where(t => t.Name.EndsWith("-suffix")).SelectMany(t => t.Columns)
+          .Any(c => c.Name == "column-suffix"),
+        Is.False);
+    }
+
+    [Test]
+    public void Test12()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables["prefix-table"].Columns.Any(c => c.Name == "prefix-column"),
+        Is.True);
+      Assert.That(
+        original.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables["table-suffix"].Columns.Any(c => c.Name == "column-suffix"),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreColumn("prefix-column").WhenTable("prefix-table").WhenSchema("prefix-dbo").WhenDatabase("prefix-db");
+      _ = ignoreCollection.IgnoreColumn("column-suffix").WhenTable("table-suffix").WhenSchema("dbo-suffix").WhenDatabase("db-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+
+      Assert.That(
+        processingResults.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables["prefix-table"].Columns.Any(c => c.Name == "prefix-column"),
+        Is.False);
+      Assert.That(
+        processingResults.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables["table-suffix"].Columns.Any(c => c.Name == "column-suffix"),
+        Is.False);
+    }
+
+    [Test]
+    public void Test13()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Columns)
+          .Any(c => c.Name.StartsWith("prefix-")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreColumn("prefix-*").WhenTable("prefix-*");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].DefaultSchema.Tables
+          .Where(t=>t.Name.StartsWith("prefix-"))
+          .SelectMany(t=>t.Columns)
+          .Any(c => c.Name.StartsWith("prefix-")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test14()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].DefaultSchema.Tables["prefix-table"].Columns
+          .Any(c => c.Name.StartsWith("prefix-")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreColumn("prefix-*").WhenTable("prefix-table");
+      _ = ignoreCollection.IgnoreColumn("*-suffix").WhenTable("table-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].DefaultSchema.Tables["prefix-table"].Columns
+          .Any(c => c.Name.StartsWith("prefix-")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test15()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Columns)
+          .Any(c => c.Name == "prefix-column"),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreColumn("prefix-column").WhenTable("prefix-*");
+      _ = ignoreCollection.IgnoreColumn("column-suffix").WhenTable("*-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Columns)
+          .Any(c => c.Name == "prefix-column"),
+        Is.False);
+    }
+
+    [Test]
+    public void Test16()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name == "prefix-table")
+          .SelectMany(t => t.Columns)
+          .Any(c => c.Name == "prefix-column"),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreColumn("prefix-column").WhenTable("prefix-table");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name == "prefix-table")
+          .SelectMany(t => t.Columns)
+          .Any(c => c.Name == "prefix-column"),
+        Is.False);
+    }
+
+    #endregion
+
+    #region Ignore indexes
+
+    [Test]
+    public void Test17()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables["prefix-table"].Indexes.Any(c => c.Name.StartsWith("ix_pref-")),
+        Is.True);
+      Assert.That(
+        original.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables["table-suffix"].Indexes.Any(c => c.Name.EndsWith("-suf")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreIndex("ix_pref-*").WhenTable("prefix-table").WhenSchema("prefix-dbo").WhenDatabase("prefix-db");
+      _ = ignoreCollection.IgnoreIndex("*-suf").WhenTable("table-suffix").WhenSchema("dbo-suffix").WhenDatabase("db-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables["prefix-table"].Indexes.Any(c => c.Name.StartsWith("ix_pref-")),
+        Is.False);
+      Assert.That(
+        processingResults.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables["table-suffix"].Indexes.Any(c => c.Name.EndsWith("-suf")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test18()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name.StartsWith("ix_pref-")),
+        Is.True);
+      Assert.That(
+        original.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables
+          .Where(t => t.Name.EndsWith("-suffix"))
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name.EndsWith("-suf")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreIndex("ix_pref-*").WhenTable("prefix-*").WhenSchema("prefix-dbo").WhenDatabase("prefix-db");
+      _ = ignoreCollection.IgnoreIndex("*-suf").WhenTable("*-suffix").WhenSchema("dbo-suffix").WhenDatabase("db-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name.StartsWith("ix_pref-")),
+        Is.False);
+      Assert.That(
+        processingResults.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables
+          .Where(t => t.Name.EndsWith("-suffix"))
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name.EndsWith("-suf")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test19()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables
+          .Where(t => t.Name.StartsWith("prefix-")).SelectMany(t => t.Indexes)
+          .Any(c => c.Name == "ix_pref-index"),
+        Is.True);
+      Assert.That(
+        original.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables
+          .Where(t => t.Name.EndsWith("-suffix")).SelectMany(t => t.Indexes)
+          .Any(c => c.Name == "ix_index-suf"),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreIndex("ix_pref-index").WhenTable("prefix-*").WhenSchema("prefix-dbo").WhenDatabase("prefix-db");
+      _ = ignoreCollection.IgnoreIndex("ix_index-suf").WhenTable("*-suffix").WhenSchema("dbo-suffix").WhenDatabase("db-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables
+          .Where(t => t.Name.StartsWith("prefix-")).SelectMany(t => t.Indexes)
+          .Any(c => c.Name == "ix_pref-index"),
+        Is.False);
+      Assert.That(
+        processingResults.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables
+          .Where(t => t.Name.EndsWith("-suffix")).SelectMany(t => t.Indexes)
+          .Any(c => c.Name == "ix_index-suf"),
+        Is.False);
+    }
+
+    [Test]
+    public void Test20()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables["prefix-table"].Indexes.Any(c => c.Name == "ix_pref-index"),
+        Is.True);
+      Assert.That(
+        original.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables["table-suffix"].Indexes.Any(c => c.Name == "ix_index-suf"),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreIndex("ix_pref-index").WhenTable("prefix-table").WhenSchema("prefix-dbo").WhenDatabase("prefix-db");
+      _ = ignoreCollection.IgnoreIndex("ix_index-suf").WhenTable("table-suffix").WhenSchema("dbo-suffix").WhenDatabase("db-suffix");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+
+      Assert.That(
+        processingResults.Catalogs["prefix-db"].Schemas["prefix-dbo"].Tables["prefix-table"].Indexes.Any(c => c.Name == "ix_pref-index"),
+        Is.False);
+      Assert.That(
+        processingResults.Catalogs["db-suffix"].Schemas["dbo-suffix"].Tables["table-suffix"].Indexes.Any(c => c.Name == "ix_index-suf"),
+        Is.False);
+    }
+
+    [Test]
+    public void Test21()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name.StartsWith("ix_pref-")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreIndex("ix_pref-*").WhenTable("prefix-*");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name.StartsWith("ix_pref-")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test22()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].DefaultSchema.Tables["prefix-table"].Indexes
+          .Any(c => c.Name.StartsWith("ix_pref-")),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreIndex("ix_pref-*").WhenTable("prefix-table");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].DefaultSchema.Tables["prefix-table"].Indexes
+          .Any(c => c.Name.StartsWith("ix_pref-")),
+        Is.False);
+    }
+
+    [Test]
+    public void Test23()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name == "ix_pref-index-suf"),
+        Is.True);
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreIndex("ix_pref-index-suf").WhenTable("prefix-*");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name.StartsWith("prefix-"))
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name == "ix_pref-index-suf"),
+        Is.False);
+    }
+
+    [Test]
+    public void Test24()
+    {
+      var settings = CreateTestSettings();
+      var original = settings.ExtractionResult;
+
+      Assert.That(
+        original.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name == "prefix-table")
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name == "ix_pref-index-suf"),
+        Is.True);
+
+
+      var ignoreCollection = new IgnoreRuleCollection();
+      _ = ignoreCollection.IgnoreIndex("ix_pref-index-suf").WhenTable("prefix-table");
+
+      var processingResults = GetProcessedResults(settings, ignoreCollection);
+      Assert.That(
+        processingResults.Catalogs[0].DefaultSchema.Tables
+          .Where(t => t.Name == "prefix-table")
+          .SelectMany(t => t.Indexes)
+          .Any(c => c.Name == "ix_pref-index-suf"),
+        Is.False);
+    }
+
+    #endregion
+
+    private SchemaExtractionResult GetProcessedResults(in TestSetting settings, IgnoreRuleCollection rules)
+    {
+      var configuration = settings.DomainConfiguration;
+      configuration.IgnoreRules = rules;
+      return new IgnoreRulesHandler(settings.ExtractionResult, settings.DomainConfiguration, settings.MappingResolver)
+        .Handle();
+    }
+
+    private static TestSetting CreateTestSettings()
+    {
+      var nodeConfiguration = new NodeConfiguration();
+      var configuration = DomainConfigurationFactory.Create();
+      configuration.DefaultDatabase = "DO-Tests";
+      configuration.DefaultSchema = "dbo";
+      configuration.Databases.Add(new DatabaseConfiguration("DO-Tests") { RealName = "DO-Tests" });
+      configuration.Databases.Add(new DatabaseConfiguration("prefix-db") { RealName = "prefix-db" });
+      configuration.Databases.Add(new DatabaseConfiguration("prefix-db-suffix") { RealName = "prefix-db-suffix" });
+      configuration.Databases.Add(new DatabaseConfiguration("db-suffix") { RealName = "db-suffix" });
+
+      var extResult = new SqlExtractionResult();
+      extResult.Catalogs.Add(CreateDefaultCatalogAndSchema());
+      extResult.Catalogs.Add(CreateCatalogTemplate("prefix-db"));
+      extResult.Catalogs.Add(CreateCatalogTemplate("prefix-db-suffix"));
+      extResult.Catalogs.Add(CreateCatalogTemplate("db-suffix"));
+
+      var resolver = MappingResolver.Create(configuration, nodeConfiguration, new Sql.Info.DefaultSchemaInfo("DO-Tests", "dbo"));
+
+      return new TestSetting {
+        ExtractionResult = new SchemaExtractionResult(extResult),
+        DomainConfiguration = configuration,
+        MappingResolver = resolver
+      };
+    }
+
+    private static Catalog CreateDefaultCatalogAndSchema()
+    {
+      var catalog = new Catalog("DO-Tests");
+      var schema = catalog.CreateSchema("dbo");
+      catalog.DefaultSchema = schema;
+
+      var table = schema.CreateTable("prefix-table");
+      var column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      var index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      return catalog;
+    }
+
+    private static Catalog CreateCatalogTemplate(string name)
+    {
+      var catalog = new Catalog(name);
+      var schema = catalog.CreateSchema("prefix-dbo");
+
+      #region catalog1-schema1-table1
+
+      var table = schema.CreateTable("prefix-table");
+      var column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      var index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      #endregion
+
+      #region catalog1-schema1-table2
+
+      table = schema.CreateTable("prefix-table-suffix");
+      column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      #endregion
+
+      #region catalog1-schema1-table3
+
+      table = schema.CreateTable("table-suffix");
+      column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      #endregion
+
+      schema = catalog.CreateSchema("dbo");
+      catalog.DefaultSchema = schema;
+
+      #region catalog1-schema2-table1
+
+      table = schema.CreateTable("prefix-table");
+      column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      #endregion
+
+      #region catalog1-schema2-table2
+
+      table = schema.CreateTable("prefix-table-suffix");
+      column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      #endregion
+
+      #region catalog1-schema2-table3
+
+      table = schema.CreateTable("table-suffix");
+      column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      #endregion
+
+      schema = catalog.CreateSchema("dbo-suffix");
+
+      #region catalog1-schema3-table1
+
+      table = schema.CreateTable("prefix-table");
+      column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      #endregion
+
+      #region catalog1-schema3-table2
+
+      table = schema.CreateTable("prefix-table-suffix");
+      column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      #endregion
+
+      #region catalog1-schema3-table3
+
+      table = schema.CreateTable("table-suffix");
+      column = table.CreateColumn("Id", new SqlValueType(SqlType.Int64));
+      column.IsNullable = false;
+      _ = table.CreatePrimaryKey("pk_prefix-table-suffix", column);
+
+      column = table.CreateColumn("Name", new SqlValueType(SqlType.VarChar, 100));
+      column.IsNullable = false;
+
+      _ = table.CreateColumn("prefix-column", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("prefix-column-suffix", new SqlValueType(SqlType.Int64));
+      _ = table.CreateColumn("column-suffix", new SqlValueType(SqlType.Int64));
+
+      //normal index
+      index = table.CreateIndex("ix_normal-index");
+      column = table.CreateColumn("normal-idx-column1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("normal-idx-column2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("normal-idx-incl-column2", new SqlValueType(SqlType.VarChar, 100)));
+
+      //ignored index1
+      index = table.CreateIndex("ix_pref-index");
+      column = table.CreateColumn("pref-idx-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index2
+      index = table.CreateIndex("ix_pref-index-suf");
+      column = table.CreateColumn("pref-idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("pref-idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("pref-idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      // ignored index3
+      index = table.CreateIndex("ix_index-suf");
+      column = table.CreateColumn("idx-suf-col1", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      column = table.CreateColumn("idx-suf-col2", new SqlValueType(SqlType.Int64));
+      _ = index.CreateIndexColumn(column);
+
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col1", new SqlValueType(SqlType.VarChar, 100)));
+      index.NonkeyColumns.Add(table.CreateColumn("idx-suf-incl-col2", new SqlValueType(SqlType.VarChar, 100)));
+
+      #endregion
+
+      return catalog;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Storage/IgnoreRulesValidateTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/IgnoreRulesValidateTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2021 Xtensive LLC.
+// Copyright (C) 2013-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
@@ -14,14 +14,14 @@ using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Providers;
 using Xtensive.Sql;
 using Xtensive.Sql.Compiler;
-using Xtensive.Sql.Ddl;
-using Xtensive.Sql.Dml;
 using Xtensive.Sql.Model;
 using Model1 = Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel1;
 using ignorablePart = Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel2;
 using Model2 = Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel3;
 using Model3 = Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel4;
 using Model4 = Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel5;
+using Model5 = Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel6;
+using Model6 = Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel7;
 
 namespace Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel1
 {
@@ -133,18 +133,19 @@ namespace Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel2
       var field = orderType.DefineField("SomeIgnoredField", typeof (string));
       field.Length = 100;
 
-      IndexDef indexDef;
-      if (orderType.Indexes.TryGetValue("IndexName", out indexDef)) {
+      if (orderType.Indexes.TryGetValue("IndexName", out var indexDef)) {
         var fieldsBefore = indexDef.KeyFields.ToList();
         indexDef.KeyFields.Clear();
         indexDef.KeyFields.Add("SomeIgnoredField", Direction.Positive);
-        foreach (var keyValuePair in fieldsBefore)
+        foreach (var keyValuePair in fieldsBefore) {
           indexDef.KeyFields.Add(keyValuePair.Key, keyValuePair.Value);
+        }
       }
 
       var ignoredTable = model.Types[typeof (IgnoredTable)];
-      if (ignoredTable==null)
+      if (ignoredTable == null) {
         return;
+      }
 
       var authorType = model.Types[typeof (Model1.Author)];
       field = authorType.DefineField("IgnoredColumn", ignoredTable.UnderlyingType);
@@ -234,7 +235,11 @@ namespace Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel4
 
     [Field]
     public string FirstColumn { get; set; }
+
+    [Field]
+    public int IndexedValue { get; set; }
   }
+
   [HierarchyRoot]
   public class MyEntity2 : Entity
   {
@@ -243,6 +248,9 @@ namespace Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel4
 
     [Field]
     public string FirstColumn { get; set; }
+
+    [Field]
+    public int IndexedValue { get; set; }
   }
 }
 
@@ -250,6 +258,61 @@ namespace Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel5
 {
   [HierarchyRoot]
   public class MyEntity1 : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+
+    [Field]
+    public string FirstColumn { get; set; }
+
+    [Field]
+    public int IndexedValue { get; set; }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel6
+{
+  [HierarchyRoot]
+  public class MyEntity1 : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+
+    [Field]
+    public string FirstColumn { get; set; }
+
+    [Field]
+    public int IndexedValue { get; set; }
+  }
+
+  [HierarchyRoot]
+  public class MyEntity2 : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+
+    [Field]
+    public int IndexedValue { get; set; }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Storage.IgnoreRulesValidateModel7
+{
+  [HierarchyRoot]
+  public class MyEntity1 : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+
+    [Field]
+    public string FirstColumn { get; set; }
+
+    [Field]
+    public int IndexedValue { get; set; }
+  }
+
+  [HierarchyRoot]
+  public class MyEntity2 : Entity
   {
     [Field, Key]
     public long Id { get; private set; }
@@ -264,24 +327,27 @@ namespace Xtensive.Orm.Tests.Storage
   [TestFixture]
   public class IgnoreRulesValidateTest
   {
-    private const string defaultSchema = WellKnownSchemas.Schema1;
+    private const string DefaultSchema = WellKnownSchemas.Schema1;
     private const string Schema1 = WellKnownSchemas.Schema2;
     private const string Schema2 = WellKnownSchemas.Schema3;
 
-    private SqlDriver sqlDriver;
+    private readonly Type[] model1Types = new[] { typeof(Model1.Author), typeof(Model1.Book), typeof(Model1.Customer), typeof(Model1.Order), typeof(Model1.Person) };
+    private readonly Type[] model2Types = new[] { typeof(Model2.Author), typeof(Model2.Book), typeof(Model2.Customer), typeof(Model2.Order), typeof(Model2.Person) };
+    private readonly Type[] model3Types = new[] { typeof(Model3.MyEntity1), typeof(Model3.MyEntity2) };
+    private readonly Type[] model4Types = new[] { typeof(Model4.MyEntity1) };
+    private readonly Type[] model5Types = new[] { typeof(Model5.MyEntity1), typeof(Model5.MyEntity2) };
+    private readonly Type[] model6Types = new[] { typeof(Model6.MyEntity1), typeof(Model6.MyEntity2) };
+
+    private readonly Type[] model1PlusIgnorable = new[] {
+      typeof(Model1.Author), typeof(Model1.Book), typeof(Model1.Customer), typeof(Model1.Order), typeof(Model1.Person),
+      typeof(ignorablePart.IgnoredTable), typeof(ignorablePart.FieldInjector) };
+
+    private readonly bool createConstraintsWithTable = StorageProviderInfo.Instance.Provider == StorageProvider.Sqlite;
+    private readonly SqlDriver sqlDriver = TestSqlDriver.Create(GetConnectionInfo());
+
     private Key changedOrderKey;
-    private bool createConstraintsWithTable;
     private bool isMultidatabaseTest;
     private bool isMultischemaTest;
-
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
-    {
-      sqlDriver = TestSqlDriver.Create(GetConnectionInfo());
-      if(StorageProviderInfo.Instance.Provider == StorageProvider.Sqlite) {
-        createConstraintsWithTable = true;
-      }
-    }
 
     [SetUp]
     public void SetUp() => ClearMultidatabaseAndMultischemaFlags();
@@ -303,228 +369,60 @@ namespace Xtensive.Orm.Tests.Storage
     }
 
     [Test]
-    public void IgnoreSimpleColumnTest()
+    public void IgnoreColumnTest()
     {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
 
       var catalog = GetCatalog();
-      var schema = catalog.DefaultSchema.Name;
-      CreateColumn(catalog, schema, "MyEntity2", "SimpleIgnoredColumn", GetTypeForInteger(SqlType.Int32));
-      var ignoreRuleCollection = new IgnoreRuleCollection();
-      _ = ignoreRuleCollection.IgnoreColumn("SimpleIgnoredColumn").WhenTable("MyEntity2");
+      var schemaName = catalog.DefaultSchema.Name;
+      CreateColumn(catalog, schemaName, "MyEntity2", "SimpleIgnoredColumn", GetTypeForInteger(SqlType.Int32));
 
-      BuildSimpleDomain(DomainUpgradeMode.Validate, ignoreRuleCollection, typeof(Model3.MyEntity1)).Dispose();
-    }
+      CreateColumn(catalog, schemaName, "MyEntity2", "IgnoreAFirstColumn", GetTypeForInteger(SqlType.Int64));
+      CreateColumn(catalog, schemaName, "MyEntity2", "IgnoreASecondColumn", GetTypeForInteger(SqlType.Int64));
+      CreateColumn(catalog, schemaName, "MyEntity2", "IgnoreAThirdColumn", GetTypeForInteger(SqlType.Int64));
 
-    [Test]
-    public void IgnoreReferencedColumnTest()
-    {
-      Require.AllFeaturesSupported(ProviderFeatures.ForeignKeyConstraints);
+      CreateColumn(catalog, schemaName, "MyEntity1", "IgnoreBFirstColumn", GetTypeForInteger(SqlType.Int64));
+      CreateColumn(catalog, schemaName, "MyEntity1", "IgnoreBSecondColumn", GetTypeForInteger(SqlType.Int64));
+      CreateColumn(catalog, schemaName, "MyEntity1", "IgnoreBThirdColumn", GetTypeForInteger(SqlType.Int64));
 
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
+      CreateColumn(catalog, schemaName, "MyEntity2", "IgnoreBFirstColumn", GetTypeForInteger(SqlType.Int64));
+      CreateColumn(catalog, schemaName, "MyEntity2", "IgnoreBSecondColumn", GetTypeForInteger(SqlType.Int64));
+      CreateColumn(catalog, schemaName, "MyEntity2", "IgnoreBThirdColumn", GetTypeForInteger(SqlType.Int64));
 
-      var catalog = GetCatalog();
-      var schema = catalog.DefaultSchema.Name;
-      CreateColumn(catalog, schema, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64));
-      CreateForeignKeyInDb(catalog, schema, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity1_MyEntity1ID");
-      var ignoreRuleCollection = new IgnoreRuleCollection();
-      _ = ignoreRuleCollection.IgnoreColumn("ReferencedIgnoredColumn").WhenTable("MyEntity2").WhenSchema(schema);
-
-      BuildSimpleDomain(DomainUpgradeMode.Validate, ignoreRuleCollection, typeof(Model3.MyEntity1)).Dispose();
-    }
-
-    [Test]
-    public void IgnoreSimpleTableTest()
-    {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
-
-      var catalog = GetCatalog();
-      var schema = catalog.DefaultSchema.Name;
-      var addedColumnsNames = new[] { "Id", "FirstColumn" };
-      var addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int32), GetTypeForInteger(SqlType.Int64) };
-
-      if (createConstraintsWithTable) {
-        var delayedOp = CreateTableDelayed(catalog, schema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes);
-        CreatePrimaryKeyLocally(catalog, schema, "MyIgnoredEntity", "Id", "PK_MyIgnoredEntity_Id");
-        delayedOp();
-      }
-      else {
-        CreateTable(catalog, schema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes);
-        CreatePrimaryKeyInDb(catalog, schema, "MyIgnoredEntity", "Id", "PK_MyIgnoredEntity_Id");
-      }
-      var ignoreRules = new IgnoreRuleCollection();
-      _ = ignoreRules.IgnoreTable("MyIgnoredEntity");
-
-      BuildSimpleDomain(DomainUpgradeMode.Validate, ignoreRules, typeof(Model3.MyEntity1)).Dispose();
-    }
-
-    [Test]
-    public void IgnoreReferencedTableTest()
-    {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
-
-      var catalog = GetCatalog();
-      var schema = catalog.DefaultSchema.Name;
-      var addedColumnsNames = new[] { "Id", "FirstColumn", "MyEntity2Id" };
-      var addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int32), GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64) };
-
-      if (createConstraintsWithTable) {
-        var delayedOp = CreateTableDelayed(catalog, schema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes);
-        CreatePrimaryKeyLocally(catalog, schema, "MyIgnoredEntity", "Id", "PK_MyIgnoredEntity_Id");
-        CreateForeignKeyLocally(catalog, schema, "MyIgnoredEntity", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntityMyEntity2Id");
-        delayedOp();
-      }
-      else {
-        CreateTable(catalog, schema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes);
-        CreatePrimaryKeyInDb(catalog, schema, "MyIgnoredEntity", "Id", "PK_MyIgnoredEntity_Id");
-        CreateForeignKeyInDb(catalog, schema, "MyIgnoredEntity", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntityMyEntity2Id");
-      }
-
-      var ignoreRules = new IgnoreRuleCollection();
-      _ = ignoreRules.IgnoreTable("MyIgnoredEntity");
-
-      BuildSimpleDomain(DomainUpgradeMode.Validate, ignoreRules, typeof(Model3.MyEntity1)).Dispose();
-    }
-
-    [Test]
-    public void InsertIntoTableWithIgnoredColumnTest()
-    {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
-
-      var catalog = GetCatalog();
-      var schema = catalog.DefaultSchema.Name;
-      CreateColumn(catalog, schema, "Myentity2", "SimpleIgnoredColumn", GetTypeForInteger(SqlType.Int64));
-      var ignoreRuleCollection = new IgnoreRuleCollection();
-      _ = ignoreRuleCollection.IgnoreColumn("SimpleIgnoredColumn").WhenTable("MyEntity2");
-
-      using (var validatedDomain = BuildSimpleDomain(DomainUpgradeMode.Validate, ignoreRuleCollection, typeof(Model3.MyEntity1)))
-      using (var session = validatedDomain.OpenSession())
-      using (var transaction = session.OpenTransaction()) {
-        _ = new Model3.MyEntity2 { FirstColumn = "some test" };
-        transaction.Complete();
-      }
-      ValidateMyEntity(catalog, schema);
-    }
-
-    [Test]
-    public void InsertIntoTableWithNotNullableIgnoredColumnTest()
-    {
-      Require.ProviderIsNot(StorageProvider.Sqlite);
-
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
-
-      var catalog = GetCatalog();
-      var schema = catalog.Schemas[catalog.DefaultSchema.Name] ?? catalog.Schemas[0];
-
-      schema.Tables["MyEntity2"].CreateColumn("SimpleIgnoredColumn", GetTypeForInteger(SqlType.Int64)).IsNullable = false;
-
-      var alter = SqlDdl.Alter(schema.Tables["MyEntity2"],
-        SqlDdl.AddColumn(schema.Tables["MyEntity2"].TableColumns["SimpleIgnoredColumn"]));
-      var commandText = sqlDriver.Compile(alter).GetCommandText();
-      ExecuteNonQuery(commandText);
-
-      var ignoreRuleCollection = new IgnoreRuleCollection();
-      _ = ignoreRuleCollection.IgnoreColumn("SimpleIgnoredColumn").WhenTable("MyEntity2").WhenSchema(schema.Name);
-
-      _ = Assert.Throws(Is.InstanceOf(typeof(StorageException)), () => {
-        using (var validatedDomain = BuildSimpleDomain(DomainUpgradeMode.Validate, ignoreRuleCollection, typeof(Model3.MyEntity1)))
-        using (var session = validatedDomain.OpenSession())
-        using (var transaction = session.OpenTransaction()) {
-          _ = new Model3.MyEntity2 { FirstColumn = "some test" };
-          transaction.Complete();
-        }
-      });
-    }
-
-    [Test]
-    public void DropTableWithIgnoredColumnTest()
-    {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
-
-      var catalog = GetCatalog();
-      var schema = catalog.DefaultSchema.Name;
-      CreateColumn(catalog, schema, "MyEntity2", "SimpleIgnoredColumn", GetTypeForInteger(SqlType.Int64));
 
       var ignoreRuleCollection = new IgnoreRuleCollection();
       _ = ignoreRuleCollection.IgnoreColumn("SimpleIgnoredColumn").WhenTable("MyEntity2");
+      _ = ignoreRuleCollection.IgnoreColumn("IgnoreA*");
+      _ = ignoreRuleCollection.IgnoreColumn("IgnoreB*").WhenTable("MyEntity*");
 
-      _ = Assert.Throws<SchemaSynchronizationException>(() => {
-        BuildSimpleDomain(DomainUpgradeMode.Perform, ignoreRuleCollection, typeof(Model4.MyEntity1)).Dispose();
-      });
-    }
-
-    [Test]
-    public void DropReferencedTableTest()
-    {
-      Require.AllFeaturesSupported(ProviderFeatures.ForeignKeyConstraints);
-
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
-
-      var catalog = GetCatalog();
-      var schema = catalog.DefaultSchema.Name;
-      CreateColumn(catalog, schema, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64));
-      CreateForeignKeyInDb(catalog, schema, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity1_MyEntity1ID");
-
-      var ignoreRuleCollection = new IgnoreRuleCollection();
-      _ = ignoreRuleCollection.IgnoreColumn("ReferencedIgnoredColumn").WhenTable("MyEntity2").WhenSchema(schema);
-
-      _ = Assert.Throws<SchemaSynchronizationException>(() => {
-        BuildSimpleDomain(DomainUpgradeMode.Perform, ignoreRuleCollection, typeof(Model4.MyEntity1)).Dispose();
-      });
-    }
-
-    [Test]
-    public void IgnoreColumnsByMaskValidateTest()
-    {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
-
-      var catalog = GetCatalog();
-      var schema = catalog.DefaultSchema.Name;
-      CreateColumn(catalog, schema, "MyEntity2", "IgnoreFirstColumn", GetTypeForInteger(SqlType.Int64));
-      CreateColumn(catalog, schema, "MyEntity2", "IgnoreSecondColumn", GetTypeForInteger(SqlType.Int64));
-      CreateColumn(catalog, schema, "MyEntity2", "IgnoreThirdColumn", GetTypeForInteger(SqlType.Int64));
-      var ignoreRules = new IgnoreRuleCollection();
-      _ = ignoreRules.IgnoreColumn("Ignore*");
-
-      BuildSimpleDomain(DomainUpgradeMode.Validate, ignoreRules, typeof(Model3.MyEntity1)).Dispose();
-    }
-
-    [Test]
-    public void IgnoreTablesByMaskValidateTest()
-    {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
-
-      var catalog = GetCatalog();
-      var schema = catalog.DefaultSchema.Name;
-      var addedColumnsNames = new[] { "Id", "FirstColumn", "SecondColumn" };
-      var addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64) };
-
-      if (createConstraintsWithTable) {
-        var delayedOp = CreateTableDelayed(catalog, schema, "IgnoredFirstTable", addedColumnsNames, addedColumnsTypes);
-        CreatePrimaryKeyLocally(catalog, schema, "IgnoredFirstTable", "Id", "PK_IgnoredFirstTable_Id");
-        delayedOp();
-
-        delayedOp = CreateTableDelayed(catalog, schema, "IgnoredSecondTable", addedColumnsNames, addedColumnsTypes);
-        CreatePrimaryKeyLocally(catalog, schema, "IgnoredSecondTable", "Id", "PK_IgnoredSecondTable_Id");
-        delayedOp();
+      if (StorageProviderInfo.Instance.CheckAllFeaturesSupported(ProviderFeatures.ForeignKeyConstraints)) {
+        CreateColumn(catalog, schemaName, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64));
+        CreateForeignKeyInDb(catalog, schemaName, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity1_MyEntity1ID");
+        _ = ignoreRuleCollection.IgnoreColumn("ReferencedIgnoredColumn").WhenTable("MyEntity2").WhenSchema(schemaName);
       }
-      else {
-        CreateTable(catalog, schema, "IgnoredFirstTable", addedColumnsNames, addedColumnsTypes);
-        CreatePrimaryKeyInDb(catalog, schema, "IgnoredFirstTable", "Id", "PK_IgnoredFirstTable_Id");
 
-        CreateTable(catalog, schema, "IgnoredSecondTable", addedColumnsNames, addedColumnsTypes);
-        CreatePrimaryKeyInDb(catalog, schema, "IgnoredSecondTable", "Id", "PK_IgnoredSecondTable_Id");
+      BuildDomain(DomainUpgradeMode.Perform, ignoreRuleCollection, model3Types).Dispose();
+
+      catalog = GetCatalog();
+      var schema = catalog.DefaultSchema;
+
+      var table = schema.Tables["MyEntity2"];
+      Assert.That(table.Columns.Any(c => c.Name == "SimpleIgnoredColumn"), Is.True);
+      Assert.That(table.Columns.Count(c => c.Name.StartsWith("IgnoreA")), Is.EqualTo(3));
+      Assert.That(
+        schema.Tables.Where(t => t.Name.StartsWith("MyEntity")).SelectMany(t => t.Columns).Count(c => c.Name.StartsWith("IgnoreB")),
+        Is.EqualTo(6));
+
+      if (StorageProviderInfo.Instance.CheckAllFeaturesSupported(ProviderFeatures.ForeignKeyConstraints)) {
+        Assert.That(table.Columns.Any(c => c.Name == "ReferencedIgnoredColumn"), Is.True);
+        Assert.That(table.TableConstraints.Any(tc => tc.Name == "FK_MyEntity1_MyEntity1ID"), Is.True);
       }
-      var ignoreRules = new IgnoreRuleCollection();
-      _ = ignoreRules.IgnoreTable("Ignored*");
-
-      BuildSimpleDomain(DomainUpgradeMode.Validate, ignoreRules, typeof(Model3.MyEntity1)).Dispose();
     }
 
     [Test]
-    public void IgnoreAllColumnsInTableByMaskValidateTest()
+    public void IgnoreAllColumnsInTableTest()
     {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
 
       var catalog = GetCatalog();
       var schema = catalog.DefaultSchema.Name;
@@ -543,13 +441,251 @@ namespace Xtensive.Orm.Tests.Storage
       var ignoreRules = new IgnoreRuleCollection();
       _ = ignoreRules.IgnoreColumn("*").WhenTable("IgnoredTable");
 
-      BuildSimpleDomain(DomainUpgradeMode.Validate, ignoreRules, typeof(Model3.MyEntity1)).Dispose();
+      BuildDomain(DomainUpgradeMode.Validate, ignoreRules, model3Types).Dispose();
+    }
+
+    [Test]
+    public void IgnoreIndexTest()
+    {
+      BuildDomain(DomainUpgradeMode.Recreate, null, model1Types).Dispose();
+
+      var schema = GetCatalog().DefaultSchema;
+
+      var keyColumns = new string[] { "ISBN" };
+      CreateIndex(schema, "Book", "IX_GIgnored_Index1", keyColumns, null);
+
+      keyColumns = new string[] { "Title" };
+      CreateIndex(schema, "Book", "IX_GIgnored_Index2", keyColumns, null);
+
+      keyColumns = new string[] { "ISBN" };
+      var includedColimns = new string[] { "Title" };
+
+      CreateIndex(schema, "Book", "IX_Ignored_Index", keyColumns, includedColimns);
+
+
+      var ingnoreRuleCollection = new IgnoreRuleCollection();
+      _ = ingnoreRuleCollection.IgnoreIndex("IX_Ignored_Index").WhenTable("Book");
+      _ = ingnoreRuleCollection.IgnoreIndex("IX_GIgnored*").WhenTable("B*");
+
+      BuildDomain(DomainUpgradeMode.Perform, ingnoreRuleCollection, model1Types).Dispose();
+
+      Assert.That(GetCatalog().DefaultSchema.Tables["Book"].Indexes.Any(i => i.Name == "IX_Ignored_Index"), Is.True);
+      Assert.That(GetCatalog().DefaultSchema.Tables["Book"].Indexes.Count(i => i.Name.StartsWith("IX_GIgnored_Index")), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void IgnoreTableTest()
+    {
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
+
+      var catalog = GetCatalog();
+      var schema = catalog.DefaultSchema.Name;
+
+      if (createConstraintsWithTable) {
+        var addedColumnsNames = new[] { "Id", "FirstColumn" };
+        var addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int32), GetTypeForInteger(SqlType.Int64) };
+
+        var delayedOp = CreateTableDelayed(catalog, schema, "MyIgnoredEntity1", addedColumnsNames, addedColumnsTypes);
+        CreatePrimaryKeyLocally(catalog, schema, "MyIgnoredEntity1", "Id", "PK_MyIgnoredEntity1_Id");
+        delayedOp();
+
+
+        addedColumnsNames = new[] { "Id", "FirstColumn", "MyEntity2Id" };
+        addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int32), GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64) };
+
+        delayedOp = CreateTableDelayed(catalog, schema, "MyIgnoredEntity2", addedColumnsNames, addedColumnsTypes);
+        CreatePrimaryKeyLocally(catalog, schema, "MyIgnoredEntity2", "Id", "PK_MyIgnoredEntity2_Id");
+        CreateForeignKeyLocally(catalog, schema, "MyIgnoredEntity2", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntity2MyEntity2Id");
+        delayedOp();
+
+        addedColumnsNames = new[] { "Id", "FirstColumn", "SecondColumn" };
+        addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64) };
+
+        delayedOp = CreateTableDelayed(catalog, schema, "IgnoredFirstTable", addedColumnsNames, addedColumnsTypes);
+        CreatePrimaryKeyLocally(catalog, schema, "IgnoredFirstTable", "Id", "PK_IgnoredFirstTable_Id");
+        delayedOp();
+
+        delayedOp = CreateTableDelayed(catalog, schema, "IgnoredSecondTable", addedColumnsNames, addedColumnsTypes);
+        CreatePrimaryKeyLocally(catalog, schema, "IgnoredSecondTable", "Id", "PK_IgnoredSecondTable_Id");
+        delayedOp();
+      }
+      else {
+        var addedColumnsNames = new[] { "Id", "FirstColumn" };
+        var addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int32), GetTypeForInteger(SqlType.Int64) };
+
+        CreateTable(catalog, schema, "MyIgnoredEntity1", addedColumnsNames, addedColumnsTypes);
+        CreatePrimaryKeyInDb(catalog, schema, "MyIgnoredEntity1", "Id", "PK_MyIgnoredEntity1_Id");
+
+        addedColumnsNames = new[] { "Id", "FirstColumn", "MyEntity2Id" };
+        addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int32), GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64) };
+
+        CreateTable(catalog, schema, "MyIgnoredEntity2", addedColumnsNames, addedColumnsTypes);
+        CreatePrimaryKeyInDb(catalog, schema, "MyIgnoredEntity2", "Id", "PK_MyIgnoredEntity2_Id");
+        CreateForeignKeyInDb(catalog, schema, "MyIgnoredEntity2", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntity2MyEntity2Id");
+
+
+        addedColumnsNames = new[] { "Id", "FirstColumn", "SecondColumn" };
+        addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64) };
+
+        CreateTable(catalog, schema, "IgnoredFirstTable", addedColumnsNames, addedColumnsTypes);
+        CreatePrimaryKeyInDb(catalog, schema, "IgnoredFirstTable", "Id", "PK_IgnoredFirstTable_Id");
+
+        CreateTable(catalog, schema, "IgnoredSecondTable", addedColumnsNames, addedColumnsTypes);
+        CreatePrimaryKeyInDb(catalog, schema, "IgnoredSecondTable", "Id", "PK_IgnoredSecondTable_Id");
+      }
+
+      var ignoreRules = new IgnoreRuleCollection();
+      _ = ignoreRules.IgnoreTable("MyIgnoredEntity1");
+      _ = ignoreRules.IgnoreTable("MyIgnoredEntity2");
+      _ = ignoreRules.IgnoreTable("Ignored*");
+
+      BuildDomain(DomainUpgradeMode.Validate, ignoreRules, model3Types).Dispose();
+    }
+
+    [Test]
+    public void InsertIntoTableWithIgnoredColumnTest()
+    {
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
+
+      var catalog = GetCatalog();
+      var schema = catalog.DefaultSchema.Name;
+      CreateColumn(catalog, schema, "Myentity2", "SimpleIgnoredColumn", GetTypeForInteger(SqlType.Int64));
+      var ignoreRuleCollection = new IgnoreRuleCollection();
+      _ = ignoreRuleCollection.IgnoreColumn("SimpleIgnoredColumn").WhenTable("MyEntity2");
+
+      using (var validatedDomain = BuildDomain(DomainUpgradeMode.Validate, ignoreRuleCollection, model3Types))
+      using (var session = validatedDomain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        _ = new Model3.MyEntity2 { FirstColumn = "some test" };
+        transaction.Complete();
+      }
+      ValidateMyEntity(catalog, schema);
+    }
+
+    [Test]
+    public void InsertIntoTableWithNotNullableIgnoredColumnTest()
+    {
+      Require.ProviderIsNot(StorageProvider.Sqlite);
+
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
+
+      var catalog = GetCatalog();
+      var schema = catalog.Schemas[catalog.DefaultSchema.Name] ?? catalog.Schemas[0];
+
+      schema.Tables["MyEntity2"].CreateColumn("SimpleIgnoredColumn", GetTypeForInteger(SqlType.Int64)).IsNullable = false;
+
+      var alter = SqlDdl.Alter(schema.Tables["MyEntity2"],
+        SqlDdl.AddColumn(schema.Tables["MyEntity2"].TableColumns["SimpleIgnoredColumn"]));
+      var commandText = sqlDriver.Compile(alter).GetCommandText();
+      ExecuteNonQuery(commandText);
+
+      var ignoreRuleCollection = new IgnoreRuleCollection();
+      _ = ignoreRuleCollection.IgnoreColumn("SimpleIgnoredColumn").WhenTable("MyEntity2").WhenSchema(schema.Name);
+
+      _ = Assert.Throws(Is.InstanceOf(typeof(StorageException)), () => {
+        using (var validatedDomain = BuildDomain(DomainUpgradeMode.Validate, ignoreRuleCollection, model3Types))
+        using (var session = validatedDomain.OpenSession())
+        using (var transaction = session.OpenTransaction()) {
+          _ = new Model3.MyEntity2 { FirstColumn = "some test" };
+          transaction.Complete();
+        }
+      });
+    }
+
+    [Test]
+    public void DropTableWithIgnoredColumnTest()
+    {
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
+
+      var catalog = GetCatalog();
+      var schema = catalog.DefaultSchema.Name;
+      CreateColumn(catalog, schema, "MyEntity2", "SimpleIgnoredColumn", GetTypeForInteger(SqlType.Int64));
+
+      var ignoreRuleCollection = new IgnoreRuleCollection();
+      _ = ignoreRuleCollection.IgnoreColumn("SimpleIgnoredColumn").WhenTable("MyEntity2");
+
+      _ = Assert.Throws<SchemaSynchronizationException>(
+        () => BuildDomain(DomainUpgradeMode.Perform, ignoreRuleCollection, model4Types).Dispose());
+    }
+
+    [Test]
+    public void DropTableWithIgnoredIndexTest()
+    {
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
+
+      var schema = GetCatalog().DefaultSchema;
+      var keyColumns = new string[] { "IndexedValue" };
+      var includedColimns = new string[] { "FirstColumn" };
+
+      CreateIndex(schema, "MyEntity2", "IX_Ignored_Index", keyColumns, includedColimns);
+
+      var ignoreRuleCollection = new IgnoreRuleCollection();
+      _ = ignoreRuleCollection.IgnoreIndex("IX_Ignored_Index").WhenTable("MyEntity2");
+
+      _ = Assert.Throws<SchemaSynchronizationException>(
+        () => BuildDomain(DomainUpgradeMode.Perform, ignoreRuleCollection, model4Types).Dispose());
+    }
+
+    [Test]
+    public void DropIncludedColumnOfIgnoredIndexTest()
+    {
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
+
+      var schema = GetCatalog().DefaultSchema;
+      var keyColumns = new string[] { "IndexedValue" };
+      var includedColimns = new string[] { "FirstColumn" };
+
+      CreateIndex(schema, "MyEntity2", "IX_Ignored_Index", keyColumns, includedColimns);
+
+      var ignoreRuleCollection = new IgnoreRuleCollection();
+      _ = ignoreRuleCollection.IgnoreIndex("IX_Ignored_Index").WhenTable("MyEntity2");
+
+      _ = Assert.Throws<StorageException>(
+        () => BuildDomain(DomainUpgradeMode.Perform, ignoreRuleCollection, model5Types).Dispose());
+    }
+
+    [Test]
+    public void DropKeyColumnOfIgnoredIndexTest()
+    {
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
+
+      var schema = GetCatalog().DefaultSchema;
+      var keyColumns = new string[] { "IndexedValue" };
+      var includedColimns = new string[] { "FirstColumn" };
+
+      CreateIndex(schema, "MyEntity2", "IX_Ignored_Index", keyColumns, includedColimns);
+
+      var ignoreRuleCollection = new IgnoreRuleCollection();
+      _ = ignoreRuleCollection.IgnoreIndex("IX_Ignored_Index").WhenTable("MyEntity2");
+
+      _ = Assert.Throws<StorageException>(
+        () => BuildDomain(DomainUpgradeMode.Perform, ignoreRuleCollection, model6Types).Dispose());
+    }
+
+    [Test]
+    public void DropReferencedTableTest()
+    {
+      Require.AllFeaturesSupported(ProviderFeatures.ForeignKeyConstraints);
+
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
+
+      var catalog = GetCatalog();
+      var schema = catalog.DefaultSchema.Name;
+      CreateColumn(catalog, schema, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64));
+      CreateForeignKeyInDb(catalog, schema, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity1_MyEntity1ID");
+
+      var ignoreRuleCollection = new IgnoreRuleCollection();
+      _ = ignoreRuleCollection.IgnoreColumn("ReferencedIgnoredColumn").WhenTable("MyEntity2").WhenSchema(schema);
+
+      _ = Assert.Throws<SchemaSynchronizationException>(() => {
+        BuildDomain(DomainUpgradeMode.Perform, ignoreRuleCollection, model4Types ).Dispose();
+      });
     }
 
     [Test]
     public void UpgradeDomainWithIgnoreRuleByMaskInPerformModeTest()
     {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
 
       var catalog = GetCatalog();
       var schema = catalog.Schemas[catalog.DefaultSchema.Name] ?? catalog.Schemas[0];
@@ -560,7 +696,7 @@ namespace Xtensive.Orm.Tests.Storage
       var ignoreRules = new IgnoreRuleCollection();
       _ = ignoreRules.IgnoreColumn("Ignored*").WhenTable("MyEntity2");
 
-      using (var domain = BuildSimpleDomain(DomainUpgradeMode.Perform, ignoreRules, typeof(Model3.MyEntity1)))
+      using (var domain = BuildDomain(DomainUpgradeMode.Perform, ignoreRules, model3Types))
       using (var session = domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         _ = new Model3.MyEntity1 { FirstColumn = "Some text" };
@@ -569,17 +705,16 @@ namespace Xtensive.Orm.Tests.Storage
       }
       var myEntity2 = SqlDml.TableRef(schema.Tables["MyEntity2"]);
       var select = SqlDml.Select(myEntity2);
-      var compileConfiguration = new SqlCompilerConfiguration();
-      compileConfiguration.DatabaseQualifiedObjects = false;
-      var commandText = sqlDriver.Compile(select, compileConfiguration).GetCommandText();
-      Assert.That(ExecuteQuery(commandText, 2), Is.EqualTo(DBNull.Value));
+      
+      var commandText = sqlDriver.Compile(select, BuildCompilerConfig(false)).GetCommandText();
       Assert.That(ExecuteQuery(commandText, 3), Is.EqualTo(DBNull.Value));
+      Assert.That(ExecuteQuery(commandText, 4), Is.EqualTo(DBNull.Value));
     }
 
     [Test]
     public void UpgradeDomainWithIgnoreRuleByMaskInPerformSafelyModeTest()
     {
-      BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model3.MyEntity1)).Dispose();
+      BuildDomain(DomainUpgradeMode.Recreate, null, model3Types).Dispose();
 
       var catalog = GetCatalog();
       var schema = catalog.Schemas[catalog.DefaultSchema.Name] ?? catalog.Schemas[0];
@@ -589,7 +724,7 @@ namespace Xtensive.Orm.Tests.Storage
       var ignoreRules = new IgnoreRuleCollection();
       _ = ignoreRules.IgnoreColumn("Ignored*");
 
-      using (var domain = BuildSimpleDomain(DomainUpgradeMode.PerformSafely, ignoreRules, typeof(Model3.MyEntity1)))
+      using (var domain = BuildDomain(DomainUpgradeMode.PerformSafely, ignoreRules, model3Types))
       using (var session = domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         _ = new Model3.MyEntity1 { FirstColumn = "Some text" };
@@ -598,11 +733,9 @@ namespace Xtensive.Orm.Tests.Storage
       }
       var myEntity2 = SqlDml.TableRef(schema.Tables["MyEntity2"]);
       var select = SqlDml.Select(myEntity2);
-      var compileConfiguration = new SqlCompilerConfiguration();
-      compileConfiguration.DatabaseQualifiedObjects = false;
-      var commandText = sqlDriver.Compile(select, compileConfiguration).GetCommandText();
-      Assert.That(ExecuteQuery(commandText, 2), Is.EqualTo(DBNull.Value));
+      var commandText = sqlDriver.Compile(select, BuildCompilerConfig(false)).GetCommandText();
       Assert.That(ExecuteQuery(commandText, 3), Is.EqualTo(DBNull.Value));
+      Assert.That(ExecuteQuery(commandText, 4), Is.EqualTo(DBNull.Value));
     }
 
     [Test]
@@ -616,7 +749,7 @@ namespace Xtensive.Orm.Tests.Storage
       CreateSchema(catalog, Schema1);
       CreateSchema(catalog, Schema2);
 
-      BuildComplexDomain(DomainUpgradeMode.Recreate, null, new[] { typeof(Model1.Customer) }, new[] { typeof(Model3.MyEntity1) }).Dispose();
+      BuildDomain(DomainUpgradeMode.Recreate, null, model1Types, model3Types).Dispose();
 
       catalog = GetCatalog();
       CreateColumn(catalog, Schema2, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64));
@@ -635,7 +768,7 @@ namespace Xtensive.Orm.Tests.Storage
       _ = ignoreRules.IgnoreColumn("SomeIgnoredField").WhenTable("Order").WhenSchema(Schema1);
       _ = ignoreRules.IgnoreColumn("IgnoredColumn.Id").WhenTable("Author").WhenSchema(Schema1);
 
-      BuildComplexDomain(DomainUpgradeMode.Validate, ignoreRules, new[] { typeof(Model1.Customer) }, new[] { typeof(Model3.MyEntity1) }).Dispose();
+      BuildDomain(DomainUpgradeMode.Validate, ignoreRules, model1Types, model3Types).Dispose();
     }
 
     [Test]
@@ -645,26 +778,26 @@ namespace Xtensive.Orm.Tests.Storage
 
       SetMultidatabase();
 
-      BuildComplexDomain(DomainUpgradeMode.Recreate, null, new[] { typeof(Model1.Customer) }, new[] { typeof(Model3.MyEntity1) }).Dispose();
+      BuildDomain(DomainUpgradeMode.Recreate, null, model1Types, model3Types).Dispose();
 
       var secondCatalog = GetCatalog(Multimapping.MultidatabaseTest.Database2Name);
-      CreateColumn(secondCatalog, defaultSchema, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64), true);
-      CreateForeignKeyInDb(secondCatalog, defaultSchema, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity2_MyEntity1_MyEntity1ID", true);
+      CreateColumn(secondCatalog, DefaultSchema, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64), true);
+      CreateForeignKeyInDb(secondCatalog, DefaultSchema, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity2_MyEntity1_MyEntity1ID", true);
 
       var addedColumnsNames = new[] { "Id", "FirstColumn", "MyEntity2Id" };
       var addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int32), GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64) };
-      CreateTable(secondCatalog, defaultSchema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes, true);
-      CreatePrimaryKeyInDb(secondCatalog, defaultSchema, "MyIgnoredEntity", "Id", "PK_MyIgnoreTable_Id", true);
-      CreateForeignKeyInDb(secondCatalog, defaultSchema, "MyIgnoredEntity", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntity_MyEntity2_Id", true);
+      CreateTable(secondCatalog, DefaultSchema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes, true);
+      CreatePrimaryKeyInDb(secondCatalog, DefaultSchema, "MyIgnoredEntity", "Id", "PK_MyIgnoreTable_Id", true);
+      CreateForeignKeyInDb(secondCatalog, DefaultSchema, "MyIgnoredEntity", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntity_MyEntity2_Id", true);
 
       var ignoreRules = new IgnoreRuleCollection();
-      _ = ignoreRules.IgnoreColumn("ReferencedIgnoredColumn").WhenSchema(defaultSchema).WhenDatabase(Multimapping.MultidatabaseTest.Database2Name);
+      _ = ignoreRules.IgnoreColumn("ReferencedIgnoredColumn").WhenSchema(DefaultSchema).WhenDatabase(Multimapping.MultidatabaseTest.Database2Name);
       _ = ignoreRules.IgnoreTable("MyIgnoredEntity").WhenDatabase(Multimapping.MultidatabaseTest.Database2Name);
       _ = ignoreRules.IgnoreTable("IgnoredTable").WhenDatabase(Multimapping.MultidatabaseTest.Database1Name);
       _ = ignoreRules.IgnoreColumn("SomeIgnoredField").WhenTable("Order").WhenDatabase(Multimapping.MultidatabaseTest.Database1Name);
       _ = ignoreRules.IgnoreColumn("IgnoredColumn.Id").WhenTable("Author").WhenDatabase(Multimapping.MultidatabaseTest.Database1Name);
 
-      BuildComplexDomain(DomainUpgradeMode.Validate, ignoreRules, new[] { typeof(Model1.Customer) }, new[] { typeof(Model3.MyEntity1) }).Dispose();
+      BuildDomain(DomainUpgradeMode.Validate, ignoreRules, model1Types, model3Types).Dispose();
     }
 
     [Test]
@@ -751,14 +884,14 @@ namespace Xtensive.Orm.Tests.Storage
       BuildDomainAndFillData();
 
       var secondCatalog = GetCatalog(Multimapping.MultidatabaseTest.Database2Name);
-      CreateColumn(secondCatalog, defaultSchema, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64), true);
-      CreateForeignKeyInDb(secondCatalog, defaultSchema, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity2_MyEntity1_MyEntity1ID", true);
+      CreateColumn(secondCatalog, DefaultSchema, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64), true);
+      CreateForeignKeyInDb(secondCatalog, DefaultSchema, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity2_MyEntity1_MyEntity1ID", true);
 
       var addedColumnsNames = new[] { "Id", "FirstColumn", "MyEntity2Id" };
       var addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int32), GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64) };
-      CreateTable(secondCatalog, defaultSchema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes, true);
-      CreatePrimaryKeyInDb(secondCatalog, defaultSchema, "MyIgnoredEntity", "Id", "PK_MyIgnoreTable_Id", true);
-      CreateForeignKeyInDb(secondCatalog, defaultSchema, "MyIgnoredEntity", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntity_MyEntity2_Id", true);
+      CreateTable(secondCatalog, DefaultSchema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes, true);
+      CreatePrimaryKeyInDb(secondCatalog, DefaultSchema, "MyIgnoredEntity", "Id", "PK_MyIgnoreTable_Id", true);
+      CreateForeignKeyInDb(secondCatalog, DefaultSchema, "MyIgnoredEntity", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntity_MyEntity2_Id", true);
 
       var ignoreRules = new IgnoreRuleCollection();
       _ = ignoreRules.IgnoreColumn("ReferencedIgnoredColumn").WhenDatabase(Multimapping.MultidatabaseTest.Database2Name);
@@ -772,7 +905,7 @@ namespace Xtensive.Orm.Tests.Storage
       _ = ignoreRules.IgnoreColumn("ReferencedIgnoredColumn").WhenDatabase(Multimapping.MultidatabaseTest.Database2Name);
       _ = ignoreRules.IgnoreTable("MyIgnoredEntity").WhenDatabase(Multimapping.MultidatabaseTest.Database2Name);
       BuildDomainInValidateMode(ignoreRules);
-      ValidateMyEntity(secondCatalog, defaultSchema, true);
+      ValidateMyEntity(secondCatalog, DefaultSchema, true);
     }
 
     [Test]
@@ -784,13 +917,13 @@ namespace Xtensive.Orm.Tests.Storage
       BuildDomainAndFillData();
 
       var secondCatalog = GetCatalog(Multimapping.MultidatabaseTest.Database2Name);
-      CreateColumn(secondCatalog, defaultSchema, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64), true);
-      CreateForeignKeyInDb(secondCatalog, defaultSchema, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity2_MyEntity1_MyEntity1ID", true);
+      CreateColumn(secondCatalog, DefaultSchema, "MyEntity2", "ReferencedIgnoredColumn", GetTypeForInteger(SqlType.Int64), true);
+      CreateForeignKeyInDb(secondCatalog, DefaultSchema, "MyEntity2", "ReferencedIgnoredColumn", "MyEntity1", "Id", "FK_MyEntity2_MyEntity1_MyEntity1ID", true);
       var addedColumnsNames = new[] { "Id", "FirstColumn", "MyEntity2Id" };
       var addedColumnsTypes = new[] { GetTypeForInteger(SqlType.Int32), GetTypeForInteger(SqlType.Int64), GetTypeForInteger(SqlType.Int64) };
-      CreateTable(secondCatalog, defaultSchema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes, true);
-      CreatePrimaryKeyInDb(secondCatalog, defaultSchema, "MyIgnoredEntity", "Id", "PK_MyIgnoreTable_Id", true);
-      CreateForeignKeyInDb(secondCatalog, defaultSchema, "MyIgnoredEntity", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntity_MyEntity2_Id", true);
+      CreateTable(secondCatalog, DefaultSchema, "MyIgnoredEntity", addedColumnsNames, addedColumnsTypes, true);
+      CreatePrimaryKeyInDb(secondCatalog, DefaultSchema, "MyIgnoredEntity", "Id", "PK_MyIgnoreTable_Id", true);
+      CreateForeignKeyInDb(secondCatalog, DefaultSchema, "MyIgnoredEntity", "MyEntity2Id", "MyEntity2", "Id", "FK_MyIgnoredEntity_MyEntity2_Id", true);
 
       var ignoreRules = new IgnoreRuleCollection();
       _ = ignoreRules.IgnoreColumn("ReferencedIgnoredColumn").WhenDatabase(Multimapping.MultidatabaseTest.Database2Name);
@@ -804,155 +937,135 @@ namespace Xtensive.Orm.Tests.Storage
       _ = ignoreRules.IgnoreColumn("ReferencedIgnoredColumn").WhenDatabase(Multimapping.MultidatabaseTest.Database2Name);
       _ = ignoreRules.IgnoreTable("MyIgnoredEntity").WhenDatabase(Multimapping.MultidatabaseTest.Database2Name);
       BuildDomainInValidateMode(ignoreRules);
-      ValidateMyEntity(secondCatalog, defaultSchema, true);
+      ValidateMyEntity(secondCatalog, DefaultSchema, true);
     }
 
-    private Domain BuildSimpleDomain(DomainUpgradeMode mode, IgnoreRuleCollection ignoreRules, Type sourceType, params Type[] additionalSourceTypes)
+    private void BuildDomainAndFillData()
+    {
+      var t2Set = isMultidatabaseTest || isMultischemaTest ? model3Types : null;
+
+      using var domain = BuildDomain(DomainUpgradeMode.Recreate, null, model1PlusIgnorable, t2Set);
+      using var session = domain.OpenSession();
+      using var transaction = session.OpenTransaction();
+
+      var author = new Model1.Author {
+        FirstName = "Ivan", LastName = "Goncharov", Birthday = new DateTime(1812, 6, 18)
+      };
+      var book = new Model1.Book { ISBN = "9780140440409", Title = "Oblomov" };
+      _ = book.Authors.Add(author);
+
+      var customer = new Model1.Customer {
+        FirstName = "Alexey", LastName = "Kulakov", Birthday = new DateTime(1988, 8, 31)
+      };
+      var order = new Model1.Order { Book = book, Customer = customer };
+      order["SomeIgnoredField"] = "Secret information for FBI :)";
+
+      if (isMultidatabaseTest || isMultischemaTest) {
+        _ = new Model3.MyEntity1 { FirstColumn = "first" };
+        _ = new Model3.MyEntity2 { FirstColumn = "first" };
+      }
+      transaction.Complete();
+    }
+
+    private void UpgradeDomain(DomainUpgradeMode mode)
+    {
+      var ignoreRules = new IgnoreRuleCollection();
+      _ = ignoreRules.IgnoreTable("IgnoredTable");
+      _ = ignoreRules.IgnoreColumn("SomeIgnoredField").WhenTable("Order");
+      _ = ignoreRules.IgnoreColumn("IgnoredColumn.Id").WhenTable("Author");
+
+      using var domain = BuildDomain(mode, ignoreRules, model1Types);
+      using var session = domain.OpenSession();
+      using var transaction = session.OpenTransaction();
+
+      var currentCustomer = session.Query.All<Model1.Customer>().First(c => c.LastName == "Kulakov");
+      var order = session.Query.All<Model1.Order>().First(o => o.Customer.LastName == currentCustomer.LastName);
+      var newCustomer = new Model1.Customer { FirstName = "Fred", LastName = "Smith", Birthday = new DateTime(1998, 7, 9) };
+      order.Customer = newCustomer;
+      changedOrderKey = order.Key;
+      transaction.Complete();
+    }
+
+    private void UpgradeDomain(DomainUpgradeMode mode, IgnoreRuleCollection ignoreRules)
+    {
+      using var performDomain = BuildDomain(mode, ignoreRules, model1Types, model3Types);
+      using var session = performDomain.OpenSession();
+      using var transaction = session.OpenTransaction();
+
+      var currentCustomer = session.Query.All<Model1.Customer>().First(c => c.LastName == "Kulakov");
+      var order = session.Query.All<Model1.Order>().First(o => o.Customer.LastName == currentCustomer.LastName);
+      var newCustomer = new Model1.Customer { FirstName = "Fred", LastName = "Smith", Birthday = new DateTime(1998, 7, 9) };
+      order.Customer = newCustomer;
+      changedOrderKey = order.Key;
+      var currentEntity = session.Query.All<Model3.MyEntity2>().First(ent => ent.FirstColumn == "first");
+      currentEntity.FirstColumn = "second";
+      transaction.Complete();
+    }
+
+    private void BuildDomainInValidateMode()
+    {
+      using var domain = BuildDomain(DomainUpgradeMode.Validate, null, model1PlusIgnorable);
+      using var session = domain.OpenSession();
+      using var transaction = session.OpenTransaction();
+
+      var result = session.Query.All<Model1.Order>().First(o => o.Key == changedOrderKey);
+      Assert.That(result["SomeIgnoredField"], Is.EqualTo("Secret information for FBI :)"));
+    }
+
+    private void BuildDomainInValidateMode(IgnoreRuleCollection ignoreRules)
+    {
+      using var domain = BuildDomain(DomainUpgradeMode.Validate, ignoreRules, model1PlusIgnorable, model3Types);
+      using var session = domain.OpenSession();
+      using var transaction = session.OpenTransaction();
+
+      var result = session.Query.All<Model1.Order>().First(o => o.Key == changedOrderKey);
+      Assert.That(result["SomeIgnoredField"], Is.EqualTo("Secret information for FBI :)"));
+    }
+
+    private Domain BuildDomain(DomainUpgradeMode mode, IgnoreRuleCollection ignoreRules,
+      Type[] firstPartTypes, Type[] secondPartTypes = null)
     {
       var configuration = DomainConfigurationFactory.Create();
       configuration.UpgradeMode = mode;
-      configuration.Types.Register(sourceType.Assembly, sourceType.Namespace);
-
-      if (additionalSourceTypes != null) {
-        additionalSourceTypes.ForEach((t) => configuration.Types.Register(t.Assembly, t.Namespace));
+      foreach (var t1 in firstPartTypes) {
+        configuration.Types.Register(t1);
       }
+
+      if (isMultischemaTest || isMultidatabaseTest) {
+        foreach (var t2 in secondPartTypes) {
+          configuration.Types.Register(t2);
+        }
+
+        var part1Namespaces = firstPartTypes.Select(t => t.Namespace).Distinct();
+        var part2Namespaces = secondPartTypes.Select(t=>t.Namespace).Distinct();
+
+        if (isMultischemaTest) {
+          foreach (var ns in part1Namespaces) {
+            configuration.MappingRules.Map(firstPartTypes[0].Assembly, ns).ToSchema(Schema1);
+          }
+          foreach(var ns in part2Namespaces) {
+            configuration.MappingRules.Map(secondPartTypes[0].Assembly, ns).ToSchema(Schema2);
+          }
+          
+          configuration.DefaultSchema = DefaultSchema;
+        }
+        else {
+          foreach (var ns in part1Namespaces) {
+            configuration.MappingRules.Map(firstPartTypes[0].Assembly, ns).ToDatabase(Multimapping.MultidatabaseTest.Database1Name);
+          }
+          foreach (var ns in part2Namespaces) {
+            configuration.MappingRules.Map(secondPartTypes[0].Assembly, ns).ToDatabase(Multimapping.MultidatabaseTest.Database2Name);
+          }
+          configuration.DefaultSchema = DefaultSchema;
+          configuration.DefaultDatabase = GetConnectionInfo().ConnectionUrl.GetDatabase();
+        }
+      }
+
       if (ignoreRules != null) {
         configuration.IgnoreRules = ignoreRules;
       }
 
       return Domain.Build(configuration);
-    }
-
-    private Domain BuildComplexDomain(DomainUpgradeMode mode, IgnoreRuleCollection ignoreRules, Type[] firstPartTypes, Type[] secondPartTypes)
-    {
-      var config = DomainConfigurationFactory.Create();
-      config.UpgradeMode = mode;
-      if (isMultischemaTest) {
-        foreach (var type in firstPartTypes) {
-          config.MappingRules.Map(type.Assembly, type.Namespace).ToSchema(Schema1);
-        }
-
-        foreach (var type in secondPartTypes) {
-          config.MappingRules.Map(type.Assembly, type.Namespace).ToSchema(Schema2);
-        }
-        config.DefaultSchema = defaultSchema;
-      }
-      else if (isMultidatabaseTest) {
-        foreach (var type in firstPartTypes) {
-          config.MappingRules.Map(type.Assembly, type.Namespace).ToDatabase(Multimapping.MultidatabaseTest.Database1Name);
-        }
-
-        foreach (var type in secondPartTypes) {
-          config.MappingRules.Map(type.Assembly, type.Namespace).ToDatabase(Multimapping.MultidatabaseTest.Database2Name);
-        }
-        config.DefaultSchema = defaultSchema;
-        config.DefaultDatabase = GetConnectionInfo().ConnectionUrl.GetDatabase();
-      }
-
-      foreach (var type in firstPartTypes.Union(secondPartTypes)) {
-        config.Types.Register(type.Assembly, type.Namespace);
-      }
-
-      if (ignoreRules != null) {
-        config.IgnoreRules = ignoreRules;
-      }
-
-      return Domain.Build(config);
-    }
-
-    private void BuildDomainAndFillData()
-    {
-      var domain = isMultidatabaseTest || isMultischemaTest
-        ? BuildComplexDomain(DomainUpgradeMode.Recreate, null,
-            new[] { typeof(Model1.Customer), typeof(ignorablePart.IgnoredTable) }, new[] { typeof(Model3.MyEntity1) })
-        : BuildSimpleDomain(DomainUpgradeMode.Recreate, null, typeof(Model1.Customer), typeof(ignorablePart.IgnoredTable));
-
-      using (domain)
-      using (var session = domain.OpenSession())
-      using (var transaction = session.OpenTransaction()) {
-        var author = new Model1.Author {
-          FirstName = "Ivan",
-          LastName = "Goncharov",
-          Birthday = new DateTime(1812, 6, 18)
-        };
-        var book = new Model1.Book { ISBN = "9780140440409", Title = "Oblomov" };
-        _ = book.Authors.Add(author);
-        var customer = new Model1.Customer {
-          FirstName = "Alexey",
-          LastName = "Kulakov",
-          Birthday = new DateTime(1988, 8, 31)
-        };
-        var order = new Model1.Order { Book = book, Customer = customer };
-        order["SomeIgnoredField"] = "Secret information for FBI :)";
-
-        if (isMultidatabaseTest || isMultischemaTest) {
-          _ = new Model3.MyEntity1 { FirstColumn = "first" };
-          _ = new Model3.MyEntity2 { FirstColumn = "first" };
-        }
-        transaction.Complete();
-      }
-    }
-
-    private void UpgradeDomain(DomainUpgradeMode mode)
-    {
-      IgnoreRuleCollection ignoreRules = new IgnoreRuleCollection();
-      _ = ignoreRules.IgnoreTable("IgnoredTable");
-      _ = ignoreRules.IgnoreColumn("SomeIgnoredField").WhenTable("Order");
-      _ = ignoreRules.IgnoreColumn("IgnoredColumn.Id").WhenTable("Author");
-
-      using (var domain = BuildSimpleDomain(mode, ignoreRules, typeof(Model1.Customer)))
-      using (var session = domain.OpenSession())
-      using (var transaction = session.OpenTransaction()) {
-        var currentCustomer = session.Query.All<Model1.Customer>().First(c => c.LastName == "Kulakov");
-        var order = session.Query.All<Model1.Order>().First(o => o.Customer.LastName == currentCustomer.LastName);
-        var newCustomer = new Model1.Customer { FirstName = "Fred", LastName = "Smith", Birthday = new DateTime(1998, 7, 9) };
-        order.Customer = newCustomer;
-        changedOrderKey = order.Key;
-        transaction.Complete();
-      }
-    }
-
-    private void UpgradeDomain(DomainUpgradeMode mode, IgnoreRuleCollection ignoreRules)
-    {
-      using (var performDomain = BuildComplexDomain(mode, ignoreRules, new[] { typeof(Model1.Customer) }, new[] { typeof(Model3.MyEntity1) }))
-      using (var session = performDomain.OpenSession())
-      using (var transaction = session.OpenTransaction()) {
-        var currentCustomer = session.Query.All<Model1.Customer>().First(c => c.LastName == "Kulakov");
-        var order = session.Query.All<Model1.Order>().First(o => o.Customer.LastName == currentCustomer.LastName);
-        var newCustomer = new Model1.Customer { FirstName = "Fred", LastName = "Smith", Birthday = new DateTime(1998, 7, 9) };
-        order.Customer = newCustomer;
-        changedOrderKey = order.Key;
-        var currentEntity = session.Query.All<Model3.MyEntity2>().First(ent => ent.FirstColumn == "first");
-        currentEntity.FirstColumn = "second";
-        transaction.Complete();
-      }
-    }
-
-    private void BuildDomainInValidateMode()
-    {
-      var configuration = DomainConfigurationFactory.Create();
-      configuration.UpgradeMode = DomainUpgradeMode.Validate;
-      configuration.Types.Register(typeof(Model1.Customer).Assembly, typeof(Model1.Customer).Namespace);
-      configuration.Types.Register(typeof(ignorablePart.IgnoredTable).Assembly, typeof(ignorablePart.IgnoredTable).Namespace);
-      using (var domain = Domain.Build(configuration))
-      using (var session = domain.OpenSession())
-      using (var transaction = session.OpenTransaction()) {
-        var result = session.Query.All<Model1.Order>().First(o => o.Key == changedOrderKey);
-        Assert.That(result["SomeIgnoredField"], Is.EqualTo("Secret information for FBI :)"));
-      }
-    }
-
-    private void BuildDomainInValidateMode(IgnoreRuleCollection ignoreRules)
-    {
-      var validateDomain = BuildComplexDomain(DomainUpgradeMode.Validate, ignoreRules,
-        new[] { typeof(Model1.Customer), typeof(ignorablePart.IgnoredTable) }, new[] { typeof(Model3.MyEntity1) });
-
-      using (validateDomain)
-      using (var session = validateDomain.OpenSession())
-      using (var transaction = session.OpenTransaction()) {
-        var result = session.Query.All<Model1.Order>().First(o => o.Key == changedOrderKey);
-        Assert.That(result["SomeIgnoredField"], Is.EqualTo("Secret information for FBI :)"));
-      }
     }
 
     private Catalog GetCatalog(string catalogName = null)
@@ -976,7 +1089,7 @@ namespace Xtensive.Orm.Tests.Storage
       return catalog;
     }
 
-    private ConnectionInfo GetConnectionInfo() => DomainConfigurationFactory.Create().ConnectionInfo;
+    private static ConnectionInfo GetConnectionInfo() => DomainConfigurationFactory.Create().ConnectionInfo;
 
     private void ExecuteNonQuery(string commandText)
     {
@@ -1005,64 +1118,95 @@ namespace Xtensive.Orm.Tests.Storage
       return result;
     }
 
-    private void ValidateMyEntity(Catalog catalog, string schema, bool useDatabasePrefix = false)
+    private void ValidateMyEntity(Catalog catalog, string schemaName, bool useDatabasePrefix = false)
     {
-      var schemaToValidete = catalog.Schemas[schema] ?? catalog.Schemas[0];
+      var schemaToValidete = catalog.Schemas[schemaName] ?? catalog.Schemas[0];
 
       var myEntity2 = SqlDml.TableRef(schemaToValidete.Tables["MyEntity2"]);
       var select = SqlDml.Select(myEntity2);
       var commandText = sqlDriver.Compile(select, BuildCompilerConfig(useDatabasePrefix)).GetCommandText();
-      Assert.That(ExecuteQuery(commandText, 2), Is.EqualTo(DBNull.Value));
+      Assert.That(ExecuteQuery(commandText, 3), Is.EqualTo(DBNull.Value));
     }
 
-    private void CreateForeignKeyInDb(Catalog catalog, string schema, string table, string column, string referencedTable,
-      string referencedColumn, string foreignKeyName, bool useDatabasePrefix = false)
+    private void CreateForeignKeyInDb(Catalog catalog, string schemaName, string tableName, string columnName,
+      string referencedTableName, string referencedColumn, string foreignKeyName, bool useDatabasePrefix = false)
     {
-      var schemaToAlter = catalog.Schemas[schema] ?? catalog.Schemas[0];
+      var schemaToAlter = catalog.Schemas[schemaName] ?? catalog.Schemas[0];
 
-      var foreignKey = schemaToAlter.Tables[table].CreateForeignKey(foreignKeyName);
-      foreignKey.Columns.Add(schemaToAlter.Tables[table].TableColumns[column]);
-      foreignKey.ReferencedTable = schemaToAlter.Tables[referencedTable];
-      foreignKey.ReferencedColumns.Add(schemaToAlter.Tables[referencedTable].TableColumns[referencedColumn]);
-      var alter = SqlDdl.Alter(schemaToAlter.Tables[table], SqlDdl.AddConstraint(foreignKey));
+      var referencingTable = schemaToAlter.Tables[tableName];
+      var referencedTable = schemaToAlter.Tables[referencedTableName];
+
+      var foreignKey = referencingTable.CreateForeignKey(foreignKeyName);
+      foreignKey.Columns.Add(referencingTable.TableColumns[columnName]);
+      foreignKey.ReferencedTable = referencedTable;
+      foreignKey.ReferencedColumns.Add(referencedTable.TableColumns[referencedColumn]);
+      var alter = SqlDdl.Alter(referencingTable, SqlDdl.AddConstraint(foreignKey));
       var commandText = sqlDriver.Compile(alter, BuildCompilerConfig(useDatabasePrefix)).GetCommandText();
       ExecuteNonQuery(commandText);
     }
 
-    private void CreateForeignKeyLocally(Catalog catalog, string schema, string table, string column, string referencedTable,
-      string referencedColumn, string foreignKeyName, bool useDatabasePrefix = false)
+    private void CreateForeignKeyLocally(Catalog catalog, string schemaName, string tableName, string columnName,
+      string referencedTableName, string referencedColumnName, string foreignKeyName, bool useDatabasePrefix = false)
     {
-      var schemaToAlter = catalog.Schemas[schema] ?? catalog.Schemas[0];
-      var foreignKey = schemaToAlter.Tables[table].CreateForeignKey(foreignKeyName);
-      foreignKey.Columns.Add(schemaToAlter.Tables[table].TableColumns[column]);
-      foreignKey.ReferencedTable = schemaToAlter.Tables[referencedTable];
-      foreignKey.ReferencedColumns.Add(schemaToAlter.Tables[referencedTable].TableColumns[referencedColumn]);
+      var schemaToAlter = catalog.Schemas[schemaName] ?? catalog.Schemas[0];
+
+      var referencingTable = schemaToAlter.Tables[tableName];
+      var referencedTable = schemaToAlter.Tables[referencedTableName];
+
+      var foreignKey = referencingTable.CreateForeignKey(foreignKeyName);
+      foreignKey.Columns.Add(referencingTable.TableColumns[columnName]);
+      foreignKey.ReferencedTable = referencedTable;
+      foreignKey.ReferencedColumns.Add(referencedTable.TableColumns[referencedColumnName]);
     }
 
-    private void CreatePrimaryKeyInDb(Catalog catalog, string schema, string table, string column, string primaryKeyName, bool useDatabasePrefix = false)
+    private void CreatePrimaryKeyInDb(
+      Catalog catalog, string schemaName, string tableName, string columnName, string primaryKeyName, bool useDatabasePrefix = false)
     {
-      var schemaToAlter = catalog.Schemas[schema] ?? catalog.Schemas[0];
+      var schemaToAlter = catalog.Schemas[schemaName] ?? catalog.Schemas[0];
 
-      var primaryKey = schemaToAlter.Tables[table].CreatePrimaryKey(primaryKeyName,
-        schemaToAlter.Tables[table].TableColumns[column]);
-      var alter = SqlDdl.Alter(schemaToAlter.Tables[table], SqlDdl.AddConstraint(primaryKey));
+      var table = schemaToAlter.Tables[tableName];
+      var primaryKey = table.CreatePrimaryKey(primaryKeyName, table.TableColumns[columnName]);
+      var alter = SqlDdl.Alter(table, SqlDdl.AddConstraint(primaryKey));
       var commandText = sqlDriver.Compile(alter, BuildCompilerConfig(useDatabasePrefix)).GetCommandText();
       ExecuteNonQuery(commandText);
     }
 
-    private void CreatePrimaryKeyLocally(Catalog catalog, string schema, string table, string column, string primaryKeyName)
+    private void CreatePrimaryKeyLocally(
+      Catalog catalog, string schemaName, string tableName, string columnName, string primaryKeyName)
     {
-      var schemaToAlter = catalog.Schemas[schema] ?? catalog.Schemas[0];
-      _ = schemaToAlter.Tables[table].CreatePrimaryKey(primaryKeyName,
-        schemaToAlter.Tables[table].TableColumns[column]);
+      var schemaToAlter = catalog.Schemas[schemaName] ?? catalog.Schemas[0];
+      _ = schemaToAlter.Tables[tableName].CreatePrimaryKey(primaryKeyName,
+        schemaToAlter.Tables[tableName].TableColumns[columnName]);
     }
 
-    private void CreateColumn(Catalog catalog, string schema, string table, string columnName, SqlValueType columnType, bool useDatabasePrefix = false)
+    private void CreateIndex(Schema schema, string tableName, string indexName, string[] keyColumns, string[] includedColumns)
     {
-      var schemaToAlter = catalog.Schemas[schema] ?? catalog.Schemas[0];
-      var column = schemaToAlter.Tables[table].CreateColumn(columnName, columnType);
+      var table = schema.Tables[tableName];
+      var index = table.CreateIndex(indexName);
+
+      foreach (var keyColumn in keyColumns) {
+        _ = index.CreateIndexColumn(table.TableColumns[keyColumn]);
+      }
+
+      if (includedColumns != null) {
+        foreach(var includedColumn in includedColumns) {
+          index.NonkeyColumns.Add(table.TableColumns[includedColumn]);
+        }
+      }
+
+      var create = SqlDdl.Create(index);
+      var commandText = sqlDriver.Compile(create, BuildCompilerConfig(false)).GetCommandText();
+      ExecuteNonQuery(commandText);
+    }
+
+    private void CreateColumn(
+      Catalog catalog, string schemaName, string tableName, string columnName, SqlValueType columnType, bool useDatabasePrefix = false)
+    {
+      var schemaToAlter = catalog.Schemas[schemaName] ?? catalog.Schemas[0];
+      var table = schemaToAlter.Tables[tableName];
+      var column = table.CreateColumn(columnName, columnType);
       column.IsNullable = true;
-      var alter = SqlDdl.Alter(schemaToAlter.Tables[table], SqlDdl.AddColumn(column));
+      var alter = SqlDdl.Alter(table, SqlDdl.AddColumn(column));
       var commandText = sqlDriver.Compile(alter, BuildCompilerConfig(useDatabasePrefix)).GetCommandText();
       ExecuteNonQuery(commandText);
     }
@@ -1081,13 +1225,14 @@ namespace Xtensive.Orm.Tests.Storage
       ExecuteNonQuery(commandText);
     }
 
-    private System.Action CreateTableDelayed(Catalog catalog, string schema, string tableName, string[] columns, SqlValueType[] columnTypes, bool useDatabasePrefix = false)
+    private System.Action CreateTableDelayed(
+      Catalog catalog, string schemaName, string tableName, string[] columnNames, SqlValueType[] columnTypes, bool useDatabasePrefix = false)
     {
-      var schemaToAlter = catalog.Schemas[schema] ?? catalog.Schemas[0];
+      var schemaToAlter = catalog.Schemas[schemaName] ?? catalog.Schemas[0];
       var table = schemaToAlter.CreateTable(tableName);
 
-      for (var i = 0; i < columns.Length; i++) {
-        _ = new TableColumn(table, columns[i], columnTypes[i]);
+      for (var i = 0; i < columnNames.Length; i++) {
+        _ = new TableColumn(table, columnNames[i], columnTypes[i]);
       }
 
       var create = SqlDdl.Create(table);
@@ -1106,12 +1251,10 @@ namespace Xtensive.Orm.Tests.Storage
       }
     }
 
-    private static SqlCompilerConfiguration BuildCompilerConfig(bool useDatabasePrefix)
-    {
-      return new SqlCompilerConfiguration {
+    private static SqlCompilerConfiguration BuildCompilerConfig(bool useDatabasePrefix) =>
+      new SqlCompilerConfiguration {
         DatabaseQualifiedObjects = useDatabasePrefix
       };
-    }
 
     private void SetMultidatabase()
     {
@@ -1141,16 +1284,13 @@ namespace Xtensive.Orm.Tests.Storage
       const int IntPrecision = 10;
       const int LongPrecision = 20;
 
-      if (sqlType == SqlType.Int16) {
-        return new SqlValueType(SqlType.Decimal, ShortPrecision, 0);
-      }
-      if (sqlType == SqlType.Int32) {
-        return new SqlValueType(SqlType.Decimal, IntPrecision, 0);
-      }
-      if (sqlType == SqlType.Int64) {
-        return new SqlValueType(SqlType.Decimal, LongPrecision, 0);
-      }
-      return new SqlValueType(sqlType);
+      return sqlType == SqlType.Int16
+        ? new SqlValueType(SqlType.Decimal, ShortPrecision, 0)
+        : sqlType == SqlType.Int32
+          ? new SqlValueType(SqlType.Decimal, IntPrecision, 0)
+          : sqlType == SqlType.Int64
+            ? new SqlValueType(SqlType.Decimal, LongPrecision, 0)
+            : new SqlValueType(sqlType);
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/IngoreRulesConfigureTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/IngoreRulesConfigureTest.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Tests.Storage
       const string SomeColumn = "SomeColumn";
       const string SomeIndex = "SomeIndex";
 
-      var invalidFactories = new TestDelegate[] {
+      var invalidCases = new TestDelegate[] {
         () => new IgnoreRule(SomeDB, SomeSchema, SomeTable, SomeColumn, SomeIndex),
         () => new IgnoreRule("", SomeSchema, SomeTable, SomeColumn, SomeIndex),
         () => new IgnoreRule(SomeDB, "", SomeTable, SomeColumn, SomeIndex),
@@ -37,17 +37,77 @@ namespace Xtensive.Orm.Tests.Storage
         () => new IgnoreRule("", "", SomeTable, SomeColumn, SomeIndex),
         () => new IgnoreRule(SomeDB, "", "", SomeColumn, SomeIndex),
         () => new IgnoreRule("", SomeSchema, "", SomeColumn, SomeIndex),
-        () => new IgnoreRule("", "", "", SomeColumn, SomeIndex)
+        () => new IgnoreRule("", "", "", SomeColumn, SomeIndex),
+
+        () => new IgnoreRule() { Table = SomeTable, Column = SomeColumn, Index = SomeIndex },
+        () => new IgnoreRule() { Table = SomeTable, Index = SomeIndex, Column = SomeColumn }
       };
 
-      foreach (var func in invalidFactories) {
+      foreach (var func in invalidCases) {
         _ = Assert.Throws<InvalidOperationException>(func);
       }
+    }
 
-      _ = Assert.Throws<InvalidOperationException>(
-        () => new IgnoreRule() { Table = SomeTable, Column = SomeColumn, Index = SomeIndex, });
-      _ = Assert.Throws<InvalidOperationException>(
-        () => new IgnoreRule() { Table = SomeTable, Index = SomeIndex, Column = SomeColumn, });
+    [Test]
+    public void ValidRules()
+    {
+      const string SomeDB = "SomeDB";
+      const string SomeSchema = "SomeSchema";
+      const string SomeTable = "SomeTable";
+      const string SomeColumn = "SomeColumn";
+      const string SomeIndex = "SomeIndex";
+
+      var validCases = new TestDelegate[] {
+        () => new IgnoreRule(SomeDB, SomeSchema, SomeTable, null, SomeIndex),
+        () => new IgnoreRule(SomeDB, SomeSchema, SomeTable, SomeColumn, null),
+
+        () => new IgnoreRule(SomeDB, SomeSchema, SomeTable, "", SomeIndex),
+        () => new IgnoreRule(SomeDB, SomeSchema, SomeTable, SomeColumn, ""),
+
+        () => new IgnoreRule("", SomeSchema, SomeTable, "", SomeIndex),
+        () => new IgnoreRule(SomeDB, "", SomeTable, "", SomeIndex),
+        () => new IgnoreRule(SomeDB, SomeSchema, "", "", SomeIndex),
+        () => new IgnoreRule("", "", SomeTable, "", SomeIndex),
+        () => new IgnoreRule(SomeDB, "", "", "", SomeIndex),
+        () => new IgnoreRule("", SomeSchema, "", "", SomeIndex),
+        () => new IgnoreRule("", "", "", "", SomeIndex),
+
+        () => new IgnoreRule(null, SomeSchema, SomeTable, null, SomeIndex),
+        () => new IgnoreRule(SomeDB, null, SomeTable, null, SomeIndex),
+        () => new IgnoreRule(SomeDB, SomeSchema, null, null, SomeIndex),
+        () => new IgnoreRule(null, null, SomeTable, null, SomeIndex),
+        () => new IgnoreRule(SomeDB, null, null, null, SomeIndex),
+        () => new IgnoreRule(null, SomeSchema, null, null, SomeIndex),
+        () => new IgnoreRule(null, null, null, null, SomeIndex),
+
+        () => new IgnoreRule("", SomeSchema, SomeTable, SomeTable, ""),
+        () => new IgnoreRule(SomeDB, "", SomeTable, SomeTable, ""),
+        () => new IgnoreRule(SomeDB, SomeSchema, "", SomeTable, ""),
+        () => new IgnoreRule("", "", SomeTable, SomeTable, ""),
+        () => new IgnoreRule(SomeDB, "", "", SomeTable, ""),
+        () => new IgnoreRule("", SomeSchema, "", SomeTable, ""),
+        () => new IgnoreRule("", "", "", SomeTable, ""),
+
+        () => new IgnoreRule(null, SomeSchema, SomeTable, SomeTable, null),
+        () => new IgnoreRule(SomeDB, null, SomeTable, SomeTable, null),
+        () => new IgnoreRule(SomeDB, SomeSchema, null, SomeTable, null),
+        () => new IgnoreRule(null, null, SomeTable, SomeTable, null),
+        () => new IgnoreRule(SomeDB, null, null, SomeTable, null),
+        () => new IgnoreRule(null, SomeSchema, null, SomeTable, null),
+        () => new IgnoreRule(null, null, null, SomeTable, null),
+
+        () => new IgnoreRule("", SomeSchema, SomeTable, "", ""),
+        () => new IgnoreRule(SomeDB, "", SomeTable, "", ""),
+        () => new IgnoreRule("", "", SomeTable, "", ""),
+
+        () => new IgnoreRule(null, SomeSchema, SomeTable, null, null),
+        () => new IgnoreRule(SomeDB, null, SomeTable, null, null),
+        () => new IgnoreRule(null, null, SomeTable, null, null),
+      };
+
+      foreach (var func in validCases) {
+         Assert.DoesNotThrow(func);
+      }
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/IngoreRulesConfigureTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/IngoreRulesConfigureTest.cs
@@ -1,0 +1,53 @@
+// Copyright (C) 2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  [TestFixture]
+  public class IngoreRulesConfigureTest
+  {
+    [Test]
+    public void NoColumnOrTableIgnoredTest()
+    {
+      var configuration = DomainConfigurationFactory.Create();
+      configuration.IgnoreRules.Add(new IgnoreRule());
+
+      _ = Assert.Throws<InvalidOperationException>(() => configuration.Lock());
+    }
+
+    [Test]
+    public void CheckColumnOrIndexDeclaredTest()
+    {
+      const string SomeDB = "SomeDB";
+      const string SomeSchema = "SomeSchema";
+      const string SomeTable = "SomeTable";
+      const string SomeColumn = "SomeColumn";
+      const string SomeIndex = "SomeIndex";
+
+      var invalidFactories = new TestDelegate[] {
+        () => new IgnoreRule(SomeDB, SomeSchema, SomeTable, SomeColumn, SomeIndex),
+        () => new IgnoreRule("", SomeSchema, SomeTable, SomeColumn, SomeIndex),
+        () => new IgnoreRule(SomeDB, "", SomeTable, SomeColumn, SomeIndex),
+        () => new IgnoreRule(SomeDB, SomeSchema, "", SomeColumn, SomeIndex),
+        () => new IgnoreRule("", "", SomeTable, SomeColumn, SomeIndex),
+        () => new IgnoreRule(SomeDB, "", "", SomeColumn, SomeIndex),
+        () => new IgnoreRule("", SomeSchema, "", SomeColumn, SomeIndex),
+        () => new IgnoreRule("", "", "", SomeColumn, SomeIndex)
+      };
+
+      foreach (var func in invalidFactories) {
+        _ = Assert.Throws<InvalidOperationException>(func);
+      }
+
+      _ = Assert.Throws<InvalidOperationException>(
+        () => new IgnoreRule() { Table = SomeTable, Column = SomeColumn, Index = SomeIndex, });
+      _ = Assert.Throws<InvalidOperationException>(
+        () => new IgnoreRule() { Table = SomeTable, Index = SomeIndex, Column = SomeColumn, });
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.xsd
+++ b/Orm/Xtensive.Orm.xsd
@@ -163,13 +163,11 @@
     <xs:sequence>
       <xs:element name="rule" maxOccurs="unbounded">
         <xs:complexType>
-          <xs:choice minOccurs="0">
-            <xs:element name="column" type="xs:string"/>
-            <xs:element name="index" type="xs:string"/>
-          </xs:choice>
           <xs:attribute name="database" type="xs:string" use="optional"/>
           <xs:attribute name="schema" type="xs:string" use="optional"/>
           <xs:attribute name="table" type="xs:string" use="optional"/>
+          <xs:attribute name="column" type="xs:string" use="optional"/>
+          <xs:attribute name="index" type="xs:string" use="optional"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>

--- a/Orm/Xtensive.Orm.xsd
+++ b/Orm/Xtensive.Orm.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   Copyright (C) 2013 Xtensive LLC.
@@ -32,7 +32,7 @@
                   </xs:all>
                   <xs:attribute name="upgradeMode" type="domainUpgradeMode" default="Default" use="optional"/>
                   <xs:attribute name="foreignKeyMode" type="foreignKeyMode" default="Default" use="optional"/>
-				  <xs:attribute name="fullTextChangeTrackingMode" type="fullTextChangeTrackingMode" default="Default" use="optional"/>
+                  <xs:attribute name="fullTextChangeTrackingMode" type="fullTextChangeTrackingMode" default="Default" use="optional"/>
                   <xs:attribute name="name" type="xs:string" default="" use="optional"/>
                   <xs:attribute name="provider" type="providerEnumeration" default="sqlserver" use="optional"/>
                   <xs:attribute name="connectionString" type="xs:string" default="null" use="optional"/>
@@ -163,10 +163,13 @@
     <xs:sequence>
       <xs:element name="rule" maxOccurs="unbounded">
         <xs:complexType>
+          <xs:choice minOccurs="0">
+            <xs:element name="column" type="xs:string"/>
+            <xs:element name="index" type="xs:string"/>
+          </xs:choice>
           <xs:attribute name="database" type="xs:string" use="optional"/>
           <xs:attribute name="schema" type="xs:string" use="optional"/>
           <xs:attribute name="table" type="xs:string" use="optional"/>
-          <xs:attribute name="column" type="xs:string" use="optional"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -677,8 +677,8 @@ namespace Xtensive.Orm.Configuration
     private void ValidateIgnoreConfiguration()
     {
       foreach (var ignoreRule in IgnoreRules) {
-        if (string.IsNullOrEmpty(ignoreRule.Table) && string.IsNullOrEmpty(ignoreRule.Column))
-          throw new InvalidOperationException(string.Format(Strings.ExIgnoreRuleXMustBeAppliedToColumnOrTable, ignoreRule));
+        if (string.IsNullOrEmpty(ignoreRule.Table) && string.IsNullOrEmpty(ignoreRule.Column) && string.IsNullOrEmpty(ignoreRule.Index))
+          throw new InvalidOperationException(string.Format(Strings.ExIgnoreRuleXMustBeAppliedToColumnIndexOrTable, ignoreRule));
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/IgnoreRuleElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/IgnoreRuleElement.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2013 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
 // Created:    2013.08.16
 
@@ -19,12 +19,16 @@ namespace Xtensive.Orm.Configuration.Elements
     private const string SchemaElementName = "schema";
     private const string TableElementName = "table";
     private const string ColumnElementName = "column";
+    private const string IndexElementName = "index";
 
     /// <inheritdoc />
-    public override object Identifier
-    {
-      get { return new Tuple<string, string, string, string>(Database ?? string.Empty, Schema ?? string.Empty, Table ?? string.Empty, Column ?? string.Empty); }
-    }
+    public override object Identifier => 
+      new Tuple<string, string, string, string, string>(
+        Database ?? string.Empty,
+        Schema ?? string.Empty,
+        Table ?? string.Empty,
+        Column ?? string.Empty,
+        Index ?? string.Empty);
 
     /// <summary>
     /// <see cref="IgnoreRule.Database" copy="true"/>
@@ -32,8 +36,8 @@ namespace Xtensive.Orm.Configuration.Elements
     [ConfigurationProperty(DatabaseElementName)]
     public string Database
     {
-      get { return (string)this[DatabaseElementName]; }
-      set { this[DatabaseElementName] = value; }
+      get => (string) this[DatabaseElementName];
+      set => this[DatabaseElementName] = value;
     }
 
     /// <summary>
@@ -42,8 +46,8 @@ namespace Xtensive.Orm.Configuration.Elements
     [ConfigurationProperty(SchemaElementName)]
     public string Schema
     {
-      get { return (string) this[SchemaElementName]; }
-      set { this[SchemaElementName] = value; }
+      get => (string) this[SchemaElementName];
+      set => this[SchemaElementName] = value;
     }
 
     /// <summary>
@@ -52,8 +56,8 @@ namespace Xtensive.Orm.Configuration.Elements
     [ConfigurationProperty(TableElementName)]
     public string Table
     {
-      get { return (string) this[TableElementName]; }
-      set { this[TableElementName] = value; }
+      get => (string) this[TableElementName];
+      set => this[TableElementName] = value;
     }
 
     /// <summary>
@@ -62,17 +66,24 @@ namespace Xtensive.Orm.Configuration.Elements
     [ConfigurationProperty(ColumnElementName)]
     public string Column
     {
-      get { return (string)this[ColumnElementName]; }
-      set { this[ColumnElementName] = value; }
+      get => (string) this[ColumnElementName];
+      set => this[ColumnElementName] = value;
+    }
+
+    /// <summary>
+    /// <see cref="IgnoreRule.Index"/>
+    /// </summary>
+    [ConfigurationProperty(IndexElementName)]
+    public string Index
+    {
+      get => (string) this[IndexElementName];
+      set => this[IndexElementName] = value;
     }
 
     /// <summary>
     /// Converts this instance to corresponding <see cref="IgnoreRule"/>.
     /// </summary>
     /// <returns>Result of conversion.</returns>
-    public IgnoreRule ToNative()
-    {
-      return new IgnoreRule(Database, Schema, Table, Column);
-    }
+    public IgnoreRule ToNative() => new IgnoreRule(Database, Schema, Table, Column, Index);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Configuration/IgnoreRule.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/IgnoreRule.cs
@@ -1,16 +1,17 @@
-// Copyright (C) 2013 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2013-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
 // Created:    2013.08.16
 
+using System;
 using System.Text;
 using Xtensive.Core;
 
 namespace Xtensive.Orm.Configuration
 {
   /// <summary>
-  /// Ignore rules for presistent types
+  /// Ignore rule for items in database (tables, columns, indexes).
   /// </summary>
   public sealed class IgnoreRule : LockableBase
   {
@@ -18,33 +19,31 @@ namespace Xtensive.Orm.Configuration
     private string schema;
     private string table;
     private string column;
-
+    private string index;
 
     /// <summary>
-    /// Gets database that is assigned to ignored type when this rule is applied
+    /// Gets database that the rule should be applied to.
     /// If this property is set to null or empty value <see cref="DomainConfiguration.DefaultDatabase"/>
     /// is used instead.
     /// </summary>
     public string Database
     {
-      get { return database; }
-      set
-      {
+      get => database;
+      set {
         EnsureNotLocked();
         database = value;
       }
     }
 
     /// <summary>
-    /// Get schema that is assigned to ignored type when this rule is applied
+    /// Get schema that the rule should be applied to.
     /// If this property is set to null or empty value <see cref="DomainConfiguration.DefaultSchema"/>
     /// is used instead.
     /// </summary>
     public string Schema
     {
-      get { return schema; }
-      set
-      {
+      get => schema;
+      set {
         EnsureNotLocked();
         schema = value;
       }
@@ -52,32 +51,43 @@ namespace Xtensive.Orm.Configuration
 
 
     /// <summary>
-    /// Gets table condition.
-    /// When type is declared in the specified table, this rule is applied.
+    /// Gets table condition (exact name, prefix or suffix by using asterisk).
     /// If this property is set to null value, any table matches this rule.
     /// </summary>
     public string Table
     {
-      get { return table; }
-      set
-      {
+      get => table;
+      set {
         EnsureNotLocked();
         table = value;
       }
     }
 
     /// <summary>
-    /// Gets column condition
-    /// When type is declared in the specified column, this rule is applied.
+    /// Gets column condition (exact name, prefix or suffix by using asterisk).
     /// If this property is set to null value, any culumn matches this rule.
     /// </summary>
+    /// <remarks>Either <see cref="Column"/> or <see cref="Index"/> can be declared.</remarks>
     public string Column
     {
-      get { return column; }
-      set
-      {
+      get => column;
+      set {
         EnsureNotLocked();
-        column = value;
+        SetColumnWithCheck(value);
+      }
+    }
+
+    /// <summary>
+    /// Gets index condition (exact name, prefix or suffix by using asterisk).
+    /// If this property is set to null value, any index matches this rule.
+    /// </summary>
+    /// <remarks>Either <see cref="Index"/> or <see cref="Column"/> can be declared.</remarks>
+    public string Index
+    {
+      get => index;
+      set {
+        EnsureNotLocked();
+        SetIndexWithCheck(value);
       }
     }
 
@@ -85,21 +95,25 @@ namespace Xtensive.Orm.Configuration
     public override string ToString()
     {
       var separator = ", ";
-      StringBuilder sb = new StringBuilder();
-      
+
       var databasePart = !string.IsNullOrEmpty(database) ? $"Database = {database}" : "<default database>";
       var schemaPart = !string.IsNullOrEmpty(schema) ? $"Schema = {schema}" : "<default schema>";
       var tablePart = !string.IsNullOrEmpty(table) ? $"Table = {table}" : "<any table>";
-      var columnPart = !string.IsNullOrEmpty(column) ? $"Column = {column}" : "<any column>";
-      sb.Append(databasePart)
+
+      var columnOrIndexPart = !string.IsNullOrEmpty(column)
+        ? $"Column = {column}"
+        : (!string.IsNullOrEmpty(index))
+          ? $"Index = {index}"
+          : "<any column> OR <any index>";
+
+      return new StringBuilder(databasePart)
         .Append(separator)
         .Append(schemaPart)
         .Append(separator)
         .Append(tablePart)
         .Append(separator)
-        .Append(columnPart);
-
-      return sb.ToString();
+        .Append(columnOrIndexPart)
+        .ToString();
     }
 
     /// <summary>
@@ -108,7 +122,23 @@ namespace Xtensive.Orm.Configuration
     /// <returns>Cloned instance</returns>
     public IgnoreRule Clone()
     {
-      return new IgnoreRule(database, schema, table, column);
+      return new IgnoreRule(database, schema, table, column, index);
+    }
+
+    private void SetColumnWithCheck(in string columnToSet)
+    {
+      if (!string.IsNullOrEmpty(columnToSet) && !string.IsNullOrEmpty(index)) {
+        throw new InvalidOperationException(string.Format(Strings.ExIgnoreRuleIsAlreadyConfiguredForX, nameof(Index)));
+      }
+      column = columnToSet;
+    }
+
+    private void SetIndexWithCheck(in string indexToSet)
+    {
+      if (!string.IsNullOrEmpty(indexToSet) && !string.IsNullOrEmpty(column)) {
+        throw new InvalidOperationException(string.Format(Strings.ExIgnoreRuleIsAlreadyConfiguredForX, nameof(Column)));
+      }
+      index = indexToSet;
     }
 
     //Constructors
@@ -127,12 +157,14 @@ namespace Xtensive.Orm.Configuration
     /// <param name="schema">Value for <see cref="Schema"/></param>
     /// <param name="table">Value for <see cref="Table"/></param>
     /// <param name="column">Value for <see cref="Column"/></param>
-    public IgnoreRule (string database, string schema, string table, string column)
+    /// <param name="index">Value for <see cref="Index"/></param>
+    internal IgnoreRule(in string database, in string schema, in string table, in string column, in string index)
     {
       Database = database;
       Schema = schema;
       Table = table;
       Column = column;
+      Index = index;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Configuration/IgnoreRuleCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/IgnoreRuleCollection.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2013 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
 // Created:    2013.08.16
 
@@ -36,6 +36,16 @@ namespace Xtensive.Orm.Configuration
       var rule = new IgnoreRule {Column = columnName};
       Add(rule);
       return new IgnoreRuleConstructionFlow(rule);
+    }
+
+    /// <summary>
+    /// Adds to collection <see cref="IgnoreRule"/> for targeted specified <paramref name="indexName"/>. 
+    /// </summary>
+    /// <param name="indexName">Index to ignore</param>
+    /// <returns><see cref="IgnoreRule"/> construction flow</returns>
+    public IIgnoreRuleConstructionFlow IgnoreIndex(string indexName)
+    {
+      throw new NotImplementedException();
     }
 
     /// <inheritdoc />

--- a/Orm/Xtensive.Orm/Orm/Configuration/IgnoreRuleCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/IgnoreRuleCollection.cs
@@ -45,7 +45,9 @@ namespace Xtensive.Orm.Configuration
     /// <returns><see cref="IgnoreRule"/> construction flow</returns>
     public IIgnoreRuleConstructionFlow IgnoreIndex(string indexName)
     {
-      throw new NotImplementedException();
+      var rule = new IgnoreRule { Index = indexName };
+      Add(rule);
+      return new IgnoreRuleConstructionFlow(rule);
     }
 
     /// <inheritdoc />

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/IgnoreRulesHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/IgnoreRulesHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013-2020 Xtensive LLC.
+// Copyright (C) 2013-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
@@ -10,6 +10,7 @@ using System.Linq;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Providers;
+using Xtensive.Orm.Rse;
 using Xtensive.Sql.Model;
 
 namespace Xtensive.Orm.Upgrade
@@ -31,8 +32,9 @@ namespace Xtensive.Orm.Upgrade
     {
       foreach (var ignoreRule in ignoreRules) {
         var schema = mappingResolver.ResolveSchema(targetModel, ignoreRule.Database, ignoreRule.Schema);
-        if (schema!=null)
+        if (schema != null) {
           VisitSchema(schema, ignoreRule);
+        }
       }
       return targetModel;
     }
@@ -42,59 +44,99 @@ namespace Xtensive.Orm.Upgrade
       foreignKeysOfSchema = schema.Tables.SelectMany(t => t.TableConstraints.OfType<ForeignKey>()).ToList();
       var matcher = RuleMatcher<Table>.Create(rule.Table);
       var matchedTables = matcher.Get(schema.Tables);
-      if (!MatchingHelper.IsMatchAll(rule.Column))
-        foreach (var table in matchedTables)
+      if (!MatchingHelper.IsMatchAll(rule.Column) || !MatchingHelper.IsMatchAll(rule.Index)) {
+        foreach (var table in matchedTables) {
           VisitTable(table, rule);
-      else
-        foreach (var table in matchedTables)
+        }
+      }
+      else {
+        foreach (var table in matchedTables) {
           RemoveTable(schema.Tables, table);
+        }
+      }
     }
 
     private void VisitTable(Table table, IgnoreRule rule)
     {
-      var matcher = RuleMatcher<TableColumn>.Create(rule.Column);
-      var matchedColumns = matcher.Get(table.TableColumns);
-      foreach (var matchedColumn in matchedColumns)
-        RemoveColumn(table.TableColumns, matchedColumn);
+      var isColumnRule = !string.IsNullOrEmpty(rule.Column);
+      if (isColumnRule) {
+        var matcher = RuleMatcher<TableColumn>.Create(rule.Column);
+        var matchedColumns = matcher.Get(table.TableColumns);
+        foreach (var matchedColumn in matchedColumns) {
+          RemoveColumn(table.TableColumns, matchedColumn);
+        }
+      }
+      else {
+        var matcher = RuleMatcher<Xtensive.Sql.Model.Index>.Create(rule.Index);
+        var matchedIndexes = matcher.Get(table.Indexes);
+        foreach (var matchedIndex in matchedIndexes) {
+          RemoveIndex(table.Indexes, matchedIndex);
+        }
+      }
+      
     }
 
     private void RemoveTable(PairedNodeCollection<Schema, Table> tables, Table tableToRemove)
     {
-      foreach (var foreignKey in foreignKeysOfSchema)
-        if (foreignKey.Owner==tableToRemove || foreignKey.ReferencedTable==tableToRemove) {
-          if (foreignKey.Owner==tableToRemove) {
+      foreach (var foreignKey in foreignKeysOfSchema) {
+        if (foreignKey.Owner == tableToRemove || foreignKey.ReferencedTable == tableToRemove) {
+          if (foreignKey.Owner == tableToRemove) {
             var resolvedTableName = mappingResolver.GetNodeName(foreignKey.ReferencedTable);
-            if (!targetModel.LockedTables.ContainsKey(resolvedTableName))
-              targetModel.LockedTables.Add(resolvedTableName, string.Format(Strings.ExTableXCantBeRemovedDueToForeignKeyYOfIgnoredTableOrColumn, foreignKey.ReferencedTable.Name, foreignKey.Name));
+            if (!targetModel.LockedTables.ContainsKey(resolvedTableName)) {
+              targetModel.LockedTables.Add(resolvedTableName,
+                string.Format(Strings.ExTableXCantBeRemovedDueToForeignKeyYOfIgnoredTableOrColumn,
+                  foreignKey.ReferencedTable.Name, foreignKey.Name));
+            }
           }
-          foreignKey.Owner.TableConstraints.Remove(foreignKey);
+          _ = foreignKey.Owner.TableConstraints.Remove(foreignKey);
         }
-      tables.Remove(tableToRemove);
+      }
+
+      _ = tables.Remove(tableToRemove);
     }
 
     private void RemoveColumn(PairedNodeCollection<Table, TableColumn> columns, TableColumn columnToRemove)
     {
       RemoveForeignKeys(columnToRemove);
       RemoveIndexes(columnToRemove.Table, columnToRemove.Name);
+
       var resolvedTableName = mappingResolver.GetNodeName(columnToRemove.Table);
-      if (!targetModel.LockedTables.ContainsKey(resolvedTableName))
-        targetModel.LockedTables.Add(resolvedTableName, string.Format(Strings.ExTableXCantBeRemovedDueToTheIgnoredColumnY, columnToRemove.Table.Name, columnToRemove.Name));
-      columns.Remove(columnToRemove);
+      if (!targetModel.LockedTables.ContainsKey(resolvedTableName)) {
+        targetModel.LockedTables.Add(resolvedTableName,
+          string.Format(Strings.ExTableXCantBeRemovedDueToTheIgnoredColumnY,
+            columnToRemove.Table.Name, columnToRemove.Name));
+      }
+      _ = columns.Remove(columnToRemove);
+    }
+
+    private void RemoveIndex(PairedNodeCollection<DataTable, Xtensive.Sql.Model.Index> indexes, Xtensive.Sql.Model.Index indexToRemove)
+    {
+      var resolvedTableName = mappingResolver.GetNodeName((Table)indexToRemove.DataTable);
+      if (!targetModel.LockedTables.ContainsKey(resolvedTableName)) {
+        targetModel.LockedTables.Add(resolvedTableName,
+          string.Format(Strings.ExTableXCantBeRemovedDueToTheIgnoredColumnY,
+            ((Table) indexToRemove.DataTable).Name, indexToRemove.Name));
+      }
+      _ = indexes.Remove(indexToRemove);
     }
 
     private void RemoveForeignKeys(TableColumn referencedColumn)
     {
       foreach (var foreignKey in foreignKeysOfSchema) {
-        if (foreignKey.ReferencedColumns.Contains(referencedColumn))
-          foreignKey.Owner.TableConstraints.Remove(foreignKey);
+        if (foreignKey.ReferencedColumns.Contains(referencedColumn)) {
+          _ = foreignKey.Owner.TableConstraints.Remove(foreignKey);
+        }
 
         if (foreignKey.Columns.Contains(referencedColumn)) {
-          if (foreignKey.Owner==referencedColumn.Table) {
+          if (foreignKey.Owner == referencedColumn.Table) {
             var resolvedTableName = mappingResolver.GetNodeName(foreignKey.ReferencedTable);
-            if (!targetModel.LockedTables.ContainsKey(resolvedTableName))
-              targetModel.LockedTables.Add(resolvedTableName, string.Format(Strings.ExTableXCantBeRemovedDueToForeignKeyYOfIgnoredTableOrColumn, foreignKey.ReferencedTable.Name, foreignKey.Name));
+            if (!targetModel.LockedTables.ContainsKey(resolvedTableName)) {
+              targetModel.LockedTables.Add(resolvedTableName,
+                string.Format(Strings.ExTableXCantBeRemovedDueToForeignKeyYOfIgnoredTableOrColumn,
+                  foreignKey.ReferencedTable.Name, foreignKey.Name));
+            }
           }
-          foreignKey.Owner.TableConstraints.Remove(foreignKey);
+          _ = foreignKey.Owner.TableConstraints.Remove(foreignKey);
         }
       }
     }
@@ -104,8 +146,9 @@ namespace Xtensive.Orm.Upgrade
       var indexes = table.Indexes.Select(index => index)
         .Where(item => item.Columns.Any(column => stringComparer.Equals(column.Name, columnName)))
         .ToList();
-      foreach (var index in indexes)
-        table.Indexes.Remove(index);
+      foreach (var index in indexes) {
+        _ = table.Indexes.Remove(index);
+      }
     }
 
     // Constructors

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -1969,9 +1969,9 @@ namespace Xtensive {
         /// <summary>
         ///   Looks up a localized string similar to Ignore rule &apos;{0}&apos; must be applied to column or table..
         /// </summary>
-        internal static string ExIgnoreRuleXMustBeAppliedToColumnOrTable {
+        internal static string ExIgnoreRuleXMustBeAppliedToColumnIndexOrTable {
             get {
-                return ResourceManager.GetString("ExIgnoreRuleXMustBeAppliedToColumnOrTable", resourceCulture);
+                return ResourceManager.GetString("ExIgnoreRuleXMustBeAppliedToColumnIndexOrTable", resourceCulture);
             }
         }
         

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -1958,6 +1958,15 @@ namespace Xtensive {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rule is already configured for {0}..
+        /// </summary>
+        internal static string ExIgnoreRuleIsAlreadyConfiguredForX {
+            get {
+                return ResourceManager.GetString("ExIgnoreRuleIsAlreadyConfiguredForX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ignore rule &apos;{0}&apos; must be applied to column or table..
         /// </summary>
         internal static string ExIgnoreRuleXMustBeAppliedToColumnOrTable {

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -2354,8 +2354,8 @@ Error: {1}</value>
   <data name="ExNonLinqCallsAreNotSupportedWithinQueryExecuteDelayed" xml:space="preserve">
     <value>Non-LINQ calls are not supported within Query.ExecuteDelayed</value>
   </data>
-  <data name="ExIgnoreRuleXMustBeAppliedToColumnOrTable" xml:space="preserve">
-    <value>Ignore rule '{0}' must be applied to column or table.</value>
+  <data name="ExIgnoreRuleXMustBeAppliedToColumnIndexOrTable" xml:space="preserve">
+    <value>Ignore rule '{0}' must be applied to column, index or table.</value>
   </data>
   <data name="ExTableXCantBeRemovedDueToForeignKeyYOfIgnoredTableOrColumn" xml:space="preserve">
     <value>Table '{0}' can't be removed due to the foreign key '{1}' of a ignored table or column.</value>

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -2582,4 +2582,7 @@ Error: {1}</value>
   <data name="ExGivenTypeHasNoOrMoreThanOneCtorWithGivenParameters" xml:space="preserve">
     <value>The given type has no constructor with given parameters or more than one suitable constructor.</value>
   </data>
+  <data name="ExIgnoreRuleIsAlreadyConfiguredForX" xml:space="preserve">
+    <value>Rule is already configured for {0}.</value>
+  </data>
 </root>


### PR DESCRIPTION
IgnoreRule now supports Index as well.

Breaking change: now only one constructor of IgnoreRule is available publicly - parameterless. IgnoreRuleCollection API and rule construction flow have no breaking changes though.

Now issue #192 can be overcame by configuring some rules.