### PR TITLE
SqlServer: Both US English and British English are considered English

### DIFF
--- a/ChangeLog/6.0.12_dev.txt
+++ b/ChangeLog/6.0.12_dev.txt
@@ -1,1 +1,2 @@
 [main] Addressed DataTypeCollection.Add method issue of wrong adding storage-specifid types to the collection
+[sqlserver] Sql error messages for British English are correctly parsed

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/DriverFactory.cs
@@ -44,7 +44,8 @@ namespace Xtensive.Sql.Drivers.SqlServer
       bool isEnglish;
       using (var command = connection.CreateCommand()) {
         command.CommandText = LangIdQuery;
-        isEnglish = command.ExecuteScalar().ToString()=="0";
+        var langId = (short) command.ExecuteScalar();
+        isEnglish = langId == 0 || langId == 23;
       }
       var templates = new Dictionary<int, string>();
       using (var command = connection.CreateCommand()) {


### PR DESCRIPTION
Adds British English (code 23) as English for ErrorMessageParser.