### PR TITLE
PostgreSql: Dedicated exception when schema info can't be extracted

### DIFF
--- a/ChangeLog/6.0.11_dev.txt
+++ b/ChangeLog/6.0.11_dev.txt
@@ -1,0 +1,1 @@
+[postgresql] Dedicated exception when an extracting schema doesn't exist or it belongs to another user

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -75,6 +75,15 @@ namespace Xtensive.Sql.Drivers.PostgreSql.Resources {
         internal static string ExPostgreSqlBelow83IsNotSupported {
             get {
                 return ResourceManager.GetString("ExPostgreSqlBelow83IsNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Schema &apos;{0}&apos; either does not exist or belongs to another user..
+        /// </summary>
+        internal static string ExSchemaXDoesNotExistOrBelongsToAnotherUser {
+            get {
+                return ResourceManager.GetString("ExSchemaXDoesNotExistOrBelongsToAnotherUser", resourceCulture);
             }
         }
         

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.resx
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExPostgreSqlBelow83IsNotSupported" xml:space="preserve">
     <value>PostgreSQL below 8.3 is not supported.</value>
@@ -131,5 +131,8 @@
   </data>
   <data name="ExTheTypeOfGivenParameterCannotBeTreatedAsOffsetForDateTimeOffsetConstruction" xml:space="preserve">
     <value>The type of given parameter cannot be treated as offset for DateTimeOffset construction.</value>
+  </data>
+  <data name="ExSchemaXDoesNotExistOrBelongsToAnotherUser" xml:space="preserve">
+    <value>Schema '{0}' either does not exist or belongs to another user.</value>
   </data>
 </root>

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
@@ -441,7 +441,12 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
           && SqlDml.In(relationsTable["relkind"], SqlDml.Row('r', 'v', 'S'));
 
         if (targetSchemes!=null && targetSchemes.Count > 0) {
-          var schemesIndexes = catalog.Schemas.Where(sch => targetSchemes.ContainsKey(sch.Name)).Select(sch => context.ReversedSchemaMap[sch]);
+          var schemesIndexes = catalog.Schemas.Where(sch => targetSchemes.ContainsKey(sch.Name))
+            .Select(sch =>
+              context.ReversedSchemaMap.TryGetValue(sch, out var oid)
+                ? oid
+                : throw new InvalidOperationException(string.Format(Resources.Strings.ExSchemaXDoesNotExistOrBelongsToAnotherUser, sch.Name))
+             );
           select.Where &= SqlDml.In(relationsTable["relnamespace"], CreateOidRow(schemesIndexes));
         }
         select.Columns.Add(relationsTable["oid"], "reloid");

--- a/Orm/Xtensive.Orm.PostgreSql/Xtensive.Orm.PostgreSql.csproj
+++ b/Orm/Xtensive.Orm.PostgreSql/Xtensive.Orm.PostgreSql.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
@@ -30,6 +30,18 @@
   <ItemGroup>
     <Compile Include="..\Xtensive.Orm\Properties\Visibility.cs">
       <Link>Properties\Visibility.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Sql.Drivers.PostgreSql\Resources\Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <SubType>Designer</SubType>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </None>
+    <Compile Update="Sql.Drivers.PostgreSql\Resources\Strings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Sometimes an extracting schema doesn't exist in the database, or it is inaccessible by the user that opened connection, so instead of weird KeyNotFoundException from dictionary we throw an exception with clear error message.