### PR TITLE
Intern short (1..2 chars) contents of TextNode; Statically preallocate Comma TextNode as mostly used

### DIFF
--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -164,11 +164,7 @@ namespace Xtensive.Sql.Compiler
     internal void FlushBuffer()
     {
       if (stringBuilder.Length > 0) {
-        var s = stringBuilder.ToString();
-        if (s.Length < 3) {
-          s = string.Intern(s);
-        }
-        children.Add(new TextNode(s));
+        children.Add(TextNode.Create(stringBuilder.ToString()));
         lastNodeIsText = true;
         lastChar = stringBuilder[^1];
         _ = stringBuilder.Clear();

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -164,7 +164,11 @@ namespace Xtensive.Sql.Compiler
     internal void FlushBuffer()
     {
       if (stringBuilder.Length > 0) {
-        children.Add(new TextNode(stringBuilder.ToString()));
+        var s = stringBuilder.ToString();
+        if (s.Length < 3) {
+          s = string.Intern(s);
+        }
+        children.Add(new TextNode(s));
         lastNodeIsText = true;
         lastChar = stringBuilder[^1];
         _ = stringBuilder.Clear();

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/TextNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/TextNode.cs
@@ -9,16 +9,27 @@ namespace Xtensive.Sql.Compiler
   [DebuggerDisplay("Text = {Text}")]
   internal class TextNode : Node
   {
+    private const string CommaString = ", ";
+    private static readonly TextNode CommaNode = new TextNode(CommaString);
+
     public readonly string Text;
 
-    internal override void AcceptVisitor(NodeVisitor visitor)
+    internal override void AcceptVisitor(NodeVisitor visitor) => visitor.Visit(this);
+
+    public static TextNode Create(string text)
     {
-      visitor.Visit(this);
+      if (text.Length < 3) {
+        text = string.Intern(text);
+        if (text == CommaString) {
+          return CommaNode;
+        }
+      }
+      return new TextNode(text);
     }
 
     // Constructor
 
-    public TextNode(string text)
+    private TextNode(string text)
       : base(true)
     {
       Text = text;

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/TextNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/TextNode.cs
@@ -14,8 +14,6 @@ namespace Xtensive.Sql.Compiler
 
     public readonly string Text;
 
-    internal override void AcceptVisitor(NodeVisitor visitor) => visitor.Visit(this);
-
     public static TextNode Create(string text)
     {
       if (text.Length < 3) {
@@ -26,6 +24,8 @@ namespace Xtensive.Sql.Compiler
       }
       return new TextNode(text);
     }
+
+    internal override void AcceptVisitor(NodeVisitor visitor) => visitor.Visit(this);
 
     // Constructor
 


### PR DESCRIPTION
Most typical TextNode is  `comma+space`
Cached queries may contain Megabytes of them:
![image](https://user-images.githubusercontent.com/1176609/211781775-36fc5964-3467-4386-886d-c8cdb576817d.png)