### PR TITLE
Keep Microsoft.Data.SqlClient v5.0.0 for net5

### DIFF
--- a/Orm/Xtensive.Orm.SqlServer/Xtensive.Orm.SqlServer.csproj
+++ b/Orm/Xtensive.Orm.SqlServer/Xtensive.Orm.SqlServer.csproj
@@ -15,10 +15,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WarningLevel>2</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Xtensive.Orm\Xtensive.Orm.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Microsoft.Data.SqlClient v5.1.0 requires System.Configuration.ConfigurationManager of version 6.0.1 and newer which is not in use  for .NET5