### PR TITLE
TimeOnly constructors support

### DIFF
--- a/ChangeLog/7.1.0-RC2-dev.txt
+++ b/ChangeLog/7.1.0-RC2-dev.txt
@@ -1,0 +1,1 @@
+[main] Support for TimeOnly ctors (time parts and ticks) in Linq, except for SQLite and MySQL providers

--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Compiler.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Compiler.cs
@@ -16,11 +16,19 @@ namespace Xtensive.Sql.Drivers.Firebird.v2_5
 {
   internal class Compiler : SqlCompiler
   {
-    protected static readonly long NanosecondsPerDay = TimeSpan.FromDays(1).Ticks * 100;
-    protected static readonly long NanosecondsPerSecond = 1000000000;
-    protected static readonly long NanosecondsPerMillisecond = 1000000;
-    protected static readonly long MillisecondsPerDay = (long) TimeSpan.FromDays(1).TotalMilliseconds;
-    protected static readonly long MillisecondsPerSecond = 1000L;
+    protected const long NanosecondsPerDay = 86400000000000;
+    protected const long NanosecondsPerHour = 3600000000000;
+    protected const long NanosecondsPerMinute = 60000000000;
+    protected const long NanosecondsPerSecond = 1000000000;
+    protected const long NanosecondsPerMillisecond = 1000000;
+    protected const long MillisecondsPerDay = 86400000;
+    protected const long MillisecondsPerSecond = 1000L;
+
+    //protected static readonly long NanosecondsPerDay = TimeSpan.FromDays(1).Ticks * 100;
+    //protected static readonly long NanosecondsPerSecond = 1000000000;
+    //protected static readonly long NanosecondsPerMillisecond = 1000000;
+    //protected static readonly long MillisecondsPerDay = (long) TimeSpan.FromDays(1).TotalMilliseconds;
+    //protected static readonly long MillisecondsPerSecond = 1000L;
     private bool case_SqlDateTimePart_DayOfYear;
     private bool case_SqlDateTimePart_Second;
 
@@ -253,6 +261,9 @@ namespace Xtensive.Sql.Drivers.Firebird.v2_5
         case SqlFunctionType.TimeConstruct:
           ConstructTime(arguments).AcceptVisitor(this);
           return;
+        case SqlFunctionType.TimeToNanoseconds:
+          TimeToNanoseconds(arguments[0]).AcceptVisitor(this);
+          return;
         case SqlFunctionType.DateToString:
           Visit(DateToString(arguments[0]));
           return;
@@ -335,6 +346,16 @@ namespace Xtensive.Sql.Drivers.Firebird.v2_5
       else {
         throw new InvalidOperationException("Unsupported count of parameters");
       }
+    }
+
+    protected virtual SqlExpression TimeToNanoseconds(SqlExpression time)
+    {
+      var nPerHour = SqlDml.Extract(SqlTimePart.Hour, time) * NanosecondsPerHour;
+      var nPerMinute = SqlDml.Extract(SqlTimePart.Minute, time) * NanosecondsPerMinute;
+      var nPerSecond = SqlDml.Extract(SqlTimePart.Second, time) * NanosecondsPerSecond;
+      var nPerMillisecond = SqlDml.Extract(SqlTimePart.Millisecond, time) * NanosecondsPerMillisecond;
+
+      return nPerHour + nPerMinute + nPerSecond + nPerMillisecond;
     }
 #endif
 

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Compiler.cs
@@ -24,13 +24,6 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
     protected const long NanosecondsPerMicrosecond = 1000;
     protected const long MillisecondsPerDay = 86400000;
 
-    //protected static readonly long NanosecondsPerDay = TimeSpan.FromDays(1).Ticks * 100;
-    //protected static readonly long NanosecondsPerSecond = 1000000000;
-    //protected static readonly long NanosecondsPerMillisecond = 1000000;
-    //protected static readonly long NanosecondsPerMicrosecond = 1000;
-    //protected static readonly long MillisecondsPerDay = (long) TimeSpan.FromDays(1).TotalMilliseconds;
-    //protected static readonly long MillisecondsPerSecond = 1000L;
-
     /// <inheritdoc/>
     public override void Visit(SqlSelect node)
     {
@@ -222,9 +215,6 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
                 SqlDml.RawConcat(SqlDml.Native("INTERVAL "), SqlDml.FunctionCall("TIME_TO_SEC", arguments[0]) + arguments[1] * 60),
                 SqlDml.Native("SECOND")))));
           return;
-        case SqlFunctionType.TimeConstruct:
-          ConstructTime(arguments).AcceptVisitor(this);
-          return;
         case SqlFunctionType.TimeToNanoseconds:
           TimeToNanoseconds(arguments[0]).AcceptVisitor(this);
           return;
@@ -339,38 +329,6 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
             arguments[0] - 2001),
           arguments[1] - 1),
         arguments[2] - 1);
-    }
-
-    protected virtual SqlExpression ConstructTime(IReadOnlyList<SqlExpression> arguments)
-    {
-      SqlExpression hour, minute, second, millisecond;
-      if (arguments.Count == 4) {
-        hour = arguments[0];
-        minute = arguments[1];
-        second = arguments[2];
-        millisecond = arguments[3];
-      }
-      else if (arguments.Count == 1) {
-        var ticks = arguments[0];
-        hour = SqlDml.Cast(ticks / 36000000000, SqlType.Int32);
-        minute = SqlDml.Cast((ticks / 600000000) % 60, SqlType.Int32);
-        second = SqlDml.Cast((ticks / 10000000) % 60, SqlType.Int32);
-        millisecond = 0; //SqlDml.Cast((ticks % 10000000) / 10, SqlType.Int32);
-      }
-      else {
-        throw new InvalidOperationException("Unsupported count of parameters");
-      }
-
-      return SqlDml.FunctionCall("TIME",
-        TimeAddMillisecond(
-          TimeAddSecond(
-            TimeAddMinute(
-              TimeAddHour(
-                SqlDml.Literal(new DateTime(2001, 1, 1)),
-                hour),
-              minute),
-            second),
-          millisecond));
     }
 
     protected virtual SqlExpression TimeToNanoseconds(SqlExpression time)

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_6/Compiler.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_6/Compiler.cs
@@ -61,40 +61,6 @@ namespace Xtensive.Sql.Drivers.MySql.v5_6
       SqlDml.Modulo(
         NanosecondsPerDay + CastToDecimal(DateTimeDiffMicrosecond(time2, time1), 18, 0) * NanosecondsPerMicrosecond,
         NanosecondsPerDay);
-
-    protected override SqlUserFunctionCall ConstructTime(IReadOnlyList<SqlExpression> arguments)
-    {
-      SqlExpression hour, minute, second, millisecond;
-      if (arguments.Count == 4) {
-        hour = arguments[0];
-        minute = arguments[1];
-        second = arguments[2];
-        millisecond = arguments[3];
-      }
-      else if (arguments.Count == 1) {
-        var ticks = arguments[0];
-        if (SqlHelper.IsTimeSpanTicks(ticks, out var sourceInterval)) {
-          hour = SqlDml.Cast(ticks / 36000000000, SqlType.Int32);
-          minute = SqlDml.Cast((ticks / 600000000) % 60, SqlType.Int32);
-          second = SqlDml.Cast((ticks / 10000000) % 60, SqlType.Int32);
-          millisecond = SqlDml.Cast((ticks % 10000000) / 10, SqlType.Int32) / 1000;
-        }
-        else {
-          hour = SqlDml.Cast(ticks / 36000000000, SqlType.Int32);
-          minute = SqlDml.Cast((ticks / 600000000) % 60, SqlType.Int32);
-          second = SqlDml.Cast((ticks / 10000000) % 60, SqlType.Int32);
-          millisecond = SqlDml.Cast((ticks % 10000000) / 10, SqlType.Int32) / 1000;
-        }
-      }
-      else {
-        throw new InvalidOperationException("Unsupported count of parameters");
-      }
-      return MakeTime(hour, minute, second, millisecond);
-    }
-
-    protected SqlUserFunctionCall MakeTime(
-        SqlExpression hours, SqlExpression minutes, SqlExpression seconds, SqlExpression milliseconds) =>
-      SqlDml.FunctionCall("MAKETIME", hours, minutes, seconds + (milliseconds / 1000));
 #endif
 
     // Constructors

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/Compiler.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/Compiler.cs
@@ -44,12 +44,19 @@ namespace Xtensive.Sql.Drivers.Oracle.v09
     protected const string ToDSIntervalFunctionName = "TO_DSINTERVAL";
     protected const string TimeFormat = "HH24:MI:SS.FF7";
 
+    protected const long NanosecondsPerHour = 3600000000000;
+    protected const long NanosecondsPerMinute = 60000000000;
+    protected const long NanosecondsPerSecond = 1000000000;
+    protected const long NanosecondsPerMillisecond = 1000000;
+
     private static readonly SqlExpression SundayNumber = SqlDml.Native(
       "TO_NUMBER(TO_CHAR(TIMESTAMP '2009-07-26 00:00:00.000', 'D'))");
     private static readonly SqlNative RefTimestamp = SqlDml.Native("timestamp '2009-01-01 00:00:00.0000000'");
 
     public override void Visit(SqlFunctionCall node)
     {
+      var arguments = node.Arguments;
+
       switch (node.FunctionType) {
         case SqlFunctionType.PadLeft:
         case SqlFunctionType.PadRight:
@@ -57,107 +64,110 @@ namespace Xtensive.Sql.Drivers.Oracle.v09
           return;
         case SqlFunctionType.DateTimeOffsetAddYears:
         case SqlFunctionType.DateTimeAddYears:
-          DateTimeAddYMInterval(node.Arguments[0], node.Arguments[1], YearIntervalPart).AcceptVisitor(this);
+          DateTimeAddYMInterval(arguments[0], arguments[1], YearIntervalPart).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeOffsetAddMonths:
         case SqlFunctionType.DateTimeAddMonths:
-          DateTimeAddYMInterval(node.Arguments[0], node.Arguments[1], MonthIntervalPart).AcceptVisitor(this);
+          DateTimeAddYMInterval(arguments[0], arguments[1], MonthIntervalPart).AcceptVisitor(this);
           return;
         case SqlFunctionType.IntervalConstruct:
-          IntervalConstruct(node.Arguments[0]).AcceptVisitor(this);
+          IntervalConstruct(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeConstruct:
-          DateTimeConstruct(node.Arguments[0], node.Arguments[1], node.Arguments[2]).AcceptVisitor(this);
+          DateTimeConstruct(arguments[0], arguments[1], arguments[2]).AcceptVisitor(this);
           return;
 #if NET6_0_OR_GREATER
         case SqlFunctionType.DateConstruct:
-          DateConstruct(node.Arguments[0], node.Arguments[1], node.Arguments[2]).AcceptVisitor(this);
+          DateConstruct(arguments[0], arguments[1], arguments[2]).AcceptVisitor(this);
           return;
         case SqlFunctionType.TimeConstruct:
-          TimeConstruct(node.Arguments).AcceptVisitor(this);
+          TimeConstruct(arguments).AcceptVisitor(this);
+          return;
+        case SqlFunctionType.TimeToNanoseconds:
+          TimeToNanoseconds(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateAddYears:
-          DateTimeAddYMInterval(node.Arguments[0], node.Arguments[1], YearIntervalPart).AcceptVisitor(this);
+          DateTimeAddYMInterval(arguments[0], arguments[1], YearIntervalPart).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateAddMonths:
-          DateTimeAddYMInterval(node.Arguments[0], node.Arguments[1], MonthIntervalPart).AcceptVisitor(this);
+          DateTimeAddYMInterval(arguments[0], arguments[1], MonthIntervalPart).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateAddDays:
-          DateTimeAddDSInterval(node.Arguments[0], node.Arguments[1], DayIntervalPart).AcceptVisitor(this);
+          DateTimeAddDSInterval(arguments[0], arguments[1], DayIntervalPart).AcceptVisitor(this);
           return;
         case SqlFunctionType.TimeAddHours:
-          TimeAddHourOrMinute(node.Arguments[0], node.Arguments[1], true).AcceptVisitor(this);
+          TimeAddHourOrMinute(arguments[0], arguments[1], true).AcceptVisitor(this);
           return;
         case SqlFunctionType.TimeAddMinutes:
-          TimeAddHourOrMinute(node.Arguments[0], node.Arguments[1], false).AcceptVisitor(this);
+          TimeAddHourOrMinute(arguments[0], arguments[1], false).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateToString:
-          DateToString(node.Arguments[0]).AcceptVisitor(this);
+          DateToString(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.TimeToString:
-          TimeToString(node.Arguments[0]).AcceptVisitor(this);
+          TimeToString(arguments[0]).AcceptVisitor(this);
           return;
 #endif
         case SqlFunctionType.IntervalAbs:
-          SqlHelper.IntervalAbs(node.Arguments[0]).AcceptVisitor(this);
+          SqlHelper.IntervalAbs(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.IntervalToMilliseconds:
-          SqlHelper.IntervalToMilliseconds(node.Arguments[0]).AcceptVisitor(this);
+          SqlHelper.IntervalToMilliseconds(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.IntervalToNanoseconds:
-          SqlHelper.IntervalToNanoseconds(node.Arguments[0]).AcceptVisitor(this);
+          SqlHelper.IntervalToNanoseconds(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.Position:
-          Position(node.Arguments[0], node.Arguments[1]).AcceptVisitor(this);
+          Position(arguments[0], arguments[1]).AcceptVisitor(this);
           return;
         case SqlFunctionType.CharLength:
-          SqlDml.Coalesce(SqlDml.FunctionCall("LENGTH", node.Arguments[0]), 0).AcceptVisitor(this);
+          SqlDml.Coalesce(SqlDml.FunctionCall("LENGTH", arguments[0]), 0).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeToStringIso:
-          DateTimeToStringIso(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeToStringIso(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeOffsetConstruct:
-          DateTimeOffsetConstruct(node.Arguments[0], node.Arguments[1]).AcceptVisitor(this);
+          DateTimeOffsetConstruct(arguments[0], arguments[1]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeOffsetTimeOfDay:
-          DateTimeOffsetTimeOfDay(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeOffsetTimeOfDay(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeOffsetToLocalTime:
-          DateTimeOffsetToLocalTime(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeOffsetToLocalTime(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeToDateTimeOffset:
-          DateTimeToDateTimeOffset(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeToDateTimeOffset(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeOffsetToDateTime:
-          DateTimeOffsetToDateTime(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeOffsetToDateTime(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeOffsetToUtcTime:
-          DateTimeOffsetToUtcTime(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeOffsetToUtcTime(arguments[0]).AcceptVisitor(this);
           return;
 #if NET6_0_OR_GREATER
         case SqlFunctionType.DateTimeToDate:
-          DateTimeToDate(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeToDate(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateToDateTime:
-          DateToDateTime(node.Arguments[0]).AcceptVisitor(this);
+          DateToDateTime(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeToTime:
-          DateTimeToTime(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeToTime(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.TimeToDateTime:
-          TimeToDateTime(node.Arguments[0]).AcceptVisitor(this);
+          TimeToDateTime(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeOffsetToDate:
-          DateTimeOffsetToDate(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeOffsetToDate(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateTimeOffsetToTime:
-          DateTimeOffsetToTime(node.Arguments[0]).AcceptVisitor(this);
+          DateTimeOffsetToTime(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.DateToDateTimeOffset:
-          DateToDateTimeOffset(node.Arguments[0]).AcceptVisitor(this);
+          DateToDateTimeOffset(arguments[0]).AcceptVisitor(this);
           return;
         case SqlFunctionType.TimeToDateTimeOffset:
-          TimeToDateTimeOffset(node.Arguments[0]).AcceptVisitor(this);
+          TimeToDateTimeOffset(arguments[0]).AcceptVisitor(this);
           return;
 #endif
         default:
@@ -399,6 +409,16 @@ namespace Xtensive.Sql.Drivers.Oracle.v09
       else {
         throw new InvalidOperationException("Unsupported count of parameters");
       }
+    }
+
+    private static SqlExpression TimeToNanoseconds(SqlExpression time)
+    {
+      var nPerHour = SqlDml.Extract(SqlTimePart.Hour, time) * NanosecondsPerHour;
+      var nPerMinute = SqlDml.Extract(SqlTimePart.Minute, time) * NanosecondsPerMinute;
+      var nPerSecond = SqlDml.Extract(SqlTimePart.Second, time) * NanosecondsPerSecond;
+      var nPerMillisecond = SqlDml.Extract(SqlTimePart.Millisecond, time) * NanosecondsPerMillisecond;
+
+      return nPerHour + nPerMinute + nPerSecond + nPerMillisecond;
     }
 
     private static SqlExpression TimeAddHourOrMinute(SqlExpression time, SqlExpression hourOrMinute, bool isHour)

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v11/ServerInfoProvider.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v11/ServerInfoProvider.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.07.17
 

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v11/ServerInfoProvider.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v11/ServerInfoProvider.cs
@@ -4,11 +4,30 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.07.17
 
+using Xtensive.Sql.Info;
+
 namespace Xtensive.Sql.Drivers.Oracle.v11
 {
   internal class ServerInfoProvider : v10.ServerInfoProvider
   {
     // Constructors
+
+    public override DataTypeCollection GetDataTypesInfo()
+    {
+      const DataTypeFeatures common = DataTypeFeatures.Default | DataTypeFeatures.Nullable |
+        DataTypeFeatures.NonKeyIndexing | DataTypeFeatures.Grouping | DataTypeFeatures.Ordering |
+        DataTypeFeatures.Multiple;
+      const DataTypeFeatures index = DataTypeFeatures.Indexing | DataTypeFeatures.Clustering |
+        DataTypeFeatures.FillFactor | DataTypeFeatures.KeyConstraint;
+
+      var baseCollection = base.GetDataTypesInfo();
+
+      baseCollection.Interval = DataTypeInfo.Range(SqlType.Interval, common | index,
+        ValueRange.TimeSpan, "INTERVAL DAY(6) TO SECONDS(7)");
+
+      return baseCollection;
+    }
+
 
     public ServerInfoProvider(SqlDriver driver)
       : base(driver)

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v10_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v10_0/Compiler.cs
@@ -4,32 +4,29 @@
 // Created by: Alexey Kulakov
 // Created:    2019.09.25
 
+using System;
+using System.Collections.Generic;
 using Xtensive.Sql.Dml;
 
 namespace Xtensive.Sql.Drivers.PostgreSql.v10_0
 {
   internal class Compiler : v9_1.Compiler
   {
-    public override void Visit(SqlFunctionCall node)
-    {
-      var arguments = node.Arguments;
-      switch (node.FunctionType) {
-        case SqlFunctionType.DateTimeConstruct:
-          Visit(MakeDateTime(arguments[0], arguments[1], arguments[2]));
-          return;
+    protected override SqlUserFunctionCall ConstructDateTime(IReadOnlyList<SqlExpression> arguments) => MakeDateTime(arguments[0], arguments[1], arguments[2]);
 #if NET6_0_OR_GREATER
-        case SqlFunctionType.DateConstruct:
-          Visit(MakeDate(arguments[0], arguments[1], arguments[2]));
-          return;
-        case SqlFunctionType.TimeConstruct:
-          Visit(MakeTime(arguments[0], arguments[1], arguments[2], arguments[3]));
-          return;
-#endif
-        default:
-          base.Visit(node);
-          return;
+
+    protected override SqlUserFunctionCall ConstructDate(IReadOnlyList<SqlExpression> arguments) => MakeDate(arguments[0], arguments[1], arguments[2]);
+
+    protected override SqlExpression ConstructTime(IReadOnlyList<SqlExpression> arguments)
+    {
+      if (arguments.Count == 4) {
+        return MakeTime(arguments[0], arguments[1], arguments[2], arguments[3]);
+      }
+      else {
+        return base.ConstructTime(arguments);
       }
     }
+#endif
 
     protected static SqlUserFunctionCall MakeDateTime(SqlExpression year, SqlExpression month, SqlExpression day) =>
       SqlDml.FunctionCall("MAKE_TIMESTAMP", year, month, day, SqlDml.Literal(0), SqlDml.Literal(0), SqlDml.Literal(0.0));

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v10_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v10_0/Compiler.cs
@@ -20,10 +20,24 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v10_0
     protected override SqlExpression ConstructTime(IReadOnlyList<SqlExpression> arguments)
     {
       if (arguments.Count == 4) {
-        return MakeTime(arguments[0], arguments[1], arguments[2], arguments[3]);
+        return MakeTime(arguments[0], arguments[1], arguments[2], arguments[3], true);
+      }
+      else if (arguments.Count == 1) {
+        var ticks = arguments[0];
+        if (SqlHelper.IsTimeSpanTicks(ticks, out var sourceInterval)) {
+          // try to optimize and reduce calculations when TimeSpan.Ticks where used for TimeOnly(ticks) ctor
+          return SqlDml.Cast(SqlDml.Cast(sourceInterval, SqlType.VarChar), SqlType.Time);
+        }
+        else {
+          var hour = SqlDml.Cast(ticks / 36000000000, SqlType.Int32);
+          var minute = SqlDml.Cast((ticks / 600000000) % 60, SqlType.Int32);
+          var second = SqlDml.Cast((ticks / 10000000) % 60, SqlType.Int32);
+          var microsecond = SqlDml.Cast((ticks % 10000000) / 10, SqlType.Int32);
+          return MakeTime(hour, minute, second, microsecond, false);
+        }
       }
       else {
-        return base.ConstructTime(arguments);
+        throw new InvalidOperationException("Unsupported count of parameters");
       }
     }
 #endif
@@ -36,8 +50,10 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v10_0
       SqlDml.FunctionCall("MAKE_DATE", year, month, day);
 
     protected static SqlUserFunctionCall MakeTime(
-       SqlExpression hours, SqlExpression minutes, SqlExpression seconds, SqlExpression milliseconds) =>
-     SqlDml.FunctionCall("MAKE_TIME", hours, minutes, seconds + (SqlDml.Cast(milliseconds, SqlType.Double) / 1000));
+       SqlExpression hours, SqlExpression minutes, SqlExpression seconds, SqlExpression secondFractions, in bool isMilliseconds) =>
+      (isMilliseconds) 
+        ? SqlDml.FunctionCall("MAKE_TIME", hours, minutes, seconds + (SqlDml.Cast(secondFractions, SqlType.Double) / 1000))
+        : SqlDml.FunctionCall("MAKE_TIME", hours, minutes, seconds + (SqlDml.Cast(secondFractions, SqlType.Double) / 1000000));
 #endif
 
     // Constructors

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
@@ -20,6 +20,11 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
     private const string TimeFormat = "HH24:MI:SS.US0";
 #endif
 
+    private const long NanosecondsPerHour = 3600000000000;
+    private const long NanosecondsPerMinute = 60000000000;
+    private const long NanosecondsPerSecond = 1000000000;
+    private const long NanosecondsPerMillisecond = 1000000;
+
     private static readonly Type SqlPlaceholderType = typeof(SqlPlaceholder);
 
     private static readonly SqlNative OneYearInterval = SqlDml.Native("interval '1 year'");
@@ -134,6 +139,9 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
           return;
         case SqlFunctionType.TimeConstruct:
           ConstructTime(node.Arguments).AcceptVisitor(this);
+          return;
+        case SqlFunctionType.TimeToNanoseconds:
+          TimeToNanoseconds(node.Arguments[0]).AcceptVisitor(this);
           return;
 #endif
         case SqlFunctionType.DateTimeTruncate:
@@ -422,8 +430,17 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       }
       else {
         throw new InvalidOperationException("Unsupported count of parameters");
-      }
-      
+      } 
+    }
+
+    protected virtual SqlExpression TimeToNanoseconds(SqlExpression time)
+    {
+      var nPerHour = SqlDml.Extract(SqlTimePart.Hour, time) * NanosecondsPerHour;
+      var nPerMinute = SqlDml.Extract(SqlTimePart.Minute, time) * NanosecondsPerMinute;
+      var nPerSecond = SqlDml.Extract(SqlTimePart.Second, time) * NanosecondsPerSecond;
+      var nPerMillisecond = SqlDml.Extract(SqlTimePart.Millisecond, time) * NanosecondsPerMillisecond;
+
+      return nPerHour + nPerMinute + nPerSecond + nPerMillisecond;
     }
 #endif
 

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
@@ -415,22 +415,40 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
 
     protected virtual SqlExpression ConstructTime(IReadOnlyList<SqlExpression> arguments)
     {
+      SqlExpression hour, minute, second, microsecond;
       if (arguments.Count == 4) {
-        return ZeroTimeLiteral
-          + (OneHourInterval * (arguments[0]))
-          + (OneMinuteInterval * (arguments[1]))
-          + (OneSecondInterval * (arguments[2] + (SqlDml.Cast(arguments[3], SqlType.Double) / 1000)));
+        hour = arguments[0];
+        minute = arguments[1];
+        second = arguments[2];
+        microsecond = arguments[3] * 1000;
       }
       else if (arguments.Count == 1) {
         var ticks = arguments[0];
-        if (SqlHelper.IsTimeSpanTicks(ticks, out var intervalExpr)) {
-          return ZeroTimeLiteral + intervalExpr;
+        if (SqlHelper.IsTimeSpanTicks(ticks, out var sourceInterval)) {
+          // try to optimize and reduce calculations when TimeSpan.Ticks where used for TimeOnly(ticks) ctor
+          return SqlDml.Cast(SqlDml.Cast(sourceInterval, SqlType.VarChar), SqlType.Time);
         }
-        return ZeroTimeLiteral + (ticks / SqlDml.Literal(10000000.0) * OneSecondInterval);
+        else {
+          hour = SqlDml.Cast(ticks / 36000000000, SqlType.Int32);
+          minute = SqlDml.Cast((ticks / 600000000) % 60, SqlType.Int32);
+          second = SqlDml.Cast((ticks / 10000000) % 60, SqlType.Int32);
+          microsecond = SqlDml.Cast((ticks % 10000000) / 10, SqlType.Int32);
+        }
       }
       else {
         throw new InvalidOperationException("Unsupported count of parameters");
-      } 
+      }
+
+      // Using string version of time allows to control hours overflow
+      // we cannot add hours, minutes and other parts to 00:00:00.000000 time
+      // because hours might step over 24 hours and start counting from 0.
+      // Starting from v10 new function is in use, which controlls overflow
+      var hourString = SqlDml.Cast(hour, new SqlValueType(SqlType.VarChar, 3));
+      var minuteString = SqlDml.Cast(minute, new SqlValueType(SqlType.VarChar, 2));
+      var secondString = SqlDml.Cast(second, new SqlValueType(SqlType.VarChar, 2));
+      var microsecondString = SqlDml.Cast(microsecond, new SqlValueType(SqlType.VarChar, 7));
+      var composedTimeString = SqlDml.Concat(hourString, SqlDml.Literal(":"), minuteString, SqlDml.Literal(":"), secondString, SqlDml.Literal("."), microsecondString);
+      return SqlDml.Cast(composedTimeString, SqlType.Time);
     }
 
     protected virtual SqlExpression TimeToNanoseconds(SqlExpression time)

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
@@ -548,23 +548,6 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       return false;
     }
 
-    private bool IsTimeSpanTicks(SqlExpression expressionToCheck, out SqlExpression source)
-    {
-      source = null;
-
-      if (expressionToCheck is SqlCast sqlCast && sqlCast.Type.Type==SqlType.Int64) {
-        var operand = sqlCast.Operand;
-        if (operand is SqlBinary sqlBinary && sqlBinary.NodeType == SqlNodeType.Divide) {
-          var left = sqlBinary.Left;
-          if (left is SqlFunctionCall functionCall && functionCall.FunctionType == SqlFunctionType.IntervalToNanoseconds) {
-            source = functionCall.Arguments[0];
-            return true;
-          }
-        }
-      }
-      return false;
-    }
-
     // Constructors
 
     protected internal Compiler(SqlDriver driver)

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
@@ -517,35 +517,36 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
     /// <exception cref="InvalidOperationException"></exception>
     protected virtual SqlExpression ConstructTime(IReadOnlyList<SqlExpression> arguments)
     {
-      SqlExpression hour, minute, second, millisecond;
+      SqlExpression hour, minute, second, microsecond;
       if (arguments.Count == 4) {
         hour = arguments[0];
         minute = arguments[1];
         second = arguments[2];
-        millisecond = arguments[3];
+        microsecond = arguments[3] * 10000;
       }
       else if (arguments.Count == 1) {
         var ticks = arguments[0];
+        // try to optimize and reduce calculations when TimeSpan.Ticks where used for TimeOnly(ticks) ctor
+        ticks = SqlHelper.IsTimeSpanTicks(ticks, out var sourceInterval) ? sourceInterval / 100 : ticks;
         hour = SqlDml.Cast(ticks / 36000000000, SqlType.Int32);
         minute = SqlDml.Cast((ticks / 600000000) % 60, SqlType.Int32);
         second = SqlDml.Cast((ticks / 10000000) % 60, SqlType.Int32);
-        millisecond = SqlDml.Cast(ticks % 10000000, SqlType.Int32);
+        microsecond = SqlDml.Cast(ticks % 10000000, SqlType.Int32);
       }
       else {
         throw new InvalidOperationException("Unsupported count of parameters");
       }
 
-      return SqlDml.Cast(
-        DateAddMillisecond(
-          DateAddSecond(
-            DateAddMinute(
-              DateAddHour(
-                SqlDml.Literal(new TimeOnly(0, 0, 0)),
-                hour),
-              minute),
-            second),
-          millisecond),
-        SqlType.Time);
+      // Using string version of time allows to control hours overflow
+      // we cannot add hours, minutes and other parts to 00:00:00.000000 time
+      // because hours might step over 24 hours and start counting from 0.
+      // Starting from v11 built-in function with hour overflow control is used.
+      var hourString = SqlDml.Cast(hour, new SqlValueType(SqlType.VarChar, 3));
+      var minuteString = SqlDml.Cast(minute, new SqlValueType(SqlType.VarChar, 2));
+      var secondString = SqlDml.Cast(second, new SqlValueType(SqlType.VarChar, 2));
+      var microsecondString = SqlDml.Cast(microsecond, new SqlValueType(SqlType.VarChar, 7));
+      var composedTimeString = SqlDml.Concat(hourString, SqlDml.Literal(":"), minuteString, SqlDml.Literal(":"), secondString, SqlDml.Literal("."), microsecondString);
+      return SqlDml.Cast(composedTimeString, SqlType.Time);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Compiler.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2012-2022 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.04.02
 

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Compiler.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Compiler.cs
@@ -32,6 +32,7 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
     private const string DateTimeFormat = "%Y-%m-%d %H:%M:%f";
     private const string DateTimeIsoFormat = "%Y-%m-%dT%H:%M:%S";
     private const string DateTimeOffsetExampleString = "2001-02-03 04:05:06.789+02.45";
+    private const string STRFTIMEFunctionName = "STRFTIME";
 
     private static readonly int StartOffsetIndex = DateTimeOffsetExampleString.IndexOf('+');
 
@@ -216,9 +217,6 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
             arguments[0] - 2001),
             arguments[1] - 1),
             arguments[2] - 1).AcceptVisitor(this);
-          return;
-        case SqlFunctionType.TimeConstruct:
-          TimeConstruct(arguments).AcceptVisitor(this);
           return;
         case SqlFunctionType.TimeToNanoseconds:
           TimeToNanoseconds(arguments[0]).AcceptVisitor(this);
@@ -461,9 +459,9 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
       DateTimeAddSeconds(date, interval / Convert.ToDouble(NanosecondsPerSecond));
 
     private static SqlExpression DateTimeTruncate(SqlExpression date) =>
-      DateTime(SqlDml.FunctionCall("STRFTIME", DateWithZeroTimeFormat, date));
+      DateTime(SqlDml.FunctionCall(STRFTIMEFunctionName, DateWithZeroTimeFormat, date));
 
-    private static SqlExpression DateTime(SqlExpression date) => SqlDml.FunctionCall("STRFTIME", DateTimeFormat, date);
+    private static SqlExpression DateTime(SqlExpression date) => SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, date);
 
     private static SqlCast CastToInt(SqlExpression arg) => SqlDml.Cast(arg, SqlType.Int32);
 
@@ -504,71 +502,41 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
       DateTimeSubtractDateTime(DateTimeOffsetExtractDateTimeAsString(dateTimeOffset), dateTimeOffset);
 
     private static SqlExpression DateTimeOffsetToUtcDateTime(SqlExpression dateTimeOffset) =>
-      SqlDml.FunctionCall("STRFTIME", DateTimeFormat, dateTimeOffset, "LOCALTIME", "UTC");
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, dateTimeOffset, "LOCALTIME", "UTC");
 
     private static SqlExpression DateTimeOffsetToLocalDateTime(SqlExpression dateTimeOffset) =>
-      SqlDml.FunctionCall("STRFTIME", DateTimeFormat, dateTimeOffset, "LOCALTIME");
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, dateTimeOffset, "LOCALTIME");
 
     private static SqlExpression DateTimeToDateTimeOffset(SqlExpression dateTime) =>
       SqlDml.Concat(DateTime(dateTime), ServerOffsetAsString());
 
     private static SqlExpression DateTimeOffsetToDateTime(SqlExpression dateTimeOffset) =>
       SqlDml.Cast(SqlDml.Extract(SqlDateTimeOffsetPart.DateTime, dateTimeOffset), SqlType.DateTime);
-      //SqlDml.Concat(DateTime(node.Arguments[0]), ServerOffsetAsString());
 
     private static SqlExpression DateTimeToStringIso(SqlExpression dateTime) =>
-      SqlDml.FunctionCall("STRFTIME", DateTimeIsoFormat, dateTime);
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeIsoFormat, dateTime);
 
     private static SqlExpression DateTimeAddYear(SqlExpression date, SqlExpression years) =>
-      SqlDml.FunctionCall("STRFTIME", DateTimeFormat, date, SqlDml.Concat(years, " ", "YEARS"));
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, date, SqlDml.Concat(years, " ", "YEARS"));
 
     private static SqlExpression DateTimeAddMonth(SqlExpression date, SqlExpression months) =>
-      SqlDml.FunctionCall("STRFTIME", DateTimeFormat, date, SqlDml.Concat(months, " ", "MONTHS"));
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, date, SqlDml.Concat(months, " ", "MONTHS"));
 
     private static SqlExpression DateTimeAddDay(SqlExpression date, SqlExpression days) =>
-      SqlDml.FunctionCall("STRFTIME", DateTimeFormat, date, SqlDml.Concat(days, " ", "DAYS"));
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, date, SqlDml.Concat(days, " ", "DAYS"));
 
     private static SqlExpression DateTimeAddSeconds(SqlExpression date, SqlExpression seconds) =>
-      SqlDml.FunctionCall("STRFTIME", DateTimeFormat, date, SqlDml.Concat(seconds, " ", "SECONDS"));
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, date, SqlDml.Concat(seconds, " ", "SECONDS"));
 #if NET6_0_OR_GREATER
 
     private static SqlExpression DateAddYear(SqlExpression date, SqlExpression years) =>
-      SqlDml.FunctionCall("STRFTIME", DateFormat, date, SqlDml.Concat(years, " ", "YEARS"));
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateFormat, date, SqlDml.Concat(years, " ", "YEARS"));
 
     private static SqlExpression DateAddMonth(SqlExpression date, SqlExpression months) =>
-      SqlDml.FunctionCall("STRFTIME", DateFormat, date, SqlDml.Concat(months, " ", "MONTHS"));
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateFormat, date, SqlDml.Concat(months, " ", "MONTHS"));
 
     private static SqlExpression DateAddDay(SqlExpression date, SqlExpression days) =>
-      SqlDml.FunctionCall("STRFTIME", DateFormat, date, SqlDml.Concat(days, " ", "DAYS"));
-
-    private static SqlExpression TimeConstruct(IReadOnlyList<SqlExpression> arguments)
-    {
-      SqlExpression hour, minute, second, millisecond;
-      if (arguments.Count == 4) {
-        hour = arguments[0];
-        minute = arguments[1];
-        second = arguments[2];
-        millisecond = arguments[3];
-      }
-      else if (arguments.Count == 1) {
-        var ticks = arguments[0];
-        hour = SqlDml.Cast(ticks / 36000000000, SqlType.Int32);
-        minute = SqlDml.Cast((ticks / 600000000) % 60, SqlType.Int32);
-        second = SqlDml.Cast((ticks / 10000000) % 60, SqlType.Int32);
-        millisecond = SqlDml.Cast(ticks % 10000000, SqlType.Int32);
-      }
-      else {
-        throw new InvalidOperationException("Unsupported count of parameters");
-      }
-      return TimeAddSeconds(
-        TimeAddMinutes(
-          TimeAddHours(
-            SqlDml.Literal(new TimeOnly(0, 0, 0, 0)),
-            hour),
-          minute),
-        second,
-        millisecond);
-    }
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateFormat, date, SqlDml.Concat(days, " ", "DAYS"));
 
     private static SqlExpression TimeToNanoseconds(SqlExpression time)
     {
@@ -580,16 +548,16 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
       return nPerHour + nPerMinute + nPerSecond + nPerMillisecond;
     }
 
-    private static SqlExpression TimeAddHours(SqlExpression time, SqlExpression seconds) =>
-      SqlDml.FunctionCall("STRFTIME", TimeFormat, time, SqlDml.Concat(seconds, " ", "HOURS"));
+    private static SqlExpression TimeAddHours(SqlExpression time, SqlExpression hours) =>
+      SqlDml.FunctionCall(STRFTIMEFunctionName, TimeFormat, time, SqlDml.Concat(hours, " ", "HOURS"));
 
-    private static SqlExpression TimeAddMinutes(SqlExpression time, SqlExpression seconds) =>
-      SqlDml.FunctionCall("STRFTIME", TimeFormat, time, SqlDml.Concat(seconds, " ", "MINUTES"));
+    private static SqlExpression TimeAddMinutes(SqlExpression time, SqlExpression minutes) =>
+      SqlDml.FunctionCall(STRFTIMEFunctionName, TimeFormat, time, SqlDml.Concat(minutes, " ", "MINUTES"));
 
     private static SqlExpression TimeAddSeconds(SqlExpression time, SqlExpression seconds, SqlExpression milliseconds) =>
-      SqlDml.FunctionCall("STRFTIME", TimeFormat, time, SqlDml.Concat(seconds, ".", milliseconds, " ", "SECONDS"));
+      SqlDml.FunctionCall(STRFTIMEFunctionName, TimeFormat, time, SqlDml.Concat(seconds, ".", milliseconds, " ", "SECONDS"));
     private static SqlExpression TimeAddSeconds(SqlExpression time, SqlExpression seconds) =>
-      SqlDml.FunctionCall("STRFTIME", TimeFormat, time, SqlDml.Concat(seconds, " ", "SECONDS"));
+      SqlDml.FunctionCall(STRFTIMEFunctionName, TimeFormat, time, SqlDml.Concat(seconds, " ", "SECONDS"));
 
     private static SqlExpression TimeAddInterval(SqlExpression time, SqlExpression interval) =>
       TimeAddSeconds(time, interval / Convert.ToDouble(NanosecondsPerSecond));
@@ -602,8 +570,8 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
       var minutesInSecs1 = SqlDml.Extract(SqlTimePart.Minute, time1) * 60;
       var minutesInSecs2 = SqlDml.Extract(SqlTimePart.Minute, time2) * 60;
 
-      var seconds1 = SqlDml.FunctionCall("STRFTIME", "%f", time1);
-      var seconds2 = SqlDml.FunctionCall("STRFTIME", "%f", time2);
+      var seconds1 = SqlDml.FunctionCall(STRFTIMEFunctionName, "%f", time1);
+      var seconds2 = SqlDml.FunctionCall(STRFTIMEFunctionName, "%f", time2);
 
       var difference = ((hoursInSecs1 + minutesInSecs1 + seconds1) * NanosecondsPerSecond)
         - ((hoursInSecs2 + minutesInSecs2 + seconds2) * NanosecondsPerSecond);
@@ -612,41 +580,41 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
     }
 
     private static SqlExpression DateToString(SqlExpression dateTime) =>
-      SqlDml.FunctionCall("STRFTIME", DateFormat, dateTime);
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateFormat, dateTime);
 
     private static SqlExpression TimeToString(SqlExpression dateTime) =>
-      SqlDml.FunctionCall("STRFTIME", TimeToStringFormat, dateTime);
+      SqlDml.FunctionCall(STRFTIMEFunctionName, TimeToStringFormat, dateTime);
 
     private static SqlExpression DateTimeToDate(SqlExpression dateTime) =>
-      SqlDml.FunctionCall("STRFTIME", DateFormat, dateTime);
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateFormat, dateTime);
 
     private static SqlExpression DateToDateTime(SqlExpression date) =>
-      SqlDml.FunctionCall("STRFTIME", DateTimeFormat, SqlDml.Concat(date, " 00:00:00"));
+      SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, SqlDml.Concat(date, " 00:00:00"));
 
     private static SqlExpression DateTimeToTime(SqlExpression dateTime) =>
-      SqlDml.FunctionCall("STRFTIME", TimeFormat, dateTime);
+      SqlDml.FunctionCall(STRFTIMEFunctionName, TimeFormat, dateTime);
     private static SqlExpression TimeToDateTime(SqlExpression time) =>
-      SqlDml.FunctionCall("STRFTIME", "1900-01-01 " + TimeFormat, time);
+      SqlDml.FunctionCall(STRFTIMEFunctionName, "1900-01-01 " + TimeFormat, time);
 
     private static SqlExpression DateTimeOffsetToTime(SqlExpression dateTimeOffset) =>
-      DateTimeToTime(SqlDml.FunctionCall("STRFTIME", TimeFormat, DateTimeOffsetExtractDateTimeAsString(dateTimeOffset)));
+      DateTimeToTime(SqlDml.FunctionCall(STRFTIMEFunctionName, TimeFormat, DateTimeOffsetExtractDateTimeAsString(dateTimeOffset)));
 
     private static SqlExpression DateTimeOffsetToDate(SqlExpression dateTimeOffset) =>
-      DateTimeToDate(SqlDml.FunctionCall("STRFTIME", DateFormat, DateTimeOffsetExtractDateTimeAsString(dateTimeOffset)));
+      DateTimeToDate(SqlDml.FunctionCall(STRFTIMEFunctionName, DateFormat, DateTimeOffsetExtractDateTimeAsString(dateTimeOffset)));
 
     private static SqlExpression TimeToDateTimeOffset(SqlExpression time) =>
-      SqlDml.Concat(SqlDml.FunctionCall("STRFTIME", DateTimeFormat, SqlDml.Concat("1900-01-01 ", time)), ServerOffsetAsString());
+      SqlDml.Concat(SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, SqlDml.Concat("1900-01-01 ", time)), ServerOffsetAsString());
 
     private static SqlExpression DateToDateTimeOffset(SqlExpression date) =>
-      SqlDml.Concat(SqlDml.FunctionCall("STRFTIME", DateTimeFormat, SqlDml.Concat(date, " 00:00:00")), ServerOffsetAsString());
+      SqlDml.Concat(SqlDml.FunctionCall(STRFTIMEFunctionName, DateTimeFormat, SqlDml.Concat(date, " 00:00:00")), ServerOffsetAsString());
 #endif
 
     private static SqlExpression DateOrTimeGetMilliseconds(SqlExpression date) =>
-      CastToLong(SqlDml.FunctionCall("STRFTIME", "%f", date) * MillisecondsPerSecond) -
-        CastToLong(SqlDml.FunctionCall("STRFTIME", "%S", date) * MillisecondsPerSecond);
+      CastToLong(SqlDml.FunctionCall(STRFTIMEFunctionName, "%f", date) * MillisecondsPerSecond) -
+        CastToLong(SqlDml.FunctionCall(STRFTIMEFunctionName, "%S", date) * MillisecondsPerSecond);
 
     private static SqlExpression DateOrTimeGetTotalSeconds(SqlExpression date) =>
-      SqlDml.FunctionCall("STRFTIME", "%s", date);
+      SqlDml.FunctionCall(STRFTIMEFunctionName, "%s", date);
 
     private static SqlExpression DateTimeSubtractDateTime(SqlExpression date1, SqlExpression date2) =>
       (((DateOrTimeGetTotalSeconds(date1) - DateOrTimeGetTotalSeconds(date2)) * MillisecondsPerSecond)
@@ -655,7 +623,7 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
     private static SqlExpression ServerOffsetAsString()
     {
       const string constDateTime = "2016-01-01 12:00:00";
-      return OffsetToOffsetAsString((SqlDml.FunctionCall("STRFTIME", "%s", constDateTime) - SqlDml.FunctionCall("STRFTIME", "%s", constDateTime, "UTC")) / 60);
+      return OffsetToOffsetAsString((SqlDml.FunctionCall(STRFTIMEFunctionName, "%s", constDateTime) - SqlDml.FunctionCall(STRFTIMEFunctionName, "%s", constDateTime, "UTC")) / 60);
     }
 
     private static SqlDateTimePart ConvertDateTimeOffsetPartToDateTimePart(SqlDateTimeOffsetPart dateTimeOffsetPart)

--- a/Orm/Xtensive.Orm.Tests.Sql/DateTimeIntervalTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/DateTimeIntervalTest.cs
@@ -254,10 +254,31 @@ namespace Xtensive.Orm.Tests.Sql
     }
 
     [Test]
-    public virtual void TimeOnlyConstructTest()
+    public virtual void TimeOnlyConstructTest1()
     {
+      Require.ProviderIsNot(StorageProvider.Sqlite | StorageProvider.MySql);
+
       CheckEquality(
         SqlDml.TimeConstruct(DefaultTimeOnly.Hour, DefaultTimeOnly.Minute, DefaultTimeOnly.Second, DefaultTimeOnly.Millisecond),
+        DefaultTimeOnly);
+    }
+
+    [Test]
+    public virtual void TimeOnlyConstructTest2()
+    {
+      Require.ProviderIsNot(StorageProvider.Sqlite | StorageProvider.MySql);
+
+      var ticksPerHour = new TimeOnly(1, 0).Ticks;
+      var ticksPerMinute = new TimeOnly(0, 1).Ticks;
+      var ticksPerSecond = new TimeOnly(0, 0, 1).Ticks;
+      var ticksPerMillisecond = new TimeOnly(0, 0, 0, 1).Ticks;
+      var testTicks = ticksPerHour * DefaultTimeOnly.Hour +
+        ticksPerMinute * DefaultTimeOnly.Minute +
+        ticksPerSecond * DefaultTimeOnly.Second +
+        ticksPerMillisecond * DefaultTimeOnly.Millisecond;
+
+      CheckEquality(
+        SqlDml.TimeConstruct(testTicks),
         DefaultTimeOnly);
     }
 

--- a/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/Model.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/Model.cs
@@ -5,8 +5,6 @@
 // Created:    2016.08.01
 
 using System;
-using System.Net.Sockets;
-using Org.BouncyCastle.Crypto.Digests;
 
 namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.Model
 {
@@ -194,7 +192,12 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.Model
     public int Microsecond { get; set; }
 
     [Field]
-    public long Ticks { get; set; }
+    public long DateTimeTicks { get; set; }
+#if NET6_0_OR_GREATER
+
+    [Field]
+    public long TimeOnlyTicks { get; set; }
+#endif
 
     [Field]
     [Validation.RangeConstraint(Min = -23, Max = 23)]
@@ -203,6 +206,9 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.Model
     [Field]
     [Validation.RangeConstraint(Min = 0, Max = 59)]
     public int OffsetMinute { get; set; }
+
+    [Field]
+    public TimeSpan TimeSpan { get; set; }
 
     public static AllPossiblePartsEntity FromDateTime(Session session, DateTime dateTime, int microsecond)
     {
@@ -217,7 +223,11 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.Model
         Microsecond = microsecond,
         OffsetHour = 0,
         OffsetMinute = 0,
-        Ticks = dateTime.Ticks
+        DateTimeTicks = dateTime.Ticks,
+#if NET6_0_OR_GREATER
+        TimeOnlyTicks = TimeOnly.FromDateTime(dateTime).Ticks,
+        TimeSpan = TimeOnly.FromDateTime(dateTime).ToTimeSpan(),
+#endif
       };
     }
 
@@ -234,7 +244,11 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.Model
         Microsecond = microsecond,
         OffsetHour = dateTimeOffset.Offset.Hours,
         OffsetMinute = dateTimeOffset.Offset.Minutes,
-        Ticks = dateTimeOffset.Ticks
+        DateTimeTicks = dateTimeOffset.Ticks,
+#if NET6_0_OR_GREATER
+        TimeOnlyTicks = TimeOnly.FromDateTime(dateTimeOffset.DateTime).Ticks,
+        TimeSpan = TimeOnly.FromDateTime(dateTimeOffset.DateTime).ToTimeSpan(),
+#endif
       };
     }
 
@@ -288,7 +302,7 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.Model
     public TimeOnly? NullableTimeOnly { get; set; }
 
     public TimeOnlyEntity(Session session)
-      :base(session)
+      : base(session)
     {
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/TimeOnly/ConstructorTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/TimeOnly/ConstructorTest.cs
@@ -108,31 +108,6 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.TimeOnlys
     }
 
     [Test]
-    public void MysqlCtorTicksFromIntervalTicks()
-    {
-      Require.ProviderIs(StorageProvider.MySql);
-
-      if (StorageProviderInfo.Instance.Info.StorageVersion <= StorageProviderVersion.MySql55) {
-        ExecuteInsideSession((s) => {
-          var result = s.Query.All<AllPossiblePartsEntity>()
-            .Select(e => new { Entity = e, ConstructedTime = new TimeOnly(e.TimeSpan.Ticks) })
-            .Where(a => a.ConstructedTime == FirstTimeOnly)
-            .OrderBy(a => a.Entity.Id).ToList(3);
-          Assert.That(result.Count, Is.EqualTo(1));
-        });
-      }
-      else {
-        ExecuteInsideSession((s) => {
-          var result = s.Query.All<AllPossiblePartsEntity>()
-            .Select(e => new { Entity = e, ConstructedTime = new TimeOnly(e.TimeSpan.Ticks) })
-            .Where(a => a.ConstructedTime == FirstMillisecondTimeOnly)
-            .OrderBy(a => a.Entity.Id).ToList(3);
-          Assert.That(result.Count, Is.EqualTo(1));
-        });
-      }
-    }
-
-    [Test]
     public void TicksFromColumnsBasedExpression()
     {
       var ticksPerHour = new TimeOnly(1, 0).Ticks;

--- a/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/TimeOnly/ConstructorTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/TimeOnly/ConstructorTest.cs
@@ -14,6 +14,8 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.TimeOnlys
 {
   public class ConstructorTest : DateTimeBaseTest
   {
+    protected override void CheckRequirements() => Require.ProviderIsNot(StorageProvider.MySql | StorageProvider.Sqlite);
+
     [Test]
     public void CtorHMSM()
     {

--- a/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/TimeOnly/ConstructorTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/TimeOnly/ConstructorTest.cs
@@ -22,7 +22,8 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.TimeOnlys
           .Select(e => new {
             Entity = e,
             ConstructedTime = new TimeOnly(e.Hour, e.Minute, e.Second, e.Millisecond) })
-          .Where(a => a.ConstructedTime == FirstMillisecondTimeOnly).OrderBy(a => a.Entity.Id).ToList(3);
+          .Where(a => a.ConstructedTime == FirstMillisecondTimeOnly)
+          .OrderBy(a => a.Entity.Id).ToList(3);
         Assert.That(result.Count, Is.EqualTo(1));
       });
     }
@@ -36,7 +37,8 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.TimeOnlys
             Entity = e,
             ConstructedTime = new TimeOnly(e.Hour, e.Minute, e.Second)
           })
-          .Where(a => a.ConstructedTime == FirstTimeOnly).OrderBy(a => a.Entity.Id).ToList(3);
+          .Where(a => a.ConstructedTime == FirstTimeOnly)
+          .OrderBy(a => a.Entity.Id).ToList(3);
         Assert.That(result.Count, Is.EqualTo(1));
       });
     }
@@ -48,6 +50,140 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.TimeOnlys
         var result = s.Query.All<AllPossiblePartsEntity>()
           .Select(e => new { Entity = e, ConstructedTime = new TimeOnly(e.Hour, e.Minute) })
           .Where(a => a.ConstructedTime == FirstTimeOnly.Add(TimeSpan.FromSeconds(-5)))
+          .OrderBy(a => a.Entity.Id).ToList(3);
+        Assert.That(result.Count, Is.EqualTo(1));
+      });
+    }
+
+    [Test]
+    public void CtorTicksLiteralValue()
+    {
+      var ticksPerHour = new TimeOnly(1, 0).Ticks;
+      var ticksPerMinute = new TimeOnly(0, 1).Ticks;
+      var ticksPerSecond = new TimeOnly(0, 0, 1).Ticks;
+      var testTicks = ticksPerHour * FirstTimeOnly.Hour +
+        ticksPerMinute * FirstTimeOnly.Minute +
+        ticksPerSecond * FirstTimeOnly.Second;
+
+      ExecuteInsideSession((s) => {
+        var result = s.Query.All<AllPossiblePartsEntity>()
+          .Select(e => new { Entity = e, ConstructedTime = new TimeOnly(testTicks) })
+          .Where(a => a.ConstructedTime == FirstTimeOnly)
+          .OrderBy(a => a.Entity.Id).ToList(3);
+        Assert.That(result.Count, Is.EqualTo(1));
+      });
+    }
+
+    [Test]
+    public void CtorTicksLiteralExpressions()
+    {
+      var ticksPerHour = new TimeOnly(1, 0).Ticks;
+      var ticksPerMinute = new TimeOnly(0, 1).Ticks;
+      var ticksPerSecond = new TimeOnly(0, 0, 1).Ticks;
+      var testTicks = ticksPerHour * FirstTimeOnly.Hour +
+        ticksPerMinute * FirstTimeOnly.Minute +
+        ticksPerSecond * FirstTimeOnly.Second;
+
+      ExecuteInsideSession((s) => {
+        var result = s.Query.All<AllPossiblePartsEntity>()
+          .Select(e => new { Entity = e, ConstructedTime = new TimeOnly(testTicks + 1000 - 1000) })
+          .Where(a => a.ConstructedTime == FirstTimeOnly)
+          .OrderBy(a => a.Entity.Id).ToList(3);
+        Assert.That(result.Count, Is.EqualTo(1));
+      });
+    }
+
+    [Test]
+    public void CtorTicksFromIntervalTicks()
+    {
+      Require.ProviderIsNot(StorageProvider.MySql);
+
+      ExecuteInsideSession((s) => {
+        var result = s.Query.All<AllPossiblePartsEntity>()
+          .Select(e => new { Entity = e, ConstructedTime = new TimeOnly(e.TimeSpan.Ticks) })
+          .Where(a => a.ConstructedTime == FirstMillisecondTimeOnly)
+          .OrderBy(a => a.Entity.Id).ToList(3);
+        Assert.That(result.Count, Is.EqualTo(1));
+      });
+    }
+
+    [Test]
+    public void MysqlCtorTicksFromIntervalTicks()
+    {
+      Require.ProviderIs(StorageProvider.MySql);
+
+      if (StorageProviderInfo.Instance.Info.StorageVersion <= StorageProviderVersion.MySql55) {
+        ExecuteInsideSession((s) => {
+          var result = s.Query.All<AllPossiblePartsEntity>()
+            .Select(e => new { Entity = e, ConstructedTime = new TimeOnly(e.TimeSpan.Ticks) })
+            .Where(a => a.ConstructedTime == FirstTimeOnly)
+            .OrderBy(a => a.Entity.Id).ToList(3);
+          Assert.That(result.Count, Is.EqualTo(1));
+        });
+      }
+      else {
+        ExecuteInsideSession((s) => {
+          var result = s.Query.All<AllPossiblePartsEntity>()
+            .Select(e => new { Entity = e, ConstructedTime = new TimeOnly(e.TimeSpan.Ticks) })
+            .Where(a => a.ConstructedTime == FirstMillisecondTimeOnly)
+            .OrderBy(a => a.Entity.Id).ToList(3);
+          Assert.That(result.Count, Is.EqualTo(1));
+        });
+      }
+    }
+
+    [Test]
+    public void TicksFromColumnsBasedExpression()
+    {
+      var ticksPerHour = new TimeOnly(1, 0).Ticks;
+      var ticksPerMinute = new TimeOnly(0, 1).Ticks;
+      var ticksPerSecond = new TimeOnly(0, 0, 1).Ticks;
+      var testTicks = ticksPerHour * FirstTimeOnly.Hour +
+        ticksPerMinute * FirstTimeOnly.Minute +
+        ticksPerSecond * FirstTimeOnly.Second;
+
+      Assert.That(new TimeOnly(testTicks).Ticks, Is.EqualTo(testTicks));
+      Assert.That(new TimeOnly(testTicks), Is.EqualTo(FirstTimeOnly));
+
+      ExecuteInsideSession((s) => {
+        var result = s.Query.All<AllPossiblePartsEntity>()
+          .Select(e => new {
+            Entity = e,
+            ConstructedTime = new TimeOnly(e.Hour * ticksPerHour + e.Minute * ticksPerMinute + e.Second * ticksPerSecond)
+          })
+          .Where(a => a.ConstructedTime == FirstTimeOnly)
+          .OrderBy(a => a.Entity.Id).ToList(3);
+        Assert.That(result.Count, Is.EqualTo(1));
+      });
+    }
+
+    [Test]
+    public void TicksFromColumnsBasedExpressionMilliseconds()
+    {
+      if (StorageProviderInfo.Instance.CheckProviderIs(StorageProvider.MySql)) {
+        Require.ProviderVersionAtLeast(StorageProviderVersion.MySql56);
+      }
+
+      var ticksPerHour = new TimeOnly(1, 0).Ticks;
+      var ticksPerMinute = new TimeOnly(0, 1).Ticks;
+      var ticksPerSecond = new TimeOnly(0, 0, 1).Ticks;
+      var ticksPerMillisecond = new TimeOnly(0,0,0,1).Ticks;
+      var testTicks = ticksPerHour * FirstMillisecondTimeOnly.Hour +
+        ticksPerMinute * FirstMillisecondTimeOnly.Minute +
+        ticksPerSecond * FirstMillisecondTimeOnly.Second +
+        ticksPerMillisecond * FirstMillisecondTimeOnly.Millisecond;
+
+      Assert.That(new TimeOnly(testTicks).Ticks, Is.EqualTo(testTicks));
+      Assert.That(new TimeOnly(testTicks), Is.EqualTo(FirstMillisecondTimeOnly));
+
+      ExecuteInsideSession((s) => {
+        var result = s.Query.All<AllPossiblePartsEntity>()
+          .Select(e => new {
+            Entity = e,
+            ConstructedTime = new TimeOnly(
+              e.Hour * ticksPerHour + e.Minute * ticksPerMinute + e.Second * ticksPerSecond + e.Millisecond * ticksPerMillisecond)
+          })
+          .Where(a => a.ConstructedTime == FirstMillisecondTimeOnly)
           .OrderBy(a => a.Entity.Id).ToList(3);
         Assert.That(result.Count, Is.EqualTo(1));
       });

--- a/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/TimeOnly/PartsExtractionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DateTimeAndDateTimeOffset/TimeOnly/PartsExtractionTest.cs
@@ -77,14 +77,12 @@ namespace Xtensive.Orm.Tests.Linq.DateTimeAndDateTimeOffset.TimeOnlys
     }
 
     [Test]
-    [Ignore("Not implemented yet.")]
     public void ExtractTicksTest()
     {
-      Require.ProviderIsNot(StorageProvider.PostgreSql | StorageProvider.Oracle);
-
       ExecuteInsideSession((s) => {
-        RunTest<SingleTimeOnlyEntity>(s, c => c.TimeOnly.Ticks == FirstTimeOnly.Ticks);
-        RunWrongTest<SingleTimeOnlyEntity>(s, c => c.TimeOnly.Ticks < FirstTimeOnly.Ticks);
+        var firstMillisecondTimeOnly = FirstMillisecondTimeOnly.AdjustTimeOnlyForCurrentProvider();
+        RunTest<SingleTimeOnlyEntity>(s, c => c.MillisecondTimeOnly.Ticks == firstMillisecondTimeOnly.Ticks);
+        RunWrongTest<SingleTimeOnlyEntity>(s, c => c.MillisecondTimeOnly.Ticks < FirstTimeOnly.Ticks);
       });
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeOnlyCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeOnlyCompilers.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Xtensive LLC.
+// Copyright (C) 2022-2023 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeOnlyCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeOnlyCompilers.cs
@@ -59,9 +59,9 @@ namespace Xtensive.Orm.Providers
         [Type(typeof(int))] SqlExpression minute) =>
       SqlDml.TimeConstruct(hour, minute, 0, 0);
 
-    //[Compiler(typeof(TimeOnly), null, TargetKind.Constructor)]
-    //public static SqlExpression TimeOnlyCtor([Type(typeof(long))] SqlExpression ticks) =>
-    //  new SqlFunctionCall(SqlFunctionType.TimeConstruct, ticks);
+    [Compiler(typeof(TimeOnly), null, TargetKind.Constructor)]
+    public static SqlExpression TimeOnlyCtor([Type(typeof(long))] SqlExpression ticks) =>
+      SqlDml.TimeConstruct(ticks);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeOnlyCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeOnlyCompilers.cs
@@ -35,6 +35,10 @@ namespace Xtensive.Orm.Providers
     public static SqlExpression TimeOnlyMillisecond(SqlExpression _this) =>
       ExpressionTranslationHelpers.ToInt(SqlDml.Extract(SqlTimePart.Millisecond, _this));
 
+    [Compiler(typeof(TimeOnly), "Ticks", TargetKind.PropertyGet)]
+    public static SqlExpression TimeSpanTicks(SqlExpression _this) =>
+      ExpressionTranslationHelpers.ToLong(SqlDml.TimeToNanoseconds(_this) / NanosecondsPerTick);
+
     #endregion
 
     #region Constructors

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeSpanCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeSpanCompilers.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2021 Xtensive LLC.
+// Copyright (C) 2009-2023 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeSpanCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeSpanCompilers.cs
@@ -163,6 +163,7 @@ namespace Xtensive.Orm.Providers
     [Compiler(typeof(TimeSpan), "Ticks", TargetKind.PropertyGet)]
     public static SqlExpression TimeSpanTicks(SqlExpression _this)
     {
+      // there are some operations that rely on this structure.
       return ExpressionTranslationHelpers.ToLong(SqlDml.IntervalToNanoseconds(_this) / NanosecondsPerTick);
     }
 

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlFunctionType.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlFunctionType.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 
 using System;
 

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlFunctionType.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlFunctionType.cs
@@ -74,6 +74,7 @@ namespace Xtensive.Sql.Dml
     TimeToString,
     TimeToDateTime,
     TimeToDateTimeOffset,
+    TimeToNanoseconds,
 #endif
 
     DateTimeConstruct,

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2007-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -614,9 +614,15 @@ namespace Xtensive.Sql
       SqlValidator.EnsureIsArithmeticExpression(second);
       SqlValidator.EnsureIsArithmeticExpression(millisecond);
 
-      //var m = milliseconds + 1000L * (seconds + 60L * (minutes + 60L * hours));
-      //var ticks = 10_000 * m;
       return new SqlFunctionCall(SqlFunctionType.TimeConstruct, hour, minute, second, millisecond);
+    }
+
+    public static SqlFunctionCall TimeConstruct(SqlExpression ticks)
+    {
+      ArgumentNullException.ThrowIfNull(ticks);
+      SqlValidator.EnsureIsArithmeticExpression(ticks);
+
+      return new SqlFunctionCall(SqlFunctionType.TimeConstruct, ticks);
     }
 #endif
 

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -636,15 +636,15 @@ namespace Xtensive.Sql
 
     public static SqlBinary TimePlusInterval(SqlExpression left, SqlExpression right)
     {
-      ArgumentValidator.EnsureArgumentNotNull(left, "left");
-      ArgumentValidator.EnsureArgumentNotNull(right, "right");
+      ArgumentNullException.ThrowIfNull(left, nameof(left));
+      ArgumentNullException.ThrowIfNull(right, nameof(right));
       return new SqlBinary(SqlNodeType.TimePlusInterval, left, right);
     }
 
     public static SqlBinary TimeMinusTime(SqlExpression left, SqlExpression right)
     {
-      ArgumentValidator.EnsureArgumentNotNull(left, "left");
-      ArgumentValidator.EnsureArgumentNotNull(right, "right");
+      ArgumentNullException.ThrowIfNull(left, nameof(left));
+      ArgumentNullException.ThrowIfNull(right, nameof(right));
       return new SqlBinary(SqlNodeType.TimeMinusTime, left, right);
     }
 #endif
@@ -680,52 +680,52 @@ namespace Xtensive.Sql
 #if NET6_0_OR_GREATER
     public static SqlFunctionCall DateTimeToTime(SqlExpression expression)
     {
-      ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
+      ArgumentNullException.ThrowIfNull(expression, nameof(expression));
       return new SqlFunctionCall(SqlFunctionType.DateTimeToTime, expression);
     }
 
     public static SqlFunctionCall DateAddYears(SqlExpression source, SqlExpression years)
     {
-      ArgumentValidator.EnsureArgumentNotNull(source, "source");
-      ArgumentValidator.EnsureArgumentNotNull(years, "years");
+      ArgumentNullException.ThrowIfNull(source, nameof(source));
+      ArgumentNullException.ThrowIfNull(years, nameof(years));
       return new SqlFunctionCall(SqlFunctionType.DateAddYears, source, years);
     }
 
     public static SqlFunctionCall DateAddMonths(SqlExpression source, SqlExpression months)
     {
-      ArgumentValidator.EnsureArgumentNotNull(source, "source");
-      ArgumentValidator.EnsureArgumentNotNull(months, "months");
+      ArgumentNullException.ThrowIfNull(source, nameof(source));
+      ArgumentNullException.ThrowIfNull(months, nameof(months));
       return new SqlFunctionCall(SqlFunctionType.DateAddMonths, source, months);
     }
 
     public static SqlFunctionCall DateAddDays(SqlExpression source, SqlExpression days)
     {
-      ArgumentValidator.EnsureArgumentNotNull(source, "source");
-      ArgumentValidator.EnsureArgumentNotNull(days, "days");
+      ArgumentNullException.ThrowIfNull(source, nameof(source));
+      ArgumentNullException.ThrowIfNull(days, nameof(days));
       return new SqlFunctionCall(SqlFunctionType.DateAddDays, source, days);
     }
 
     public static SqlFunctionCall DateToString(SqlExpression expression)
     {
-      ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
+      ArgumentNullException.ThrowIfNull(expression, nameof(expression));
       return new SqlFunctionCall(SqlFunctionType.DateToString, expression);
     }
 
     public static SqlFunctionCall DateToDateTime(SqlExpression expression)
     {
-      ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
+      ArgumentNullException.ThrowIfNull(expression, nameof(expression));
       return new SqlFunctionCall(SqlFunctionType.DateToDateTime, expression);
     }
 
     public static SqlFunctionCall DateTimeToDate(SqlExpression expression)
     {
-      ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
+      ArgumentNullException.ThrowIfNull(expression, nameof(expression));
       return new SqlFunctionCall(SqlFunctionType.DateTimeToDate, expression);
     }
 
     public static SqlFunctionCall DateToDateTimeOffset(SqlExpression expression)
     {
-      ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
+      ArgumentNullException.ThrowIfNull(expression, nameof(expression));
       return new SqlFunctionCall(SqlFunctionType.DateToDateTimeOffset, expression);
     }
 
@@ -733,25 +733,27 @@ namespace Xtensive.Sql
     {
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
       ArgumentValidator.EnsureArgumentNotNull(hours, "hours");
+      ArgumentNullException.ThrowIfNull(source, nameof(source));
+      ArgumentNullException.ThrowIfNull(hours, nameof(hours));
       return new SqlFunctionCall(SqlFunctionType.TimeAddHours, source, hours);
     }
 
     public static SqlFunctionCall TimeAddMinutes(SqlExpression source, SqlExpression minutes)
     {
-      ArgumentValidator.EnsureArgumentNotNull(source, "source");
-      ArgumentValidator.EnsureArgumentNotNull(minutes, "minutes");
+      ArgumentNullException.ThrowIfNull(source, nameof(source));
+      ArgumentNullException.ThrowIfNull(minutes, nameof(minutes));
       return new SqlFunctionCall(SqlFunctionType.TimeAddMinutes, source, minutes);
     }
 
     public static SqlFunctionCall TimeToString(SqlExpression expression)
     {
-      ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
+      ArgumentNullException.ThrowIfNull(expression, nameof(expression));
       return new SqlFunctionCall(SqlFunctionType.TimeToString, expression);
     }
 
     public static SqlFunctionCall TimeToDateTime(SqlExpression expression)
     {
-      ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
+      ArgumentNullException.ThrowIfNull(expression, nameof(expression));
       return new SqlFunctionCall(SqlFunctionType.TimeToDateTime, expression);
     }
 
@@ -763,7 +765,7 @@ namespace Xtensive.Sql
 
     public static SqlFunctionCall TimeToDateTimeOffset(SqlExpression expression)
     {
-      ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
+      ArgumentNullException.ThrowIfNull(expression, nameof(expression));
       return new SqlFunctionCall(SqlFunctionType.TimeToDateTimeOffset, expression);
     }
 #endif
@@ -904,13 +906,14 @@ namespace Xtensive.Sql
 
     public static SqlFunctionCall DateTimeOffsetToTime(SqlExpression dateTimeOffset)
     {
-      ArgumentValidator.EnsureArgumentNotNull(dateTimeOffset, nameof(dateTimeOffset));
+      ArgumentNullException.ThrowIfNull(dateTimeOffset, nameof(dateTimeOffset));
       return new SqlFunctionCall(SqlFunctionType.DateTimeOffsetToTime, dateTimeOffset);
     }
 
     public static SqlFunctionCall DateTimeOffsetToDate(SqlExpression dateTimeOffset)
     {
       ArgumentValidator.EnsureArgumentNotNull(dateTimeOffset, nameof(dateTimeOffset));
+      ArgumentNullException.ThrowIfNull(dateTimeOffset, nameof(dateTimeOffset));
       return new SqlFunctionCall(SqlFunctionType.DateTimeOffsetToDate, dateTimeOffset);
     }
 #endif

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -755,6 +755,12 @@ namespace Xtensive.Sql
       return new SqlFunctionCall(SqlFunctionType.TimeToDateTime, expression);
     }
 
+    public static SqlExpression TimeToNanoseconds(SqlExpression source)
+    {
+      ArgumentNullException.ThrowIfNull(source, nameof(source));
+      return new SqlFunctionCall(SqlFunctionType.TimeToNanoseconds, source);
+    }
+
     public static SqlFunctionCall TimeToDateTimeOffset(SqlExpression expression)
     {
       ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
@@ -783,13 +789,13 @@ namespace Xtensive.Sql
     public static SqlFunctionCall IntervalToMilliseconds(SqlExpression source)
     {
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
-      return new SqlFunctionCall(SqlFunctionType.IntervalToMilliseconds, source); 
+      return new SqlFunctionCall(SqlFunctionType.IntervalToMilliseconds, source);
     }
 
     public static SqlFunctionCall IntervalToNanoseconds(SqlExpression source)
     {
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
-      return new SqlFunctionCall(SqlFunctionType.IntervalToNanoseconds, source); 
+      return new SqlFunctionCall(SqlFunctionType.IntervalToNanoseconds, source);
     }
 
     public static SqlFunctionCall IntervalAbs(SqlExpression source)

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -731,8 +731,6 @@ namespace Xtensive.Sql
 
     public static SqlFunctionCall TimeAddHours(SqlExpression source, SqlExpression hours)
     {
-      ArgumentValidator.EnsureArgumentNotNull(source, "source");
-      ArgumentValidator.EnsureArgumentNotNull(hours, "hours");
       ArgumentNullException.ThrowIfNull(source, nameof(source));
       ArgumentNullException.ThrowIfNull(hours, nameof(hours));
       return new SqlFunctionCall(SqlFunctionType.TimeAddHours, source, hours);

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -1134,6 +1134,18 @@ namespace Xtensive.Sql
     {
       return new SqlLiteral<DateTime>(value);
     }
+#if NET6_0_OR_GREATER
+
+    public static SqlLiteral<DateOnly> Literal(DateOnly value)
+    {
+      return new SqlLiteral<DateOnly>(value);
+    }
+
+    public static SqlLiteral<TimeOnly> Literal(TimeOnly value)
+    {
+      return new SqlLiteral<TimeOnly>(value);
+    }
+#endif
 
     public static SqlLiteral<TimeSpan> Literal(TimeSpan value)
     {

--- a/Orm/Xtensive.Orm/Sql/SqlHelper.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2021 Xtensive LLC.
+// Copyright (C) 2009-2023 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm/Sql/SqlHelper.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlHelper.cs
@@ -172,6 +172,31 @@ namespace Xtensive.Sql
     }
 
     /// <summary>
+    /// Checks if <paramref name="expressionToCheck"/> is indeed a representation of TimeSpan.Ticks
+    /// created by <see cref="Xtensive.Orm.Providers.TimeSpanCompilers.TimeSpanTicks"/>
+    /// </summary>
+    /// <param name="expressionToCheck">Expression to check</param>
+    /// <param name="sourceInterval">Source interval expression</param>
+    /// <returns></returns>
+    public static bool IsTimeSpanTicks(SqlExpression expressionToCheck, out SqlExpression sourceInterval)
+    {
+      sourceInterval = null;
+
+      if (expressionToCheck is SqlCast sqlCast
+        && (sqlCast.Type.Type == SqlType.Int64 || sqlCast.Type.Type == SqlType.Decimal)) {
+        var operand = sqlCast.Operand;
+        if (operand is SqlBinary sqlBinary && sqlBinary.NodeType == SqlNodeType.Divide) {
+          var left = sqlBinary.Left;
+          if (left is SqlFunctionCall functionCall && functionCall.FunctionType == SqlFunctionType.IntervalToNanoseconds) {
+            sourceInterval = functionCall.Arguments[0];
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    /// <summary>
     /// Converts the specified interval expression to expression
     /// that represents absolute value (duration) of the specified interval.
     /// This is a generic implementation that uses comparison with zero interval.


### PR DESCRIPTION
Adds support for ```TimeOnly``` constructors (from parts and from ticks) in queries for majority of providers.

Some providers (or versions of them) require special and not the best way to construct ```TIME``` values but save way in terms of value range. If there is a function to create a time value, we use it (e.g. MS SQL Server from v11, PostgreSQL from v10). In other cases, there are following ways:
1) add all time parts one by one to ```00:00:00.000``` time value;
2) compose a string of time value and then cast it to time.

Both of them have certain overhead but the second one provides boundaries check and an exception will be thrown if cast from string fails, which is good. The first way will have value overflow problem when there are more than 24 hours, which is possible.

Cases when ```TimeSpan.Ticks``` is used as parameter value for ```TimeOnly(ticks)``` constructor are handled additionally, to have less calculations.

**Excluded providers are**: SQLite, MySQL providers. These RDBMSs have certain particularities which were disqualifying.
**SQLite**:  ```TIME``` values can have range, which is wider than ```TimeOnly```'s range, for example,  24:05.xx.xxx is valid value. The other part of problem is that there is no way to guarantee correct value even if it is wrong (25:05:xx.xxx). Storage will return NULL instead of exception of some sort. NULL value may be valid in case of ```Nullable<TimeOnly>``` persistent field which may cause wrong results of query. Value overflow is not an option because it also may lead to unexpected results.
**MySQL**: ```TIME``` value have range from ```-838:59:59.000000``` to ```838:59:59.000000```,  which is part of the problem the second part is that even if hour part is 839, the storage does not throw any errors but return max value. If there was an overflow error we could mathematically overcome this problem by adding 815 hours and then subtracting this value from result time value, but we can't. Newer versions have ```MAKE_TIME``` function which also doesn't control parameters, even if string is used as value, it will return ```NULL``` which may be valid value.