### PR TITLE
Domain.OpenSessionInternalAsync: Prevent continuation if parent task was canceled

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -362,7 +362,7 @@ namespace Xtensive.Orm
                 }
                 exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
               }
-            }, TaskContinuationOptions.ExecuteSynchronously)
+            }, TaskContinuationOptions.NotOnCanceled | TaskContinuationOptions.ExecuteSynchronously)
             .ConfigureAwait(false);
         }
         catch (OperationCanceledException) {


### PR DESCRIPTION
Problem appeared in #291, in case of cancelled parent task of connection opening the exception which supposed to notify about cancellation became swallowed. Adding ```TaskContinuationOption.NotOnCanceled``` prevents continuation from happening and the exception is risen and passed to user code how it should be.