### PR TITLE
Optimization: avoid 2-level cache in AttributeHelper

### DIFF
--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -24,27 +24,10 @@ namespace Xtensive.Reflection
       private static readonly Type attributeType = typeof(TAttribute);
       public static readonly ConcurrentDictionary<PerAttributeKey, TAttribute[]> Dictionary = new();
 
-      private static List<TAttribute> GetAttributesAsNewList(MemberInfo member)
-      {
-        var attrObjects = member.GetCustomAttributes(attributeType, false);
-        var attrs = new List<TAttribute>(attrObjects.Length);
-        for (int i = 0, count = attrObjects.Length; i < count; ++i) {
-          attrs.Add((TAttribute) attrObjects[i]);
-        }
-        return attrs;
-      }
+      public static readonly Func<PerAttributeKey, TAttribute[]> AttributesExtractor = ExtractAttributesByKey;
 
-      private static void AddAttributesFromBase(ref List<TAttribute> attributes, MemberInfo member, AttributeSearchOptions options)
+      private static TAttribute[] ExtractAttributesByKey(PerAttributeKey key)
       {
-        if (member.GetBaseMember() is MemberInfo bm) {
-          var attrsToAdd = bm.GetAttributes<TAttribute>(options);
-          if (attrsToAdd.Count > 0) {
-            (attributes ??= new List<TAttribute>(attrsToAdd.Count)).AddRange(attrsToAdd);
-          }
-        }
-      }
-
-      public static readonly Func<PerAttributeKey, TAttribute[]> AttributesExtractor = key => {
         var (member, options) = key;
 
         var attributesAsObjects = member.GetCustomAttributes(attributeType, false);
@@ -74,8 +57,27 @@ namespace Xtensive.Reflection
         }
 
         return attributes?.ToArray(attributes.Count) ?? Array.Empty<TAttribute>();
-      };
-    }
+      }
+
+      private static List<TAttribute> GetAttributesAsNewList(MemberInfo member)
+      {
+        var attrObjects = member.GetCustomAttributes(attributeType, false);
+        var attrs = new List<TAttribute>(attrObjects.Length);
+        for (int i = 0, count = attrObjects.Length; i < count; ++i) {
+          attrs.Add((TAttribute) attrObjects[i]);
+        }
+        return attrs;
+      }
+
+      private static void AddAttributesFromBase(ref List<TAttribute> attributes, MemberInfo member, AttributeSearchOptions options)
+      {
+        if (member.GetBaseMember() is MemberInfo bm) {
+          var attrsToAdd = bm.GetAttributes<TAttribute>(options);
+          if (attrsToAdd.Count > 0) {
+            (attributes ??= new List<TAttribute>(attrsToAdd.Count)).AddRange(attrsToAdd);
+          }
+        }
+      }
 
     /// <summary>
     /// A shortcut to <see cref="MemberInfo.GetCustomAttributes(Type,bool)"/> method.


### PR DESCRIPTION
1-level caching would be faster and have lesser memory footprint
Also store Arrays in the cache instead of List<> to save memory
These caches are very sparsed:
![image](https://user-images.githubusercontent.com/1176609/210515591-007ad16d-055e-4350-b2e5-ec15ddc60086.png)
