### PR TITLE
Weaver: Fixes broken catch leaving to final ret operation

### DIFF
--- a/ChangeLog/6.0.11_dev.txt
+++ b/ChangeLog/6.0.11_dev.txt
@@ -1,0 +1,1 @@
+[weaver] Fixed ctor processing with try...catch where there was broken catch section leaving

--- a/Weaver/Xtensive.Orm.Weaver/Tasks/ImplementInitializablePatternTask.cs
+++ b/Weaver/Xtensive.Orm.Weaver/Tasks/ImplementInitializablePatternTask.cs
@@ -20,8 +20,7 @@ namespace Xtensive.Orm.Weaver.Tasks
     {
       var body = constructor.Body;
       var il = body.GetILProcessor();
-      var originalLastRet = body.Instructions.Reverse().First(i => i != null && i.OpCode.Code == Code.Ret);
-
+      var originalLastRet = body.Instructions.Reverse().FirstOrDefault(i => i != null && i.OpCode.Code == Code.Ret);
       var leavePlaceholder = il.Create(OpCodes.Nop);
 
       var initializeCall = EmitInitializeCall(context, il);
@@ -71,7 +70,7 @@ namespace Xtensive.Orm.Weaver.Tasks
     private void FixCatchLeave(Instruction start, Instruction end, Instruction oldRetTarget, Instruction newTarget)
     {
       var current = start;
-      while (current != end) {
+      while (current != end && current != null) {
         var next = current.Next;
         var code = current.OpCode.Code;
         if ((code == Code.Leave || code == Code.Leave_S) && current.Operand == oldRetTarget) {

--- a/Weaver/Xtensive.Orm.Weaver/Tasks/ImplementInitializablePatternTask.cs
+++ b/Weaver/Xtensive.Orm.Weaver/Tasks/ImplementInitializablePatternTask.cs
@@ -38,9 +38,10 @@ namespace Xtensive.Orm.Weaver.Tasks
       il.Append(ret);
       il.Replace(leavePlaceholder, il.Create(OpCodes.Leave, ret));
       if (body.ExceptionHandlers.Count != 0) {
-        foreach (var eHandler in body.ExceptionHandlers) {
-          FixCatchLeave(eHandler.HandlerStart, eHandler.HandlerEnd, originalLastRet, initializeCall);
-        }
+        if (originalLastRet != null)
+          foreach (var eHandler in body.ExceptionHandlers) {
+            FixCatchLeave(eHandler.HandlerStart, eHandler.HandlerEnd, originalLastRet, initializeCall);
+          }
       }
 
       body.InitLocals = true;


### PR DESCRIPTION
There are broken leave.s operations in entity constructors with bodies like below

```
  public SomeEntity(Session session) : base(session)
  {
    try
    {
      this.DoThis();
    }
    catch (Exception ex)
    {
      this.DoSomethingElse();
      return;
    }
    this.DoAFinalThing();
  }
```

This PR gets last ret operation (if it exists) and changes leave.s operation's target instruction (if it exists) in catch part to correct instruction that added by Weaver