### PR TITLE
Improves memory efficiency of building indexes.

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClassTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClassTable.cs
@@ -120,7 +120,7 @@ namespace Xtensive.Orm.Building.Builders
             var filteredIndex = BuildFilterIndex(type, ancestorIndex, filterByTypes);
             baseIndexes.Push(filteredIndex);
           }
-          var virtualPrimaryIndex = baseIndexes.Count == 1 
+          var virtualPrimaryIndex = baseIndexes.Count == 1
             ? baseIndexes.Pop()
             : BuildJoinIndex(type, baseIndexes);
           type.Indexes.Add(virtualPrimaryIndex);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ConcreteTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ConcreteTable.cs
@@ -92,11 +92,9 @@ namespace Xtensive.Orm.Building.Builders
 
       // Build primary virtual union index
       if (descendants.Count > 0) {
-        var indexesToUnion = new List<IndexInfo>(descendants.Count + 1) { type.Indexes.PrimaryIndex };
-        foreach (var index in descendants.Select(static t => t.Indexes.PrimaryIndex)) {
-          var indexView = BuildViewIndex(type, index);
-          indexesToUnion.Add(indexView);
-        }
+        var indexesToUnion = descendants.Select(t => BuildViewIndex(type, t.Indexes.PrimaryIndex))
+          .Prepend(type.Indexes.PrimaryIndex);
+
         var virtualPrimaryIndex = BuildUnionIndex(type, indexesToUnion);
         type.Indexes.Add(virtualPrimaryIndex);
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -165,13 +165,10 @@ namespace Xtensive.Orm.Building.Builders
                   var filterIndex = BuildFilterIndex(implementor,
                     typedIndex ?? typeIndexes.Dequeue(),
                     NonAbstractTypeWithDescendants(implementor, hierarchyImplementors));
-                  var indexesToJoin = new List<IndexInfo>(1 + typeIndexes.Count);
-                  indexesToJoin.Add(filterIndex);
-                  indexesToJoin.AddRange(typeIndexes);
 
-                  var indexToApplyView = indexesToJoin.Count > 1 
-                    ? BuildJoinIndex(implementor, indexesToJoin) 
-                    : indexesToJoin[0];
+                  var indexToApplyView = typeIndexes.Count > 0
+                    ? BuildJoinIndex(implementor, typeIndexes.Prepend(filterIndex))
+                    : filterIndex;
                   var indexView = BuildViewIndex(@interface, indexToApplyView);
                   underlyingIndex.UnderlyingIndexes.Add(indexView);
                 }
@@ -496,7 +493,7 @@ namespace Xtensive.Orm.Building.Builders
       var attributes = realIndex.Attributes
         & (IndexAttributes.Primary | IndexAttributes.Secondary | IndexAttributes.Unique | IndexAttributes.Abstract)
         | IndexAttributes.Typed | IndexAttributes.Virtual;
-      var result = new IndexInfo(reflectedType, attributes, realIndex, Array.Empty<IndexInfo>());
+      var result = new IndexInfo(reflectedType, attributes, realIndex, addAncestorToUnderlyings: true);
 
       // Adding key columns
       foreach (KeyValuePair<ColumnInfo, Direction> pair in realIndex.KeyColumns) {
@@ -531,7 +528,7 @@ namespace Xtensive.Orm.Building.Builders
       var attributes = indexToFilter.Attributes
         & (IndexAttributes.Primary | IndexAttributes.Secondary | IndexAttributes.Unique | IndexAttributes.Abstract)
         | IndexAttributes.Filtered | IndexAttributes.Virtual;
-      var result = new IndexInfo(reflectedType, attributes, indexToFilter, Array.Empty<IndexInfo>()) {
+      var result = new IndexInfo(reflectedType, attributes, indexToFilter, addAncestorToUnderlyings: true) {
         FilterByTypes = filterByTypes
       };
 
@@ -560,11 +557,10 @@ namespace Xtensive.Orm.Building.Builders
     {
       var nameBuilder = context.NameBuilder;
       var firstIndex = indexesToJoin.First();
-      var otherIndexes = indexesToJoin.Skip(1).ToArray();
       var attributes = firstIndex.Attributes
         & (IndexAttributes.Primary | IndexAttributes.Secondary | IndexAttributes.Unique)
         | IndexAttributes.Join | IndexAttributes.Virtual;
-      var result = new IndexInfo(reflectedType, attributes, firstIndex, otherIndexes);
+      var result = new IndexInfo(reflectedType, attributes, indexesToJoin);
 
       // Adding key columns
       foreach (KeyValuePair<ColumnInfo, Direction> pair in firstIndex.KeyColumns) {
@@ -645,11 +641,10 @@ namespace Xtensive.Orm.Building.Builders
     {
       var nameBuilder = context.NameBuilder;
       var firstIndex = indexesToUnion.First();
-      var otherIndexes = indexesToUnion.Skip(1).ToArray();
       var attributes = firstIndex.Attributes
         & (IndexAttributes.Primary | IndexAttributes.Secondary | IndexAttributes.Unique)
         | IndexAttributes.Union | IndexAttributes.Virtual;
-      var result = new IndexInfo(reflectedType, attributes, firstIndex, otherIndexes);
+      var result = new IndexInfo(reflectedType, attributes, indexesToUnion);
 
       // Adding key columns
       foreach (KeyValuePair<ColumnInfo, Direction> pair in firstIndex.KeyColumns) {
@@ -682,7 +677,7 @@ namespace Xtensive.Orm.Building.Builders
       var attributes = indexToApplyView.Attributes
         & (IndexAttributes.Primary | IndexAttributes.Secondary | IndexAttributes.Unique | IndexAttributes.Abstract)
         | IndexAttributes.View | IndexAttributes.Virtual;
-      var result = new IndexInfo(reflectedType, attributes, indexToApplyView, Array.Empty<IndexInfo>());
+      var result = new IndexInfo(reflectedType, attributes, indexToApplyView, addAncestorToUnderlyings: true);
 
       // Adding key columns
       foreach (KeyValuePair<ColumnInfo, Direction> pair in indexToApplyView.KeyColumns) {

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
@@ -399,12 +399,6 @@ namespace Xtensive.Orm.Model
 
     // Constructors
 
-    private IndexInfo()
-    {
-      includedColumns = new ColumnInfoCollection(this, "IncludedColumns");
-      valueColumns = new ColumnInfoCollection(this, "ValueColumns");
-    }
-
     /// <summary>
     /// Initializes a new instance of this class.
     /// </summary>
@@ -494,6 +488,12 @@ namespace Xtensive.Orm.Model
       if (UnderlyingIndexes.Count == 0) {
         throw new ArgumentException(Strings.ExSequenceContainsNoElements, nameof(baseIndexes));
       }
+    }
+
+    private IndexInfo()
+    {
+      includedColumns = new ColumnInfoCollection(this, "IncludedColumns");
+      valueColumns = new ColumnInfoCollection(this, "ValueColumns");
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
@@ -329,23 +329,33 @@ namespace Xtensive.Orm.Model
       if (!IsPrimary)
         return;
 
-      var system = new List<int>();
+      var keyColumnsCount = keyColumns.Count;
+      var system = new int[keyColumnsCount + 2];
       var lazy = new List<int>();
-      var regular = new List<int>();
+      var regular = new int[Columns.Count - keyColumnsCount];
 
-      for (int i = 0, count = Columns.Count; i < count; i++) {
+      var regularIndex = 0;
+      var systemIndex = 0;
+
+      for (var i = 0; i < Columns.Count; i++) {
         var item = Columns[i];
-        if (item.IsPrimaryKey || item.IsSystem)
-          system.Add(i);
+        if (item.IsPrimaryKey || item.IsSystem) {
+          system[systemIndex++] = i;
+        }
         else {
           if (item.IsLazyLoad)
             lazy.Add(i);
-          else
-            regular.Add(i);
+          else {
+            regular[regularIndex++] = i;
+            //regularIndex++;
+          }
         }
       }
 
-      ColumnIndexMap = new ColumnIndexMap(system, regular, lazy);
+      ColumnIndexMap = new ColumnIndexMap(
+        (systemIndex == system.Length) ? system : new ArraySegment<int>(system, 0, systemIndex),
+        (regularIndex == 0) ? Array.Empty<int>() : new ArraySegment<int>(regular, 0, regularIndex),
+        (lazy.Count == 0) ? Array.Empty<int>() : lazy);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
- allows to skip some copying of underlying indexes for Union and Join indexes
- shrinks size of final ```ColumnIndexMap``` for real-world models, reduce amount of lists (and capacity changes)

This should be merged after #297.