### PR TITLE
remove `Change end_of_line` rule in `.editorconfig` to avoid confusion with `CRLF` <-> `LF` conversions on Linux dev environment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,7 +35,7 @@ indent_style = space
 tab_width = 2
 
 # New line preferences
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = false
 
 #### .NET Coding Conventions ####

--- a/.editorconfig
+++ b/.editorconfig
@@ -35,7 +35,6 @@ indent_style = space
 tab_width = 2
 
 # New line preferences
-end_of_line = lf
 insert_final_newline = false
 
 #### .NET Coding Conventions ####


### PR DESCRIPTION
Source code in the repository actually has LF ending
No need to force VS insert CRLF, and then convert it by git during commits