### PR TITLE
Fix hiding exception & StackTrace in OpenSessionInternalAsync()

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -346,18 +347,27 @@ namespace Xtensive.Orm
         // That would make session accessible for user before
         // connection become opened.
         session = new Session(this, storageNode, configuration, false);
+        ExceptionDispatchInfo exceptionDispatchInfo = null;
         try {
           await ((SqlSessionHandler) session.Handler).OpenConnectionAsync(cancellationToken)
             .ContinueWith(t => {
-              if (sessionScope != null) {
-                session.AttachToScope(sessionScope);
+              if (t.Status == TaskStatus.RanToCompletion) {
+                if (sessionScope != null) {
+                  session.AttachToScope(sessionScope);
+                }
               }
-            }, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously)
+              else if (t.Exception != null) {
+                exceptionDispatchInfo = ExceptionDispatchInfo.Capture(t.Exception);
+              }
+            }, TaskContinuationOptions.ExecuteSynchronously)
             .ConfigureAwait(false);
         }
         catch (OperationCanceledException) {
           await session.DisposeSafelyAsync().ConfigureAwait(false);
           throw;
+        }
+        finally {
+          exceptionDispatchInfo?.Throw();
         }
       }
       NotifySessionOpen(session);

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -58,7 +58,7 @@ namespace Xtensive.Orm
     public event EventHandler Disposing;
 
     /// <summary>
-    /// Gets the <see cref="Domain"/> of the current <see cref="Session"/>. 
+    /// Gets the <see cref="Domain"/> of the current <see cref="Session"/>.
     /// </summary>
     /// <seealso cref="Session.Current"/>
     /// <seealso cref="Demand"/>
@@ -70,7 +70,7 @@ namespace Xtensive.Orm
     }
 
     /// <summary>
-    /// Gets the <see cref="Domain"/> of the current <see cref="Session"/>, or throws <see cref="InvalidOperationException"/>, 
+    /// Gets the <see cref="Domain"/> of the current <see cref="Session"/>, or throws <see cref="InvalidOperationException"/>,
     /// if active <see cref="Session"/> is not found.
     /// </summary>
     /// <returns>Current domain.</returns>
@@ -80,7 +80,7 @@ namespace Xtensive.Orm
     {
       return Session.Demand().Domain;
     }
-    
+
     /// <summary>
     /// Gets the domain configuration.
     /// </summary>
@@ -356,8 +356,11 @@ namespace Xtensive.Orm
                   session.AttachToScope(sessionScope);
                 }
               }
-              else if (t.Exception != null) {
-                exceptionDispatchInfo = ExceptionDispatchInfo.Capture(t.Exception);
+              else if (t.Exception is Exception ex) {
+                if (ex is System.AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1) {
+                  ex = aggregateException.InnerExceptions[0];
+                }
+                exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
               }
             }, TaskContinuationOptions.ExecuteSynchronously)
             .ConfigureAwait(false);
@@ -380,7 +383,7 @@ namespace Xtensive.Orm
 
     /// <inheritdoc/>
     public IExtensionCollection Extensions { get; private set; }
-    
+
     #endregion
 
     /// <summary>


### PR DESCRIPTION
`.ContinueWith()` hides all exception info/StackTrace , converting any exception into `TaskCanceledException` and Stack trace truncated by `OpenSessionInternalAsync()`.
It complicates debugging.