### PR TITLE
Improved mechanism of schema and catalog name replacement

### DIFF
--- a/ChangeLog/7.1.0-Beta-2-dev.txt
+++ b/ChangeLog/7.1.0-Beta-2-dev.txt
@@ -7,6 +7,10 @@
 [main] Obsolete Query's members have been removed
 [main] Obsolete members of DelayedScalarQuery<T> have been removed
 [main] Obsolete FieldInfo.IsDynalicallyDefined property's been removed (FieldInfo.IsDynamicallyDefined is still there)
+[main] Changed translation of queries when DomainConfiguration.ShareStorageSchemaOverNodes set to true
+[main] StorageDriver.Compile(ISqlCompileUnit, NodeConfiguration) became obsolete
+[main] SqlNodeActualizer became obsolete
+[main] SqlCompilerConfiguration's DatabaseMapping and SchemaMapping moved to SqlPostCompilerConfiguration
 [main] Some EventArgs inheritors that were sealed classes transformed to read-only structures
 [main] DbCommandEventArgs became read-only structure
 [main] SqlCustomFunctionCall and SqlFunctionCall share one base type

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Translator.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Translator.cs
@@ -215,7 +215,8 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
     }
 
     /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SchemaNode node) => TranslateIdentifier(context.Output, node.Name);
+    public override void Translate(SqlCompilerContext context, SchemaNode node) =>
+      base.Translate(context, node);
 
     /// <inheritdoc/>
     public override void Translate(SqlCompilerContext context, SqlCreateTable node, CreateTableSection section)

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Translator.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Translator.cs
@@ -579,9 +579,8 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
 
     public virtual void Translate(SqlCompilerContext context, SqlRenameColumn action) //TODO: Work on this.
     {
-      string schemaName = action.Column.Table.Schema.DbName;
-      string tableName = action.Column.Table.DbName;
-      string columnName = action.Column.DbName;
+      var column = action.Column;
+      var tableName = column.Table.DbName;
 
       //alter table `actor` change column last_name1 last_name varchar(45)
 
@@ -589,11 +588,11 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
       _ = output.Append("ALTER TABLE ");
       TranslateIdentifier(output, tableName);
       _ = output.Append(" CHANGE COLUMN ");
-      TranslateIdentifier(output, columnName);
+      TranslateIdentifier(output, column.DbName);
       _ = output.AppendSpace();
       TranslateIdentifier(output, action.NewName);
       _ = output.AppendSpace()
-        .Append(Translate(action.Column.DataType));
+        .Append(Translate(column.DataType));
     }
 
     // Constructors

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
@@ -1250,15 +1250,15 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
         var sequenceMap = context.SequenceMap;
         foreach (var (segId, seq) in sequenceMap) {
           if (query.Length == 0) {
-            query.AppendFormat("SELECT * FROM (\nSELECT {0} as id, * FROM {1}", segId,
-              Driver.Translator.TranslateToString(null, seq)); // context is not used in PostrgreSQL translator
+            _ = query.AppendFormat("SELECT * FROM (\nSELECT {0} as id, * FROM {1}", segId,
+              SqlHelper.Quote(SqlHelper.EscapeSetup.WithQuotes, new[] { seq.Schema.DbName, seq.DbName }));
           }
           else {
-            query.AppendFormat("\nUNION ALL\nSELECT {0} as id, * FROM {1}", segId,
-              Driver.Translator.TranslateToString(null, seq)); // context is not used in PostgreSQL translator
+            _ = query.AppendFormat("\nUNION ALL\nSELECT {0} as id, * FROM {1}", segId,
+              SqlHelper.Quote(SqlHelper.EscapeSetup.WithQuotes, new[] { seq.Schema.DbName, seq.DbName }));
           }
         }
-        query.Append("\n) all_sequences\nORDER BY id");
+        _ = query.Append("\n) all_sequences\nORDER BY id");
       }
       return SqlDml.Fragment(SqlDml.Native(query.ToString()));
     }

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
@@ -222,22 +222,27 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       });
     }
 
+    ///// <inheritdoc/>
+    //public override string TranslateToString(SqlCompilerContext context, SchemaNode node)
+    //{
+    //  //temporary tables need no schema qualifier
+    //  if (node is TemporaryTable || node.Schema == null) {
+    //    return QuoteIdentifier(new[] { node.Name });
+    //  }
+    //  return QuoteIdentifier(new[] { node.Schema.Name, node.Name });
+    //}
+
     /// <inheritdoc/>
-    public override string TranslateToString(SqlCompilerContext context, SchemaNode node)
+    public override void Translate(SqlCompilerContext context, SchemaNode node)
     {
-      //temporary tables need no schema qualifier
-      if (!(node is TemporaryTable) && node.Schema != null) {
-        return context == null
-          ? QuoteIdentifier(new[] { node.Schema.Name, node.Name })
-          : QuoteIdentifier(new[] { context.SqlNodeActualizer.Actualize(node.Schema), node.Name });
-
+      if (node is TemporaryTable) {
+        TranslateIdentifier(context.Output, node.Name);
       }
-      return QuoteIdentifier(new[] { node.Name });
+      else {
+        base.Translate(context, node);
+      }
+      //context.Output.Append(TranslateToString(context, node));
     }
-
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SchemaNode node) =>
-      context.Output.Append(TranslateToString(context, node));
 
     /// <inheritdoc/>
     public override void Translate(SqlCompilerContext context, SqlCreateTable node, CreateTableSection section)

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
@@ -314,9 +314,9 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
     /// <inheritdoc/>
     public override void Translate(SqlCompilerContext context, SqlDropIndex node)
     {
+      var index = node.Index;
       _ = context.Output.Append("DROP INDEX ");
-      TranslateIdentifier(context.Output,
-        context.SqlNodeActualizer.Actualize(node.Index.DataTable.Schema), node.Index.Name);
+      TranslateIdentifier(context.Output, index.DataTable.Schema.DbName, index.DbName);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Translator.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Translator.cs
@@ -83,7 +83,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
       AddUseStatement(context, sequence.Schema.Catalog);
       _ = context.Output.Append(action)
         .Append(" SEQUENCE ");
-      TranslateIdentifier(context.Output, sequence.Schema.Name, sequence.Name);
+      TranslateIdentifier(context.Output, sequence.Schema.DbName, sequence.DbName);
     }
 
     public Translator(SqlDriver driver)

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Translator.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Translator.cs
@@ -306,7 +306,7 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
     /// <inheritdoc/>
     public override void Translate(SqlCompilerContext context, SqlDropIndex node)
     {
-      var index = node.Index
+      var index = node.Index;
       _ = context.Output.Append("DROP INDEX ");
       TranslateIdentifier(context.Output, index.DataTable.Schema.DbName, index.DbName);
     }

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Translator.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Translator.cs
@@ -306,10 +306,8 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
     /// <inheritdoc/>
     public override void Translate(SqlCompilerContext context, SqlDropIndex node)
     {
-      _ = context.Output.Append("DROP INDEX ")
-        .Append(context.SqlNodeActualizer.Actualize(node.Index.DataTable.Schema))
-        .Append(".");
-      TranslateIdentifier(context.Output, node.Index.DbName);
+      _ = context.Output.Append("DROP INDEX ");
+      TranslateIdentifier(context.Output, node.Index.DataTable.Schema.DbName, node.Index.DbName);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Translator.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Translator.cs
@@ -306,8 +306,9 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
     /// <inheritdoc/>
     public override void Translate(SqlCompilerContext context, SqlDropIndex node)
     {
+      var index = node.Index
       _ = context.Output.Append("DROP INDEX ");
-      TranslateIdentifier(context.Output, node.Index.DataTable.Schema.DbName, node.Index.DbName);
+      TranslateIdentifier(context.Output, index.DataTable.Schema.DbName, index.DbName);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm.Tests.Sql/MakeNamesUnreadableTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/MakeNamesUnreadableTest.cs
@@ -402,7 +402,7 @@ namespace Xtensive.Orm.Tests.Sql
       }
       else {
         var compilerConfiguration = new SqlCompilerConfiguration() { SharedStorageSchema = true };
-        _ = Assert.Throws<InvalidOperationException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
 
         var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
 

--- a/Orm/Xtensive.Orm.Tests.Sql/MakeNamesUnreadableTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/MakeNamesUnreadableTest.cs
@@ -366,7 +366,7 @@ namespace Xtensive.Orm.Tests.Sql
       if (IsMultidatabaseSupported) {
         var compilerConfiguration = new SqlCompilerConfiguration() { DatabaseQualifiedObjects = true, SharedStorageSchema = true };
 
-        _ = Assert.Throws<ArgumentNullException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        _ = Assert.Throws<InvalidOperationException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
 
         var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
 
@@ -385,7 +385,7 @@ namespace Xtensive.Orm.Tests.Sql
       if (IsMultischemaSupported) {
         var compilerConfiguration = new SqlCompilerConfiguration() { SharedStorageSchema = true };
 
-        _ = Assert.Throws<ArgumentNullException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        _ = Assert.Throws<InvalidOperationException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
 
         var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
         Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText(postCompilerConfiguration));
@@ -402,7 +402,7 @@ namespace Xtensive.Orm.Tests.Sql
       }
       else {
         var compilerConfiguration = new SqlCompilerConfiguration() { SharedStorageSchema = true };
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        _ = Assert.Throws<InvalidOperationException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
 
         var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
 

--- a/Orm/Xtensive.Orm.Tests.Sql/MakeNamesUnreadableTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/MakeNamesUnreadableTest.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2017 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2017-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
 // Created:    2017.03.24
 
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using Xtensive.Sql;
 using Xtensive.Sql.Compiler;
-using Xtensive.Sql.Info;
 using Xtensive.Sql.Model;
 
 namespace Xtensive.Orm.Tests.Sql
@@ -21,6 +20,8 @@ namespace Xtensive.Orm.Tests.Sql
     private const string SchemaName = "dbo";
     private const string DummySchemaName = "DummySchema";
     private const string DummyDatabaseName = "DummyDatabase";
+
+    private readonly Dictionary<string, string> emptyMap = new(0);
 
     [Test]
     public void ReadingNamesTest()
@@ -48,14 +49,14 @@ namespace Xtensive.Orm.Tests.Sql
 
       catalog.MakeNamesUnreadable();
 
-      Assert.Throws<InvalidOperationException>(() => {var catalogName = catalog.Name;});
-      Assert.Throws<InvalidOperationException>(() => {var catalogDbName = catalog.DbName;});
+      _ = Assert.Throws<InvalidOperationException>(() => { var catalogName = catalog.Name; });
+      _ = Assert.Throws<InvalidOperationException>(() => { var catalogDbName = catalog.DbName; });
 
       Assert.DoesNotThrow(() => {var catalogName = catalog.GetNameInternal();});
       Assert.DoesNotThrow(() => {var catalogDbName = catalog.GetDbNameInternal();});
 
-      Assert.Throws<InvalidOperationException>(() => {var schemaName = defaultSchema.Name;});
-      Assert.Throws<InvalidOperationException>(() => {var schemaName = defaultSchema.DbName;});
+      _ = Assert.Throws<InvalidOperationException>(() => {var schemaName = defaultSchema.Name;});
+      _ = Assert.Throws<InvalidOperationException>(() => {var schemaName = defaultSchema.DbName;});
 
       Assert.DoesNotThrow(() => {var schemaName = defaultSchema.GetNameInternal();});
       Assert.DoesNotThrow(() => {var schemaName = defaultSchema.GetDbNameInternal();});
@@ -115,11 +116,11 @@ namespace Xtensive.Orm.Tests.Sql
 
       catalog.MakeNamesUnreadable();
 
-      Assert.Throws<InvalidOperationException>(() => catalog.Name = newCatalogName);
-      Assert.Throws<InvalidOperationException>(() => catalog.DbName = newCatalogDbName);
+      _ = Assert.Throws<InvalidOperationException>(() => catalog.Name = newCatalogName);
+      _ = Assert.Throws<InvalidOperationException>(() => catalog.DbName = newCatalogDbName);
 
-      Assert.Throws<InvalidOperationException>(() => defaultSchema.Name = newSchemaName);
-      Assert.Throws<InvalidOperationException>(() => defaultSchema.DbName = newSchemaDbName);
+      _ = Assert.Throws<InvalidOperationException>(() => defaultSchema.Name = newSchemaName);
+      _ = Assert.Throws<InvalidOperationException>(() => defaultSchema.DbName = newSchemaDbName);
     }
 
     [Test]
@@ -129,8 +130,8 @@ namespace Xtensive.Orm.Tests.Sql
 
       var table = defaultSchema.CreateTable(string.Format("Crt1_{0}", TableName));
       var column = table.CreateColumn("Id", GetServerTypeFor(typeof (int)));
-      table.CreatePrimaryKey("PK_Crt_DenyNamesReadingTest", column);
-      column = table.CreateColumn("CreationDate", GetServerTypeFor(typeof (DateTime)));
+      _ = table.CreatePrimaryKey("PK_Crt_DenyNamesReadingTest", column);
+      _ = table.CreateColumn("CreationDate", GetServerTypeFor(typeof (DateTime)));
       var createTableQuery = SqlDdl.Create(table);
 
       TestQueryNamesReadable(createTableQuery, defaultSchema);
@@ -144,8 +145,8 @@ namespace Xtensive.Orm.Tests.Sql
 
       var table = defaultSchema.CreateTable(string.Format("Crt1_{0}", TableName));
       var column = table.CreateColumn("Id", GetServerTypeFor(typeof (int)));
-      table.CreatePrimaryKey("PK_Crt_DenyNamesReadingTest", column);
-      column = table.CreateColumn("CreationDate", GetServerTypeFor(typeof (DateTime)));
+      _ = table.CreatePrimaryKey("PK_Crt_DenyNamesReadingTest", column);
+      _ = table.CreateColumn("CreationDate", GetServerTypeFor(typeof (DateTime)));
       var createTableQuery = SqlDdl.Create(table);
 
       TestQueryNamesUnreadable(createTableQuery, defaultSchema);
@@ -307,51 +308,50 @@ namespace Xtensive.Orm.Tests.Sql
 
     private void TestQueryNamesReadable(ISqlCompileUnit query, Schema defaultSchema)
     {
-      string queryText = string.Empty;
+      var queryText = string.Empty;
 
-      if (MultidatabaseSupported()) {
-        var compilerConfiguration = new SqlCompilerConfiguration(new Dictionary<string, string>(), new Dictionary<string, string>()) {DatabaseQualifiedObjects = true};
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+      if (IsMultidatabaseSupported) {
+        var compilerConfiguration = new SqlCompilerConfiguration { DatabaseQualifiedObjects = true };
+        var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
+
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.True);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.True);
 
-        var schemaMap = new Dictionary<string, string> {{defaultSchema.GetDbNameInternal(), DummySchemaName}};
-        var databaseMap =new Dictionary<string, string> {{defaultSchema.Catalog.GetDbNameInternal(), DummyDatabaseName}};
-        compilerConfiguration = new SqlCompilerConfiguration(databaseMap, schemaMap) {DatabaseQualifiedObjects = true};
+        compilerConfiguration = new SqlCompilerConfiguration { DatabaseQualifiedObjects = true };
+        postCompilerConfiguration = new SqlPostCompilerConfiguration(GetDatabaseMap(defaultSchema.Catalog), GetSchemaMap(defaultSchema));
 
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.True);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.True);
         Assert.That(queryText.Contains(DummyDatabaseName), Is.False);
         Assert.That(queryText.Contains(DummySchemaName), Is.False);
       }
-      if (MultischemaSupported()) {
-        var compilerConfiguration = new SqlCompilerConfiguration(new Dictionary<string, string>(), new Dictionary<string, string>()) {DatabaseQualifiedObjects = false};
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+      if (IsMultischemaSupported) {
+        var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
+
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.True);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
 
-        var schemaMap = new Dictionary<string, string>() { { defaultSchema.GetDbNameInternal(), DummySchemaName } };
-        var databaseMap = new Dictionary<string, string>() { { defaultSchema.Catalog.GetDbNameInternal(), DummyDatabaseName } };
-        compilerConfiguration = new SqlCompilerConfiguration(databaseMap, schemaMap) { DatabaseQualifiedObjects = false };
+        postCompilerConfiguration = new SqlPostCompilerConfiguration(GetDatabaseMap(defaultSchema.Catalog), GetSchemaMap(defaultSchema));
 
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.True);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(DummyDatabaseName), Is.False);
         Assert.That(queryText.Contains(DummySchemaName), Is.False);
       }
       else {
-        var compilerConfiguration = new SqlCompilerConfiguration(new Dictionary<string, string>(), new Dictionary<string, string>()) {DatabaseQualifiedObjects = false};
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
+
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
 
-        var schemaMap = new Dictionary<string, string> {{defaultSchema.GetDbNameInternal(), DummySchemaName}};
-        var databaseMap = new Dictionary<string, string> {{defaultSchema.Catalog.GetDbNameInternal(), DummyDatabaseName}};
-        compilerConfiguration = new SqlCompilerConfiguration(databaseMap, schemaMap) { DatabaseQualifiedObjects = false };
+        postCompilerConfiguration = new SqlPostCompilerConfiguration(GetDatabaseMap(defaultSchema.Catalog), GetSchemaMap(defaultSchema));
 
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(DummyDatabaseName), Is.False);
@@ -361,58 +361,56 @@ namespace Xtensive.Orm.Tests.Sql
 
     private void TestQueryNamesUnreadable(ISqlCompileUnit query, Schema defaultSchema)
     {
-      string queryText = string.Empty;
+      var queryText = string.Empty;
 
-      if (MultidatabaseSupported()) {
-        Assert.Throws<ArgumentNullException>(() => queryText = Driver.Compile(query).GetCommandText());
+      if (IsMultidatabaseSupported) {
+        var compilerConfiguration = new SqlCompilerConfiguration() { DatabaseQualifiedObjects = true, SharedStorageSchema = true };
 
-        var compilerConfiguration =
-          new SqlCompilerConfiguration(new Dictionary<string, string>(), new Dictionary<string, string>()) {DatabaseQualifiedObjects = true};
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        _ = Assert.Throws<ArgumentNullException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+
+        var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
+
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.True);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.True);
 
-        var schemaMap = new Dictionary<string, string> {{defaultSchema.GetDbNameInternal(), DummySchemaName}};
-        var databaseMap = new Dictionary<string, string> {{defaultSchema.Catalog.GetDbNameInternal(), DummyDatabaseName}};
-        compilerConfiguration = new SqlCompilerConfiguration(databaseMap, schemaMap) {DatabaseQualifiedObjects = true};
+        postCompilerConfiguration = new SqlPostCompilerConfiguration(GetDatabaseMap(defaultSchema.Catalog), GetSchemaMap(defaultSchema));
 
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(DummyDatabaseName), Is.True);
         Assert.That(queryText.Contains(DummySchemaName), Is.True);
       }
-      if (MultischemaSupported()) {
-        Assert.Throws<ArgumentNullException>(() => queryText = Driver.Compile(query).GetCommandText());
+      if (IsMultischemaSupported) {
+        var compilerConfiguration = new SqlCompilerConfiguration() { SharedStorageSchema = true };
 
-        var compilerConfiguration =
-          new SqlCompilerConfiguration(new Dictionary<string, string>(), new Dictionary<string, string>()) {DatabaseQualifiedObjects = false};
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        _ = Assert.Throws<ArgumentNullException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+
+        var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.True);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
 
-        var schemaMap = new Dictionary<string, string> {{defaultSchema.GetDbNameInternal(), DummySchemaName}};
-        var databaseMap = new Dictionary<string, string> {{defaultSchema.Catalog.GetDbNameInternal(), DummyDatabaseName}};
-        compilerConfiguration = new SqlCompilerConfiguration(databaseMap, schemaMap) {DatabaseQualifiedObjects = false};
+        postCompilerConfiguration = new SqlPostCompilerConfiguration(GetDatabaseMap(defaultSchema.Catalog), GetSchemaMap(defaultSchema));
 
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query,compilerConfiguration).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(DummyDatabaseName), Is.False);
         Assert.That(queryText.Contains(DummySchemaName), Is.True);
       }
       else {
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText());
-
-        var compilerConfiguration =
-          new SqlCompilerConfiguration(new Dictionary<string, string>(), new Dictionary<string, string>()) {DatabaseQualifiedObjects = false};
+        var compilerConfiguration = new SqlCompilerConfiguration() { SharedStorageSchema = true };
         Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+
+        var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
+
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
 
-        var schemaMap = new Dictionary<string, string> {{defaultSchema.GetDbNameInternal(), DummySchemaName}};
-        var databaseMap = new Dictionary<string, string> {{defaultSchema.Catalog.GetDbNameInternal(), DummyDatabaseName}};
-        compilerConfiguration = new SqlCompilerConfiguration(databaseMap, schemaMap) {DatabaseQualifiedObjects = false};
+        postCompilerConfiguration = new SqlPostCompilerConfiguration(GetDatabaseMap(defaultSchema.Catalog), GetSchemaMap(defaultSchema));
 
         Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.False);
@@ -422,6 +420,13 @@ namespace Xtensive.Orm.Tests.Sql
       }
     }
 
+    private static Dictionary<string, string> GetSchemaMap(Schema schema) =>
+      new() { { schema.GetDbNameInternal(), DummySchemaName } };
+
+    private static Dictionary<string, string> GetDatabaseMap(Catalog catalog) =>
+      new() { { catalog.GetDbNameInternal(), DummyDatabaseName } };
+
+
     private Schema GetSchema()
     {
       var catalog = new Catalog(CatalogName);
@@ -430,34 +435,15 @@ namespace Xtensive.Orm.Tests.Sql
       var defaultSchema = catalog.DefaultSchema = schema;
       var table = defaultSchema.CreateTable(TableName);
       var column = table.CreateColumn("Id", GetServerTypeFor(typeof (int)));
-      table.CreatePrimaryKey("PK_DenyNamesReadingTest", column);
-      column = table.CreateColumn("CreationDate", GetServerTypeFor(typeof (DateTime)));
+      _ = table.CreatePrimaryKey("PK_DenyNamesReadingTest", column);
+      _ = table.CreateColumn("CreationDate", GetServerTypeFor(typeof (DateTime)));
       return defaultSchema;
     }
 
-    private SqlValueType GetServerTypeFor(Type type)
-    {
-      return Driver.TypeMappings.Mappings[type].MapType(255, null, null);
-    }
+    private SqlValueType GetServerTypeFor(Type type) =>
+      Driver.TypeMappings.Mappings[type].MapType(255, null, null);
 
-    private SqlValueType GetServerTypeFor(Type type, int length)
-    {
-      return Driver.TypeMappings.Mappings[type].MapType(length, null, null);
-    }
-
-    private SqlValueType GetServerTypeFor(Type type, int length, int precision, int scale)
-    {
-      return Driver.TypeMappings.Mappings[type].MapType(length, precision, scale);
-    }
-
-    private bool MultidatabaseSupported()
-    {
-      return Driver.ServerInfo.Query.Features.HasFlag(QueryFeatures.MultidatabaseQueries);
-    }
-
-    private bool MultischemaSupported()
-    {
-      return Driver.ServerInfo.Query.Features.HasFlag(QueryFeatures.MultischemaQueries);
-    }
+    private SqlValueType GetServerTypeFor(Type type, int length) =>
+      Driver.TypeMappings.Mappings[type].MapType(length, null, null);
   }
 }

--- a/Orm/Xtensive.Orm.Tests.Sql/MakeNamesUnreadableTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/MakeNamesUnreadableTest.cs
@@ -364,7 +364,7 @@ namespace Xtensive.Orm.Tests.Sql
       var queryText = string.Empty;
 
       if (IsMultidatabaseSupported) {
-        var compilerConfiguration = new SqlCompilerConfiguration() { DatabaseQualifiedObjects = true, SharedStorageSchema = true };
+        var compilerConfiguration = new SqlCompilerConfiguration() { DatabaseQualifiedObjects = true };
 
         _ = Assert.Throws<InvalidOperationException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
 
@@ -383,36 +383,33 @@ namespace Xtensive.Orm.Tests.Sql
         Assert.That(queryText.Contains(DummySchemaName), Is.True);
       }
       if (IsMultischemaSupported) {
-        var compilerConfiguration = new SqlCompilerConfiguration() { SharedStorageSchema = true };
-
-        _ = Assert.Throws<InvalidOperationException>(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        _ = Assert.Throws<InvalidOperationException>(() => queryText = Driver.Compile(query).GetCommandText());
 
         var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText(postCompilerConfiguration));
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.True);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
 
         postCompilerConfiguration = new SqlPostCompilerConfiguration(GetDatabaseMap(defaultSchema.Catalog), GetSchemaMap(defaultSchema));
 
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query,compilerConfiguration).GetCommandText(postCompilerConfiguration));
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(DummyDatabaseName), Is.False);
         Assert.That(queryText.Contains(DummySchemaName), Is.True);
       }
       else {
-        var compilerConfiguration = new SqlCompilerConfiguration() { SharedStorageSchema = true };
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText());
 
         var postCompilerConfiguration = new SqlPostCompilerConfiguration(emptyMap, emptyMap);
 
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText(postCompilerConfiguration));
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText(postCompilerConfiguration));
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
 
         postCompilerConfiguration = new SqlPostCompilerConfiguration(GetDatabaseMap(defaultSchema.Catalog), GetSchemaMap(defaultSchema));
 
-        Assert.DoesNotThrow(() => queryText = Driver.Compile(query, compilerConfiguration).GetCommandText());
+        Assert.DoesNotThrow(() => queryText = Driver.Compile(query).GetCommandText());
         Assert.That(queryText.Contains(defaultSchema.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(defaultSchema.Catalog.GetDbNameInternal()), Is.False);
         Assert.That(queryText.Contains(DummyDatabaseName), Is.False);

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlTest.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.07.21
 
@@ -10,12 +10,16 @@ using NUnit.Framework;
 using Xtensive.Core;
 using Xtensive.Orm;
 using Xtensive.Sql;
+using Xtensive.Sql.Info;
 using Xtensive.Sql.Model;
 
 namespace Xtensive.Orm.Tests.Sql
 {
   public abstract class SqlTest
   {
+    private bool? isMultidatabase;
+    private bool? isMultischema;
+
     protected string Url
     {
       get { return TestConnectionInfoProvider.GetConnectionUrl(); }
@@ -23,6 +27,9 @@ namespace Xtensive.Orm.Tests.Sql
 
     protected SqlConnection Connection { get; private set; }
     protected SqlDriver Driver { get; private set; }
+
+    protected bool IsMultischemaSupported => isMultischema ??= Driver.ServerInfo.Query.Features.HasFlag(QueryFeatures.MultischemaQueries);
+    protected bool IsMultidatabaseSupported => isMultidatabase ??= Driver.ServerInfo.Query.Features.HasFlag(QueryFeatures.MultidatabaseQueries);
 
     [OneTimeSetUp]
     public void RealTestFixtureSetUp()

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/NodeConfigurationExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/NodeConfigurationExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -18,12 +18,12 @@ namespace Xtensive.Orm.Configuration
       return nodeConfiguration.SchemaMapping.Apply(schema.GetNameInternal());
     }
 
-    public static IDictionary<string, string> GetDatabaseMapping(this NodeConfiguration nodeConfiguration)
+    public static IReadOnlyDictionary<string, string> GetDatabaseMapping(this NodeConfiguration nodeConfiguration)
     {
       return nodeConfiguration.DatabaseMapping.ToDictionary(key => key.Key, value => value.Value);
     }
 
-    public static IDictionary<string, string> GetSchemaMapping(this NodeConfiguration nodeConfiguration)
+    public static IReadOnlyDictionary<string, string> GetSchemaMapping(this NodeConfiguration nodeConfiguration)
     {
       return nodeConfiguration.SchemaMapping.ToDictionary(key => key.Key, value => value.Value);
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Xtensive.Core;
+using Xtensive.Orm.Configuration;
 using Xtensive.Sql;
 using Xtensive.Sql.Compiler;
 using Tuple = Xtensive.Tuples.Tuple;
@@ -47,12 +48,18 @@ namespace Xtensive.Orm.Providers
       ArgumentValidator.EnsureArgumentNotNull(task, "task");
       ArgumentValidator.EnsureArgumentNotNullOrEmpty(parameterNamePrefix, "parameterNamePrefix");
 
+      var nodeConfiguration = Session.StorageNode.Configuration;
+      var shareStorageNodesOverNodes = Session.Domain.Configuration.ShareStorageSchemaOverNodes;
+
       var result = new List<CommandPart>();
       int parameterIndex = 0;
       foreach (var request in task.RequestSequence) {
         var tuple = task.Tuple;
         var compilationResult = request.GetCompiledStatement();
-        var configuration = new SqlPostCompilerConfiguration();
+        var configuration = shareStorageNodesOverNodes
+          ? new SqlPostCompilerConfiguration(nodeConfiguration.GetDatabaseMapping(), nodeConfiguration.GetSchemaMapping())
+          : new SqlPostCompilerConfiguration();
+
         var part = new CommandPart();
         
         foreach (var binding in request.ParameterBindings) {
@@ -95,7 +102,14 @@ namespace Xtensive.Orm.Providers
 
       int parameterIndex = 0;
       var compilationResult = request.GetCompiledStatement();
-      var configuration = new SqlPostCompilerConfiguration();
+      var upgradeContext = Upgrade.UpgradeContext.GetCurrent(Session.Domain.UpgradeContextCookie);
+      var nodeConfiguration = upgradeContext != null ? upgradeContext.NodeConfiguration : Session.StorageNode.Configuration;
+
+      var shareStorageNodesOverNodes = Session.Domain.Configuration.ShareStorageSchemaOverNodes;
+      var configuration = shareStorageNodesOverNodes
+          ? new SqlPostCompilerConfiguration(nodeConfiguration.GetDatabaseMapping(), nodeConfiguration.GetSchemaMapping())
+          : new SqlPostCompilerConfiguration();
+      ;
       var result = new CommandPart();
 
       foreach (var binding in request.ParameterBindings) {

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequest.cs
@@ -41,9 +41,7 @@ namespace Xtensive.Orm.Providers
     {
       if (compiledStatement!=null)
         return;
-      compiledStatement =(NodeConfiguration!=null)
-        ? driver.Compile(CompileUnit, NodeConfiguration)
-        : driver.Compile(CompileUnit);
+      compiledStatement = driver.Compile(CompileUnit);
       CompileUnit = null;
       Statement = null;
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/QueryRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/QueryRequest.cs
@@ -42,9 +42,7 @@ namespace Xtensive.Orm.Providers
     {
       if (compiledStatement!=null && accessor!=null)
         return;
-      compiledStatement = (NodeConfiguration!=null)
-        ? driver.Compile(Statement, NodeConfiguration)
-        : driver.Compile(Statement);
+      compiledStatement = driver.Compile(Statement);
       accessor = driver.GetDataReaderAccessor(TupleDescriptor);
       Statement = null;
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/SequenceQueryBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SequenceQueryBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
+// Copyright (C) 2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -29,6 +29,10 @@ namespace Xtensive.Orm.Providers
         ? SequenceQueryCompartment.SameSession
         : compartment;
 
+      var postCompilerConfiguration = (nodeConfiguration != null)
+        ? new SqlPostCompilerConfiguration(nodeConfiguration.GetDatabaseMapping(), nodeConfiguration.GetSchemaMapping())
+        : new SqlPostCompilerConfiguration();
+
       var sqlNext = hasSequences
         ? GetSequenceBasedNextImplementation(generatorNode, increment)
         : GetTableBasedNextImplementation(generatorNode);
@@ -37,18 +41,18 @@ namespace Xtensive.Orm.Providers
       var batch = sqlNext as SqlBatch;
       if (batch == null || hasBatches)
         // There are batches or there is single statement, so we can run this as a single request
-        return new SequenceQuery(Compile(sqlNext, nodeConfiguration).GetCommandText(), actualCompartment);
+        return new SequenceQuery(Compile(sqlNext, nodeConfiguration).GetCommandText(postCompilerConfiguration), actualCompartment);
 
       // No batches, so we must execute this manually
       if (!storesAutoIncrementSettingsInMemory)
         return new SequenceQuery(
-          Compile((ISqlCompileUnit)batch[0], nodeConfiguration).GetCommandText(),
-          Compile((ISqlCompileUnit)batch[1], nodeConfiguration).GetCommandText(),
+          Compile((ISqlCompileUnit)batch[0], nodeConfiguration).GetCommandText(postCompilerConfiguration),
+          Compile((ISqlCompileUnit)batch[1], nodeConfiguration).GetCommandText(postCompilerConfiguration),
           actualCompartment);
       return new SequenceQuery(
-          Compile((ISqlCompileUnit)batch[0], nodeConfiguration).GetCommandText(),
-          Compile((ISqlCompileUnit)batch[1], nodeConfiguration).GetCommandText(),
-          Compile((ISqlCompileUnit)batch[2], nodeConfiguration).GetCommandText(),
+          Compile((ISqlCompileUnit)batch[0], nodeConfiguration).GetCommandText(postCompilerConfiguration),
+          Compile((ISqlCompileUnit)batch[1], nodeConfiguration).GetCommandText(postCompilerConfiguration),
+          Compile((ISqlCompileUnit)batch[2], nodeConfiguration).GetCommandText(postCompilerConfiguration),
           actualCompartment);
     }
 
@@ -74,9 +78,13 @@ namespace Xtensive.Orm.Providers
 
     public string BuildCleanUpQuery(SchemaNode generatorNode, NodeConfiguration nodeConfiguration)
     {
+      var postCompilerConfiguration = (nodeConfiguration != null)
+        ? new SqlPostCompilerConfiguration(nodeConfiguration.GetDatabaseMapping(), nodeConfiguration.GetSchemaMapping())
+        : new SqlPostCompilerConfiguration();
+
       var table = (Table)generatorNode;
       var delete = SqlDml.Delete(SqlDml.TableRef(table));
-      return Compile(delete, nodeConfiguration).GetCommandText();
+      return Compile(delete, nodeConfiguration).GetCommandText(postCompilerConfiguration);
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SequenceQueryBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SequenceQueryBuilder.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.03.07
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Providers
       var atRootPolicy = false;
 
       if (table==null) {
-        table = Mapping[index.ReflectedType.GetRoot()];
+        table = Mapping[index.ReflectedType.Root];
         atRootPolicy = true;
       }
 
@@ -76,7 +76,7 @@ namespace Xtensive.Orm.Providers
         }
       }
       else {
-        var root = index.ReflectedType.GetRoot().AffectedIndexes.First(i => i.IsPrimary);
+        var root = index.ReflectedType.Root.AffectedIndexes.First(i => i.IsPrimary);
         var lookup = root.Columns.ToDictionary(c => c.Field, c => c.Name);
         foreach (var c in indexColumns) {
           queryColumns.Add(tableRef[lookup[c.Field]]);

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2020 Xtensive LLC.
+// Copyright (C) 2012-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
@@ -12,8 +12,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xtensive.Core;
 using Xtensive.IoC;
+using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Upgrade;
 using Xtensive.Sql;
+using Xtensive.Sql.Compiler;
 
 namespace Xtensive.Orm.Providers
 {
@@ -248,11 +250,11 @@ namespace Xtensive.Orm.Providers
       }
 
       var upgradeContext = UpgradeContext.GetCurrent(session.Domain.UpgradeContextCookie);
-      if (upgradeContext!=null) {
-        return driver.Compile(statement, upgradeContext.NodeConfiguration).GetCommandText();
-      }
+      var nodeConfiguration = upgradeContext != null ? upgradeContext.NodeConfiguration : session.StorageNode.Configuration;
 
-      return driver.Compile(statement, session.StorageNode.Configuration).GetCommandText();
+      return driver.Compile(statement, nodeConfiguration)
+        .GetCommandText(
+          new SqlPostCompilerConfiguration(nodeConfiguration.GetDatabaseMapping(), nodeConfiguration.GetSchemaMapping()));
     }
 
     private CommandWithDataReader ExecuteReader(DbCommand command, CommandBehavior commandBehavior)

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
@@ -252,7 +252,7 @@ namespace Xtensive.Orm.Providers
       var upgradeContext = UpgradeContext.GetCurrent(session.Domain.UpgradeContextCookie);
       var nodeConfiguration = upgradeContext != null ? upgradeContext.NodeConfiguration : session.StorageNode.Configuration;
 
-      return driver.Compile(statement, nodeConfiguration)
+      return driver.Compile(statement)
         .GetCommandText(
           new SqlPostCompilerConfiguration(nodeConfiguration.GetDatabaseMapping(), nodeConfiguration.GetSchemaMapping()));
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -84,17 +84,20 @@ namespace Xtensive.Orm.Providers
       var options = new SqlCompilerConfiguration {
         DatabaseQualifiedObjects = configuration.IsMultidatabase,
         CommentLocation = configuration.TagsLocation.ToCommentLocation(),
+        SharedStorageSchema = false,
       };
       return underlyingDriver.Compile(statement, options);
     }
 
+#pragma warning disable IDE0060 // Remove unused parameter
     public SqlCompilationResult Compile(ISqlCompileUnit statement, NodeConfiguration nodeConfiguration)
+#pragma warning restore IDE0060 // Remove unused parameter
     {
-      var options = configuration.ShareStorageSchemaOverNodes
-        ? new SqlCompilerConfiguration(nodeConfiguration.GetDatabaseMapping(), nodeConfiguration.GetSchemaMapping())
-        : new SqlCompilerConfiguration();
-      options.DatabaseQualifiedObjects = configuration.IsMultidatabase;
-      options.CommentLocation = configuration.TagsLocation.ToCommentLocation();
+      var options = new SqlCompilerConfiguration {
+        SharedStorageSchema = configuration.ShareStorageSchemaOverNodes,
+        DatabaseQualifiedObjects = configuration.IsMultidatabase,
+        CommentLocation = configuration.TagsLocation.ToCommentLocation()
+      };
       return underlyingDriver.Compile(statement, options);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2021 Xtensive LLC.
+// Copyright (C) 2009-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -84,7 +84,6 @@ namespace Xtensive.Orm.Providers
       var options = new SqlCompilerConfiguration {
         DatabaseQualifiedObjects = configuration.IsMultidatabase,
         CommentLocation = configuration.TagsLocation.ToCommentLocation(),
-        SharedStorageSchema = false,
       };
       return underlyingDriver.Compile(statement, options);
     }
@@ -94,7 +93,6 @@ namespace Xtensive.Orm.Providers
 #pragma warning restore IDE0060 // Remove unused parameter
     {
       var options = new SqlCompilerConfiguration {
-        SharedStorageSchema = configuration.ShareStorageSchemaOverNodes,
         DatabaseQualifiedObjects = configuration.IsMultidatabase,
         CommentLocation = configuration.TagsLocation.ToCommentLocation()
       };

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -88,9 +88,8 @@ namespace Xtensive.Orm.Providers
       return underlyingDriver.Compile(statement, options);
     }
 
-#pragma warning disable IDE0060 // Remove unused parameter
+    [Obsolete]
     public SqlCompilationResult Compile(ISqlCompileUnit statement, NodeConfiguration nodeConfiguration)
-#pragma warning restore IDE0060 // Remove unused parameter
     {
       var options = new SqlCompilerConfiguration {
         DatabaseQualifiedObjects = configuration.IsMultidatabase,

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012-2020 Xtensive LLC.
+// Copyright (C) 2012-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -60,10 +60,7 @@ namespace Xtensive.Orm.Services
     public SqlCompilationResult CompileQuery(ISqlCompileUnit query)
     {
       ArgumentValidator.EnsureArgumentNotNull(query, "query");
-      var upgradeContext = UpgradeContext.GetCurrent(Session.Domain.UpgradeContextCookie);
-      if (upgradeContext!=null)
-        return driver.Compile(query, upgradeContext.NodeConfiguration);
-      return driver.Compile(query, Session.StorageNode.Configuration);
+      return driver.Compile(query);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2021 Xtensive LLC.
+// Copyright (C) 2003-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using Xtensive.Sql.Model;
 
 namespace Xtensive.Sql.Compiler
 {
@@ -134,6 +135,9 @@ namespace Xtensive.Sql.Compiler
     public void AppendCycleItem(int index) => Add(new CycleItemNode(index));
 
     public void AppendPlaceholderWithId(object id) => Add(new PlaceholderNode(id));
+
+    public void AppendSchemaNodePlaceholder(SchemaNode schemaNode, SqlHelper.EscapeSetup escapeSetup, bool databaseNameRequired) =>
+      Add(new SchemaNodePlaceholderNode(schemaNode, escapeSetup, databaseNameRequired));
 
     public void AppendIndent()
     {

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/SchemaNodePlaceholderNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/SchemaNodePlaceholderNode.cs
@@ -1,8 +1,6 @@
-﻿// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
-// Created by: Denis Krjuchkov
-// Created:    2009.07.15
+// Copyright (C) 2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 
 using Xtensive.Sql.Model;
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/SchemaNodePlaceholderNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/SchemaNodePlaceholderNode.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (C) 2003-2010 Xtensive LLC.
+// All rights reserved.
+// For conditions of distribution and use, see license.
+// Created by: Denis Krjuchkov
+// Created:    2009.07.15
+
+using Xtensive.Sql.Model;
+
+namespace Xtensive.Sql.Compiler
+{
+  internal sealed class SchemaNodePlaceholderNode : PlaceholderNode
+  {
+    public readonly SchemaNode SchemaNode;
+
+    public readonly SqlHelper.EscapeSetup EscapeSetup;
+
+    public readonly bool DbQualified;
+
+    internal override void AcceptVisitor(NodeVisitor visitor) => base.AcceptVisitor(visitor);
+
+    public SchemaNodePlaceholderNode(SchemaNode table, in SqlHelper.EscapeSetup escapeSetup, bool requireDatabaseName)
+      : base(table)
+    {
+      SchemaNode = table;
+      EscapeSetup = escapeSetup;
+      DbQualified = requireDatabaseName;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/PostCompiler.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/PostCompiler.cs
@@ -19,6 +19,7 @@ namespace Xtensive.Sql.Compiler
 
     private readonly StringBuilder result;
     private readonly SqlPostCompilerConfiguration configuration;
+    private readonly bool canActualizeQuery;
 
     private string[] currentCycleItem;
 
@@ -59,6 +60,8 @@ namespace Xtensive.Sql.Compiler
 
     private void Visit(SchemaNodePlaceholderNode node)
     {
+      EnsureActualizationPossible();
+
       var schema = node.SchemaNode.Schema;
 
       var names = (node.DbQualified)
@@ -93,6 +96,12 @@ namespace Xtensive.Sql.Compiler
 
     #endregion
 
+    private void EnsureActualizationPossible()
+    {
+      if (!canActualizeQuery) {
+        throw new InvalidOperationException("Query was compiled with SqlCompilerConfiguration.SharedStorageSchema option set to true, it required PostCompilerConfiguration.SchemaMapping and PostCompilerConfiguration.DatabaseMapping collections to be provided.");
+      }
+    }
 
     // Constructors
 
@@ -101,6 +110,7 @@ namespace Xtensive.Sql.Compiler
       int capacity = estimatedResultLength + ResultCapacityMargin;
       result = new StringBuilder(capacity < MinimalResultCapacity ? MinimalResultCapacity : capacity);
       this.configuration = configuration;
+      canActualizeQuery = configuration.DatabaseMapping != null && configuration.SchemaMapping != null;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/PostCompiler.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/PostCompiler.cs
@@ -99,7 +99,7 @@ namespace Xtensive.Sql.Compiler
     private void EnsureActualizationPossible()
     {
       if (!canActualizeQuery) {
-        throw new InvalidOperationException("Query was compiled with SqlCompilerConfiguration.SharedStorageSchema option set to true, it required PostCompilerConfiguration.SchemaMapping and PostCompilerConfiguration.DatabaseMapping collections to be provided.");
+        throw new InvalidOperationException(Strings.ExUnableToActualizeSchemaNodeInQuery);
       }
     }
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerConfiguration.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.07.15
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerConfiguration.cs
@@ -4,6 +4,7 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.07.15
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using JetBrains.Annotations;
@@ -35,13 +36,20 @@ namespace Xtensive.Sql.Compiler
     public SqlCommentLocation CommentLocation { get; set; } = SqlCommentLocation.Nowhere;
 
     /// <summary>
+    /// Indicated whether storage schema was shared over several storage nodes.
+    /// </summary>
+    public bool SharedStorageSchema { get; init; } = false;
+
+    /// <summary>
     /// Gets database mapping.
     /// </summary>
+    [Obsolete("No longer in use")]
     public IReadOnlyDictionary<string, string> SchemaMapping { get; private set; }
 
     /// <summary>
     /// Gets database mapping.
     /// </summary>
+    [Obsolete("No longer in use")]
     public IReadOnlyDictionary<string, string> DatabaseMapping { get; private set; }
 
     /// <summary>
@@ -58,11 +66,14 @@ namespace Xtensive.Sql.Compiler
 
     public SqlCompilerConfiguration()
     {
+#pragma warning disable CS0612 // Type or member is obsolete
       SchemaMapping = null;
       DatabaseMapping = null;
+#pragma warning restore CS0612 // Type or member is obsolete
     }
 
-    public SqlCompilerConfiguration([NotNull]IDictionary<string, string> databaseMapping, [NotNull]IDictionary<string, string> schemaMapping)
+    [Obsolete]
+    public SqlCompilerConfiguration([NotNull] IDictionary<string, string> databaseMapping, [NotNull] IDictionary<string, string> schemaMapping)
     {
       ArgumentValidator.EnsureArgumentNotNull(databaseMapping, "databaseMapping");
       ArgumentValidator.EnsureArgumentNotNull(schemaMapping, "schemaMapping");

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerConfiguration.cs
@@ -61,10 +61,10 @@ namespace Xtensive.Sql.Compiler
 
     public SqlCompilerConfiguration()
     {
-#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
       SchemaMapping = null;
       DatabaseMapping = null;
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     [Obsolete]

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerConfiguration.cs
@@ -36,20 +36,15 @@ namespace Xtensive.Sql.Compiler
     public SqlCommentLocation CommentLocation { get; set; } = SqlCommentLocation.Nowhere;
 
     /// <summary>
-    /// Indicated whether storage schema was shared over several storage nodes.
-    /// </summary>
-    public bool SharedStorageSchema { get; init; } = false;
-
-    /// <summary>
     /// Gets database mapping.
     /// </summary>
-    [Obsolete("No longer in use")]
+    [Obsolete("No longer in use. Moved to SqlPostCompilerConfiguration.")]
     public IReadOnlyDictionary<string, string> SchemaMapping { get; private set; }
 
     /// <summary>
     /// Gets database mapping.
     /// </summary>
-    [Obsolete("No longer in use")]
+    [Obsolete("No longer in use. Moved to SqlPostCompilerConfiguration.")]
     public IReadOnlyDictionary<string, string> DatabaseMapping { get; private set; }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2021 Xtensive LLC.
+// Copyright (C) 2003-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
@@ -24,10 +24,13 @@ namespace Xtensive.Sql.Compiler
 
     public SqlCompilerNamingOptions NamingOptions { get; private set; }
 
+    [Obsolete("No longer in use")]
     public SqlNodeActualizer SqlNodeActualizer { get; private set; }
 
     public SqlNode[] GetTraversalPath() =>
       traversalPath ??= traversalStack.ToArray();
+
+    public bool SharedStorageSchema { get; }
 
     public bool HasOptions(SqlCompilerNamingOptions requiredOptions)
     {
@@ -143,10 +146,14 @@ namespace Xtensive.Sql.Compiler
       if (configuration.DatabaseQualifiedObjects)
         NamingOptions |= SqlCompilerNamingOptions.DatabaseQualifiedObjects;
 
+      SharedStorageSchema = configuration.SharedStorageSchema;
+
       TableNameProvider = new SqlTableNameProvider(this);
       ParameterNameProvider = new SqlParameterNameProvider(configuration);
       Output = new ContainerNode();
+#pragma warning disable CS0618 // Type or member is obsolete
       SqlNodeActualizer = new SqlNodeActualizer(configuration.DatabaseMapping, configuration.SchemaMapping);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
@@ -30,8 +30,6 @@ namespace Xtensive.Sql.Compiler
     public SqlNode[] GetTraversalPath() =>
       traversalPath ??= traversalStack.ToArray();
 
-    public bool SharedStorageSchema { get; }
-
     public bool HasOptions(SqlCompilerNamingOptions requiredOptions)
     {
       return (NamingOptions & requiredOptions)==requiredOptions;
@@ -145,8 +143,6 @@ namespace Xtensive.Sql.Compiler
       NamingOptions = SqlCompilerNamingOptions.TableQualifiedColumns | SqlCompilerNamingOptions.TableAliasing;
       if (configuration.DatabaseQualifiedObjects)
         NamingOptions |= SqlCompilerNamingOptions.DatabaseQualifiedObjects;
-
-      SharedStorageSchema = configuration.SharedStorageSchema;
 
       TableNameProvider = new SqlTableNameProvider(this);
       ParameterNameProvider = new SqlParameterNameProvider(configuration);

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
@@ -151,9 +151,9 @@ namespace Xtensive.Sql.Compiler
       TableNameProvider = new SqlTableNameProvider(this);
       ParameterNameProvider = new SqlParameterNameProvider(configuration);
       Output = new ContainerNode();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, CS0612 // Type or member is obsolete
       SqlNodeActualizer = new SqlNodeActualizer(configuration.DatabaseMapping, configuration.SchemaMapping);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, CS0612 // Type or member is obsolete
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlNodeActualizer.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlNodeActualizer.cs
@@ -4,6 +4,7 @@
 // Created by: Alexey Kulakov
 // Created:    2017.03.24
 
+using System;
 using System.Collections.Generic;
 using Xtensive.Sql.Model;
 
@@ -12,6 +13,7 @@ namespace Xtensive.Sql.Compiler
   /// <summary>
   /// Applies configured mappings to <see cref="Catalog"/>'s or <see cref="Schema"/>'s name to get actual name.
   /// </summary>
+  [Obsolete]
   public sealed class SqlNodeActualizer
   {
     private readonly IReadOnlyDictionary<string, string> databaseMapping;

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlPostCompilerConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlPostCompilerConfiguration.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.11.07
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlPostCompilerConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlPostCompilerConfiguration.cs
@@ -5,6 +5,9 @@
 // Created:    2009.11.07
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using JetBrains.Annotations;
+using Xtensive.Core;
 
 namespace Xtensive.Sql.Compiler
 {
@@ -13,20 +16,39 @@ namespace Xtensive.Sql.Compiler
   /// </summary>
   public sealed class SqlPostCompilerConfiguration
   {
-    public HashSet<object> AlternativeBranches { get; private set; }
+    public HashSet<object> AlternativeBranches { get; private set; } = new HashSet<object>();
 
-    public Dictionary<object, string> PlaceholderValues { get; private set; }
+    public Dictionary<object, string> PlaceholderValues { get; private set; } = new Dictionary<object, string>();
 
-    public Dictionary<object, List<string[]>> DynamicFilterValues { get; private set; }
+    public Dictionary<object, List<string[]>> DynamicFilterValues { get; private set; } = new Dictionary<object, List<string[]>>();
+
+    /// <summary>
+    /// Gets database mapping.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> SchemaMapping { get; private set; }
+
+    /// <summary>
+    /// Gets database mapping.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> DatabaseMapping { get; private set; }
 
 
     // Constructors
 
     public SqlPostCompilerConfiguration()
     {
-      AlternativeBranches = new HashSet<object>();
-      PlaceholderValues = new Dictionary<object, string>();
-      DynamicFilterValues = new Dictionary<object, List<string[]>>();
+      // this prevents wrong query to be executed.
+      SchemaMapping = null;
+      DatabaseMapping = null;
+    }
+
+    public SqlPostCompilerConfiguration([NotNull] IReadOnlyDictionary<string, string> databaseMapping, [NotNull] IReadOnlyDictionary<string, string> schemaMapping)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(databaseMapping, "databaseMapping");
+      ArgumentValidator.EnsureArgumentNotNull(schemaMapping, "schemaMapping");
+
+      DatabaseMapping = databaseMapping;
+      SchemaMapping = schemaMapping;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
@@ -1954,13 +1954,19 @@ namespace Xtensive.Sql.Compiler
 
       var dbQualified = node.Schema.Catalog != null
         && context.HasOptions(SqlCompilerNamingOptions.DatabaseQualifiedObjects);
-      var actualizer = context.SqlNodeActualizer;
 
-      if (dbQualified) {
-        TranslateIdentifier(output, actualizer.Actualize(node.Schema.Catalog), actualizer.Actualize(node.Schema), node.GetDbNameInternal());
+      if (context.SharedStorageSchema) {
+        // if schema is shared we use placeholders to translate
+        // schema node in PostCompiler
+        output.AppendSchemaNodePlaceholder(node, EscapeSetup, dbQualified);
       }
       else {
-        TranslateIdentifier(output, actualizer.Actualize(node.Schema), node.DbName);
+        if (dbQualified) {
+          TranslateIdentifier(output, node.Schema.Catalog.DbName, node.Schema.DbName, node.DbName);
+        }
+        else {
+          TranslateIdentifier(output, node.Schema.DbName, node.DbName);
+        }
       }
     }
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
@@ -1955,7 +1955,8 @@ namespace Xtensive.Sql.Compiler
       var dbQualified = node.Schema.Catalog != null
         && context.HasOptions(SqlCompilerNamingOptions.DatabaseQualifiedObjects);
 
-      if (context.SharedStorageSchema) {
+      
+      if (node.Schema.IsNamesReadingDenied) {
         // if schema is shared we use placeholders to translate
         // schema node in PostCompiler
         output.AppendSchemaNodePlaceholder(node, EscapeSetup, dbQualified);

--- a/Orm/Xtensive.Orm/Sql/Model/Catalog.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/Catalog.cs
@@ -14,8 +14,6 @@ namespace Xtensive.Sql.Model
   [Serializable]
   public class Catalog : Node
   {
-    private bool isNamesReadingDenied = false;
-
     private Schema defaultSchema;
     private PairedNodeCollection<Catalog, Schema> schemas;
     private PairedNodeCollection<Catalog, PartitionFunction> partitionFunctions;
@@ -25,12 +23,12 @@ namespace Xtensive.Sql.Model
     public override string Name
     {
       get {
-        if (!isNamesReadingDenied)
+        if (!IsNamesReadingDenied)
           return base.Name;
         throw new InvalidOperationException(Strings.ExNameValueReadingOrSettingIsDenied);
       }
       set {
-        if (!isNamesReadingDenied)
+        if (!IsNamesReadingDenied)
           base.Name = value;
         else
           throw new InvalidOperationException(Strings.ExNameValueReadingOrSettingIsDenied);
@@ -41,48 +39,16 @@ namespace Xtensive.Sql.Model
     public override string DbName
     {
       get {
-        if (!isNamesReadingDenied)
+        if (!IsNamesReadingDenied)
           return base.DbName;
         throw new InvalidOperationException(Strings.ExDbNameValueReadingOrSettingIsDenied);
       }
       set {
-        if (!isNamesReadingDenied)
+        if (!IsNamesReadingDenied)
           base.DbName = value;
         else
           throw new InvalidOperationException(Strings.ExDbNameValueReadingOrSettingIsDenied);
       }
-    }
-
-    /// <summary>
-    /// Creates a schema.
-    /// </summary>
-    /// <param name="name">The name.</param>
-    /// <returns></returns>
-    public Schema CreateSchema(string name)
-    {
-      return new Schema(this, name);
-    }
-
-    /// <summary>
-    /// Creates the partition function.
-    /// </summary>
-    /// <param name="name">The name.</param>
-    /// <param name="dataType">Type of the input parameter.</param>
-    /// <param name="boundaryValues">The boundary values.</param>
-    public PartitionFunction CreatePartitionFunction(string name, SqlValueType dataType, params string[] boundaryValues)
-    {
-      return new PartitionFunction(this, name, dataType, boundaryValues);
-    }
-
-    /// <summary>
-    /// Creates the partition schema.
-    /// </summary>
-    /// <param name="name">The name.</param>
-    /// <param name="partitionFunction">The partition function.</param>
-    /// <param name="filegroups">The filegroups.</param>
-    public PartitionSchema CreatePartitionSchema(string name, PartitionFunction partitionFunction, params string[] filegroups)
-    {
-      return new PartitionSchema(this, name, partitionFunction, filegroups);
     }
 
     /// <summary>
@@ -113,10 +79,7 @@ namespace Xtensive.Sql.Model
     /// Gets the schemas.
     /// </summary>
     /// <value>The schemas.</value>
-    public PairedNodeCollection<Catalog, Schema> Schemas
-    {
-      get { return schemas; }
-    }
+    public PairedNodeCollection<Catalog, Schema> Schemas => schemas;
 
     /// <summary>
     /// Gets the partition functions.
@@ -140,12 +103,40 @@ namespace Xtensive.Sql.Model
     {
       get
       {
-        if (partitionSchemas==null)
+        if (partitionSchemas == null)
           partitionSchemas =
             new PairedNodeCollection<Catalog, PartitionSchema>(this, "PartitionSchemas");
         return partitionSchemas;
       }
     }
+
+    internal bool IsNamesReadingDenied { get; private set; }
+
+    /// <summary>
+    /// Creates a schema.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <returns></returns>
+    public Schema CreateSchema(string name) => new(this, name);
+
+    /// <summary>
+    /// Creates the partition function.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <param name="dataType">Type of the input parameter.</param>
+    /// <param name="boundaryValues">The boundary values.</param>
+    public PartitionFunction CreatePartitionFunction(string name, SqlValueType dataType, params string[] boundaryValues) =>
+      new(this, name, dataType, boundaryValues);
+
+    /// <summary>
+    /// Creates the partition schema.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <param name="partitionFunction">The partition function.</param>
+    /// <param name="filegroups">The filegroups.</param>
+    public PartitionSchema CreatePartitionSchema(string name, PartitionFunction partitionFunction, params string[] filegroups) =>
+      new(this, name, partitionFunction, filegroups);
+
 
     #region ILockable Members 
 
@@ -163,37 +154,32 @@ namespace Xtensive.Sql.Model
 
     internal void MakeNamesUnreadable()
     {
-      isNamesReadingDenied = true;
-      this.Schemas.ForEach(s => s.MakeNamesUnreadable());
-      this.PartitionFunctions.ForEach(pf => pf.MakeNamesUnreadable());
-      this.PartitionSchemas.ForEach(ps => ps.MakeNamesUnreadable());
+      IsNamesReadingDenied = true;
+      Schemas.ForEach(s => s.MakeNamesUnreadable());
+      PartitionFunctions.ForEach(pf => pf.MakeNamesUnreadable());
+      PartitionSchemas.ForEach(ps => ps.MakeNamesUnreadable());
     }
 
     internal string GetActualName(IReadOnlyDictionary<string, string> catalogNameMap)
     {
-      if (!isNamesReadingDenied)
+      if (!IsNamesReadingDenied)
         return Name;
       if (catalogNameMap==null)
         throw new ArgumentNullException("catalogNameMap");
 
       var name = GetNameInternal();
-      string actualName;
-      if (catalogNameMap.TryGetValue(name, out actualName))
-        return actualName;
-      return name;
+      return catalogNameMap.TryGetValue(name, out var actualName) ? actualName : name;
     }
 
     internal string GetActualDbName(IReadOnlyDictionary<string, string> catalogNameMap)
     {
-      if (!isNamesReadingDenied)
+      if (!IsNamesReadingDenied)
         return DbName;
       if (catalogNameMap==null)
         throw new ArgumentNullException("Unable to calculate real name for catalog");
+
       var name = GetDbNameInternal();
-      string actualName;
-      if (catalogNameMap.TryGetValue(name, out actualName))
-        return actualName;
-      return name;
+      return catalogNameMap.TryGetValue(name, out var actualName) ? actualName : name;
     }
 
     // Constructors
@@ -212,6 +198,5 @@ namespace Xtensive.Sql.Model
         ? new PairedNodeCollection<Catalog, Schema>(this, "Schemas", 1, StringComparer.Ordinal)
         : new PairedNodeCollection<Catalog, Schema>(this, "Schemas", 1, StringComparer.OrdinalIgnoreCase);
     }
-
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Model/Catalog.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/Catalog.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
@@ -188,7 +188,7 @@ namespace Xtensive.Sql.Model
       if (!isNamesReadingDenied)
         return DbName;
       if (catalogNameMap==null)
-        throw new InvalidOperationException("Unable to calculate real name for catalog");
+        throw new ArgumentNullException("Unable to calculate real name for catalog");
       var name = GetDbNameInternal();
       string actualName;
       if (catalogNameMap.TryGetValue(name, out actualName))

--- a/Orm/Xtensive.Orm/Sql/Model/CatalogNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/CatalogNode.cs
@@ -15,18 +15,17 @@ namespace Xtensive.Sql.Model
   public abstract class CatalogNode : Node, IPairedNode<Catalog>
   {
     private Catalog catalog;
-    private bool isNamesReadingDenied = false;
 
     /// <inheritdoc />
     public override string Name
     {
       get {
-        if (!isNamesReadingDenied)
+        if (!IsNamesReadingDenied)
           return base.Name;
         throw new InvalidOperationException(Strings.ExNameValueReadingOrSettingIsDenied);
       }
       set {
-        if (!isNamesReadingDenied)
+        if (!IsNamesReadingDenied)
           base.Name = value;
         else
           throw new InvalidOperationException(Strings.ExNameValueReadingOrSettingIsDenied);
@@ -37,12 +36,12 @@ namespace Xtensive.Sql.Model
     public override string DbName
     {
       get {
-        if (!isNamesReadingDenied)
+        if (!IsNamesReadingDenied)
           return base.DbName;
         throw new InvalidOperationException(Strings.ExDbNameValueReadingOrSettingIsDenied);
       }
       set {
-        if (!isNamesReadingDenied)
+        if (!IsNamesReadingDenied)
           base.DbName = value;
         else
           throw new InvalidOperationException(Strings.ExDbNameValueReadingOrSettingIsDenied);
@@ -62,6 +61,8 @@ namespace Xtensive.Sql.Model
           ChangeCatalog(value);
       }
     }
+
+    internal bool IsNamesReadingDenied { get; private set; }
 
     /// <summary>
     /// Changes the catalog.
@@ -86,12 +87,12 @@ namespace Xtensive.Sql.Model
 
     internal void MakeNamesUnreadable()
     {
-      isNamesReadingDenied = true;
+      IsNamesReadingDenied = true;
     }
 
     internal string GetActualName(IReadOnlyDictionary<string, string> nodeNameMap)
     {
-      if (!isNamesReadingDenied)
+      if (!IsNamesReadingDenied)
         return Name;
       if (nodeNameMap==null)
         throw new ArgumentNullException("nodeNameMap");
@@ -105,14 +106,13 @@ namespace Xtensive.Sql.Model
 
     internal string GetActualDbName(IReadOnlyDictionary<string, string> nodeNameMap)
     {
-      if (!isNamesReadingDenied)
+      if (!IsNamesReadingDenied)
         return DbName;
       if (nodeNameMap==null)
         throw new ArgumentNullException("nodeNameMap");
 
       var name = GetDbNameInternal();
-      string actualName;
-      if (nodeNameMap.TryGetValue(name, out actualName))
+      if (nodeNameMap.TryGetValue(name, out var actualName))
         return actualName;
       return name;
     }

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -1967,7 +1967,7 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ignore rule &apos;{0}&apos; must be applied to column or table..
+        ///   Looks up a localized string similar to Ignore rule &apos;{0}&apos; must be applied to column, index or table..
         /// </summary>
         internal static string ExIgnoreRuleXMustBeAppliedToColumnIndexOrTable {
             get {
@@ -4603,6 +4603,15 @@ namespace Xtensive {
         internal static string ExTypeXShouldNotBeGeneric {
             get {
                 return ResourceManager.GetString("ExTypeXShouldNotBeGeneric", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Query was compiled with SqlCompilerConfiguration.SharedStorageSchema option set to true, it requires PostCompilerConfiguration.SchemaMapping and PostCompilerConfiguration.DatabaseMapping collections to be provided..
+        /// </summary>
+        internal static string ExUnableToActualizeSchemaNodeInQuery {
+            get {
+                return ResourceManager.GetString("ExUnableToActualizeSchemaNodeInQuery", resourceCulture);
             }
         }
         

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -4607,7 +4607,7 @@ namespace Xtensive {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Query was compiled with SqlCompilerConfiguration.SharedStorageSchema option set to true, it requires PostCompilerConfiguration.SchemaMapping and PostCompilerConfiguration.DatabaseMapping collections to be provided..
+        ///   Looks up a localized string similar to Query was compiled with DomainConfiguration.ShareStorageSchemaOverNodes option set to true, it requires PostCompilerConfiguration.SchemaMapping and PostCompilerConfiguration.DatabaseMapping collections to be provided..
         /// </summary>
         internal static string ExUnableToActualizeSchemaNodeInQuery {
             get {

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -2585,4 +2585,7 @@ Error: {1}</value>
   <data name="ExIgnoreRuleIsAlreadyConfiguredForX" xml:space="preserve">
     <value>Rule is already configured for {0}.</value>
   </data>
+  <data name="ExUnableToActualizeSchemaNodeInQuery" xml:space="preserve">
+    <value>Query was compiled with SqlCompilerConfiguration.SharedStorageSchema option set to true, it requires PostCompilerConfiguration.SchemaMapping and PostCompilerConfiguration.DatabaseMapping collections to be provided.</value>
+  </data>
 </root>

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -2586,6 +2586,6 @@ Error: {1}</value>
     <value>Rule is already configured for {0}.</value>
   </data>
   <data name="ExUnableToActualizeSchemaNodeInQuery" xml:space="preserve">
-    <value>Query was compiled with SqlCompilerConfiguration.SharedStorageSchema option set to true, it requires PostCompilerConfiguration.SchemaMapping and PostCompilerConfiguration.DatabaseMapping collections to be provided.</value>
+    <value>Query was compiled with DomainConfiguration.ShareStorageSchemaOverNodes option set to true, it requires PostCompilerConfiguration.SchemaMapping and PostCompilerConfiguration.DatabaseMapping collections to be provided.</value>
   </data>
 </root>


### PR DESCRIPTION
When domain option ```ShareSchemaOverNodes``` is activated, ```SqlTranslator``` no longer uses ```SqlNodeActualizer``` to translate schema's and catalog's to string, it puts special placeholder - ``SchemaNodePlaceholderNode``, so ```PostCompiler``` translates it later on, just before getting actual string.