### PR TITLE
DataTypeCollection: fix adding provider specific types

### DIFF
--- a/ChangeLog/6.0.12_dev.txt
+++ b/ChangeLog/6.0.12_dev.txt
@@ -1,0 +1,1 @@
+[main] Addressed DataTypeCollection.Add method issue of wrong adding storage-specifid types to the collection

--- a/Orm/Xtensive.Orm/Sql/Info/DataTypeCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Info/DataTypeCollection.cs
@@ -57,8 +57,10 @@ namespace Xtensive.Sql.Info
     public void Add(SqlType sqlType, DataTypeInfo dataTypeInfo)
     {
       this.EnsureNotLocked();
-      if (!IsLocked)
-        sqlTypes.Add(sqlType, dataTypeInfo);
+      sqlTypes.Add(sqlType, dataTypeInfo);
+      foreach (var nativeType in dataTypeInfo.NativeTypes) {
+        nativeTypes.Add(nativeType, dataTypeInfo);
+      }
     }
 
     /// <summary>


### PR DESCRIPTION
- no double IsLocked check
- custom types and they native name alternatives are added to collections properly