### PR TITLE
No activation on EntitySet enumeration

### DIFF
--- a/ChangeLog/7.1.0-RC2-dev.txt
+++ b/ChangeLog/7.1.0-RC2-dev.txt
@@ -1,1 +1,2 @@
 [main] Added support for DefaultExpression within Linq queries
+[main] No Session.Activate() in ToTransactional extension, it affects EntitySet<T> enumeration.

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerAdvancedTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerAdvancedTest.cs
@@ -502,7 +502,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
             using (Session.Deactivate()) { // Prevents Session switching check error
               Assert.AreSame(null, Session.Current);
               foreach (var orderDetail in order.Details) {
-                Assert.AreSame(order.Details.Session, Session.Current);
+                Assert.AreSame(order.Details.Session, session);
                 Assert.AreSame(session, orderDetail.Session);
                 Assert.AreSame(session, orderDetail.Order.Session);
                 Assert.AreSame(order, orderDetail.Order);

--- a/Orm/Xtensive.Orm/Orm/TransactionalExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/TransactionalExtensions.cs
@@ -177,7 +177,6 @@ namespace Xtensive.Orm
     /// <returns>"Transactional" version of sequence.</returns>
     public static IEnumerable<T> ToTransactional<T>(this IEnumerable<T> source, Session session, IsolationLevel isolationLevel)
     {
-      using (session.Activate(true))
       using (var tx = session.OpenAutoTransaction(isolationLevel)) {
         foreach (var item in source)
           yield return item;


### PR DESCRIPTION
Closes #284

```EntitySet``` enumeration was obligatory to have session activated event if all user code was completely activations-free. Now no hidden session activation happens, as in other ```TransactionalExtensions``` members