### PR TITLE
On Node removing remove related keys from QueryCache if required

### DIFF
--- a/ChangeLog/6.0.11_dev.txt
+++ b/ChangeLog/6.0.11_dev.txt
@@ -1,2 +1,3 @@
+[main] Added an option to remove cached queries of removing storage node along with the node, default behavior remains the same
 [postgresql] Dedicated exception when an extracting schema doesn't exist or it belongs to another user
 [weaver] Fixed ctor processing with try...catch where there was broken catch section leaving

--- a/Orm/Xtensive.Orm.Tests/Storage/Multinode/StaleQueryCacheForReAddedNodes.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Multinode/StaleQueryCacheForReAddedNodes.cs
@@ -1,0 +1,208 @@
+// Copyright (C) 2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Tests.Storage.Multinode.QueryCachingTestModel;
+
+namespace Xtensive.Orm.Tests.Storage.Multinode
+{
+  public sealed class StaleQueryCacheForReAddedNodes : MultinodeTest
+  {
+    private const string DefaultSchema = WellKnownSchemas.Schema1;
+    private const string Schema1 = WellKnownSchemas.Schema2;
+    private const string Schema2 = WellKnownSchemas.Schema3;
+
+    private readonly object SimpleQueryKey = new object();
+
+    protected override void CheckRequirements() =>
+      Require.AllFeaturesSupported(Orm.Providers.ProviderFeatures.Multischema);
+
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      CustomUpgradeHandler.TypeIdPerNode.Add(TestNodeId2, 100);
+      CustomUpgradeHandler.TypeIdPerNode.Add(TestNodeId3, 100);
+
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(BaseTestEntity).Assembly, typeof(BaseTestEntity).Namespace);
+      configuration.UpgradeMode = DomainUpgradeMode.Recreate;
+      configuration.DefaultSchema = DefaultSchema;
+      return configuration;
+    }
+
+    protected override void PopulateNodes()
+    {
+      CustomUpgradeHandler.CurrentNodeId = TestNodeId2;
+      var nodeConfiguration = new NodeConfiguration(TestNodeId2);
+      nodeConfiguration.SchemaMapping.Add(DefaultSchema, Schema1);
+      nodeConfiguration.UpgradeMode = DomainUpgradeMode.Recreate;
+      _ = Domain.StorageNodeManager.AddNode(nodeConfiguration);
+
+      CustomUpgradeHandler.CurrentNodeId = TestNodeId3;
+      nodeConfiguration = new NodeConfiguration(TestNodeId3);
+      nodeConfiguration.SchemaMapping.Add(DefaultSchema, Schema2);
+      nodeConfiguration.UpgradeMode = DomainUpgradeMode.Recreate;
+      _ = Domain.StorageNodeManager.AddNode(nodeConfiguration);
+    }
+
+    protected override void PopulateData()
+    {
+      var nodes = new[] { WellKnown.DefaultNodeId, TestNodeId2, TestNodeId3 };
+
+      foreach (var nodeId in nodes) {
+        var selectedNode = Domain.StorageNodeManager.GetNode(nodeId);
+        using (var session = selectedNode.OpenSession())
+        using (var tx = session.OpenTransaction()) {
+
+          var nodeIdName = string.IsNullOrEmpty(nodeId) ? "<default>" : nodeId;
+
+          _ = new BaseTestEntity(session) { BaseName = "A", BaseOwnerNodeId = nodeIdName };
+          _ = new MiddleTestEntity(session) {
+            BaseName = "AA",
+            MiddleName = "AAM",
+            BaseOwnerNodeId = nodeIdName,
+            MiddleOwnerNodeId = nodeIdName
+          };
+          _ = new LeafTestEntity(session) {
+            BaseName = "AAA",
+            MiddleName = "AAAM",
+            LeafName = "AAAL",
+            BaseOwnerNodeId = nodeIdName,
+            MiddleOwnerNodeId = nodeIdName,
+            LeafOwnerNodeId = nodeIdName
+          };
+
+          _ = new BaseTestEntity(session) { BaseName = "B", BaseOwnerNodeId = nodeIdName };
+          _ = new MiddleTestEntity(session) {
+            BaseName = "BB",
+            MiddleName = "BBM",
+            BaseOwnerNodeId = nodeIdName,
+            MiddleOwnerNodeId = nodeIdName
+          };
+          _ = new LeafTestEntity(session) {
+            BaseName = "BBB",
+            MiddleName = "BBBM",
+            LeafName = "BBBL",
+            BaseOwnerNodeId = nodeIdName,
+            MiddleOwnerNodeId = nodeIdName,
+            LeafOwnerNodeId = nodeIdName
+          };
+
+          _ = new BaseTestEntity(session) { BaseName = "C", BaseOwnerNodeId = nodeIdName };
+          _ = new MiddleTestEntity(session) {
+            BaseName = "CC",
+            MiddleName = "CCM",
+            BaseOwnerNodeId = nodeIdName,
+            MiddleOwnerNodeId = nodeIdName
+          };
+          _ = new LeafTestEntity(session) {
+            BaseName = "CCC",
+            MiddleName = "CCCM",
+            LeafName = "CCCL",
+            BaseOwnerNodeId = nodeIdName,
+            MiddleOwnerNodeId = nodeIdName,
+            LeafOwnerNodeId = nodeIdName
+          };
+
+          _ = new BaseTestEntity(session) { BaseName = "D", BaseOwnerNodeId = nodeIdName };
+          _ = new MiddleTestEntity(session) {
+            BaseName = "DD",
+            MiddleName = "DDM",
+            BaseOwnerNodeId = nodeIdName,
+            MiddleOwnerNodeId = nodeIdName
+          };
+          _ = new LeafTestEntity(session) {
+            BaseName = "DDD",
+            MiddleName = "DDDM",
+            LeafName = "DDDL",
+            BaseOwnerNodeId = nodeIdName,
+            MiddleOwnerNodeId = nodeIdName,
+            LeafOwnerNodeId = nodeIdName
+          };
+
+          // puts one query per each node to the query cache
+          _ = ExecuteSimpleQueryCaching(session);
+
+          tx.Complete();
+        }
+      }
+    }
+
+    [Test]
+    public void ReAddNodeTest()
+    {
+      var node = Domain.StorageNodeManager.GetNode(TestNodeId2);
+      var queryCacheSize = Domain.QueryCache.Count;
+
+      using (var session = node.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        _ = session.Query.Execute(SimpleQueryKey, q => q.All<BaseTestEntity>().Where(e => e.BaseName.Contains("B"))).ToList();
+      }
+      Assert.That(Domain.QueryCache.Count, Is.EqualTo(queryCacheSize));
+
+      _ = Domain.StorageNodeManager.RemoveNode(TestNodeId2);
+      Assert.That(Domain.QueryCache.Count, Is.EqualTo(queryCacheSize));
+
+      CustomUpgradeHandler.CurrentNodeId = TestNodeId2;
+      var nodeConfiguration = new NodeConfiguration(TestNodeId2);
+      nodeConfiguration.SchemaMapping.Add(DefaultSchema, Schema1);
+      nodeConfiguration.UpgradeMode = DomainUpgradeMode.Validate;
+      _ = Domain.StorageNodeManager.AddNode(nodeConfiguration);
+
+      node = Domain.StorageNodeManager.GetNode(TestNodeId2);
+
+      using (var session = node.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        _ = session.Query.Execute(SimpleQueryKey, q => q.All<BaseTestEntity>().Where(e => e.BaseName.Contains("B"))).ToList();
+      }
+      Assert.That(Domain.QueryCache.Count, Is.EqualTo(queryCacheSize));
+
+      CustomUpgradeHandler.CurrentNodeId = TestNodeId3;
+      nodeConfiguration = new NodeConfiguration(TestNodeId3);
+      nodeConfiguration.SchemaMapping.Add(DefaultSchema, Schema2);
+      nodeConfiguration.UpgradeMode = DomainUpgradeMode.Recreate;
+      _ = Domain.StorageNodeManager.AddNode(nodeConfiguration);
+    }
+
+    [Test]
+    public void ReAddNodeWithAnotherSchemaMappingNoCacheCleanTest()
+    {
+      var node = Domain.StorageNodeManager.GetNode(TestNodeId2);
+      var queryCacheSize = Domain.QueryCache.Count;
+
+      using (var session = node.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        _ = session.Query.Execute(SimpleQueryKey, q => q.All<BaseTestEntity>().Where(e => e.BaseName.Contains("B"))).ToList();
+      }
+      Assert.That(Domain.QueryCache.Count, Is.EqualTo(queryCacheSize));
+
+      _ = Domain.StorageNodeManager.RemoveNode(TestNodeId2);
+      Assert.That(Domain.QueryCache.Count, Is.EqualTo(queryCacheSize));
+
+      CustomUpgradeHandler.CurrentNodeId = TestNodeId2;
+      var nodeConfiguration = new NodeConfiguration(TestNodeId2);
+      nodeConfiguration.SchemaMapping.Add(DefaultSchema, Schema2);// uses schema of TestNodeId3
+      nodeConfiguration.UpgradeMode = DomainUpgradeMode.Validate;
+      _ = Domain.StorageNodeManager.AddNode(nodeConfiguration);
+
+      node = Domain.StorageNodeManager.GetNode(TestNodeId2);
+
+      using (var session = node.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        var results = session.Query.Execute(SimpleQueryKey, q => q.All<BaseTestEntity>().Where(e => e.BaseName.Contains("B"))).ToList();
+        foreach(var item in results) {
+          Assert.That(item.BaseOwnerNodeId, Is.EqualTo(node.Id)); // gets result from old schema
+        }
+      }
+      Assert.That(Domain.QueryCache.Count, Is.EqualTo(queryCacheSize));
+    }
+
+    private List<BaseTestEntity> ExecuteSimpleQueryCaching(Session session) =>
+     session.Query.Execute(SimpleQueryKey, q => q.All<BaseTestEntity>().Where(e => e.BaseName.Contains("B"))).ToList();
+  }
+}

--- a/Orm/Xtensive.Orm/Caching/LruCache{TKey, TItem}.cs
+++ b/Orm/Xtensive.Orm/Caching/LruCache{TKey, TItem}.cs
@@ -239,6 +239,12 @@ namespace Xtensive.Caching
 
     #endregion
 
+    internal IEnumerable<TKey> GetKeysInternal()
+    {
+      foreach (KeyValuePair<TKey, TItem> cachedItem in deque)
+        yield return cachedItem.Key;
+    }
+
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/StorageNodeManager.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNodeManager.cs
@@ -5,7 +5,9 @@
 // Created:    2014.03.13
 
 using System;
+using System.Linq;
 using JetBrains.Annotations;
+using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Providers;
 using Xtensive.Orm.Upgrade;
@@ -34,11 +36,23 @@ namespace Xtensive.Orm
     /// Removes node with specified <paramref name="nodeId"/>.
     /// </summary>
     /// <param name="nodeId">Node identifier.</param>
+    /// <param name="clearQueryCache">
+    /// if <see langword="true"/> then cached queries dedicated to the removing node will be removed from cache as well. By default <see langword="false"/>.
+    /// </param>
     /// <returns>True if node was removed, otherwise false.</returns>
-    public bool RemoveNode([NotNull] string nodeId)
+    public bool RemoveNode([NotNull] string nodeId, bool clearQueryCache = false)
     {
-      return handlers.StorageNodeRegistry.Remove(nodeId);
+      var removeResult = handlers.StorageNodeRegistry.Remove(nodeId);
+
+      if (removeResult && clearQueryCache) {
+        var queryCache = (Caching.LruCache<object, Pair<object, Linq.TranslatedQuery>>) handlers.Domain.QueryCache;
+        foreach (var key in queryCache.GetKeysInternal().Where(k => k is Pair<object, string> p && p.Second == nodeId).ToChainedBuffer()) {
+          queryCache.RemoveKey(key, true);
+        }
+      }
+      return removeResult;
     }
+
 
     /// <summary>
     /// Gets node with the specified <paramref name="nodeId"/>


### PR DESCRIPTION
Adds extra parameter for StorageNodeManager.Remove() method for being able to remove query cache items dedicated to the removing node