### PR TITLE
Optimize getting of ShortName of System.Type

### DIFF
--- a/Orm/Xtensive.Orm/Comparison/ComparerProvider.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparerProvider.cs
@@ -66,10 +66,12 @@ namespace Xtensive.Comparison
       // the comparer.
       var comparer = base.CreateAssociate<TKey, IAdvancedComparerBase>(out foundFor);
       if (foundFor == null) {
-        CoreLog.Warning(nameof(Strings.LogCantFindAssociateFor),
-          TypeSuffixes.ToDelimitedString(" \\ "),
-          typeof(TAssociate).GetShortName(),
-          typeof(TKey).GetShortName());
+        if (CoreLog.IsLogged(Orm.Logging.LogLevel.Warning)) {
+          CoreLog.Warning(nameof(Strings.LogCantFindAssociateFor),
+            TypeSuffixes.ToDelimitedString(" \\ "),
+            typeof(TAssociate).GetShortName(),
+            typeof(TKey).GetShortName());
+        }
         return null;
       }
       if (foundFor == typeof(TKey)) {
@@ -77,19 +79,23 @@ namespace Xtensive.Comparison
       }
       associate = BaseComparerWrapperType.Activate(new[] { typeof(TKey), foundFor }, ConstructorParams) as TAssociate;
       if (associate != null) {
-        CoreLog.Warning(nameof(Strings.LogGenericAssociateIsUsedFor),
+        if (CoreLog.IsLogged(Orm.Logging.LogLevel.Warning)) {
+          CoreLog.Warning(nameof(Strings.LogGenericAssociateIsUsedFor),
           BaseComparerWrapperType.GetShortName(),
-          typeof (TKey).GetShortName(),
+          typeof(TKey).GetShortName(),
           foundFor.GetShortName(),
-          typeof (TKey).GetShortName());
+          typeof(TKey).GetShortName());
+        }
         return associate;
       }
       else {
-        CoreLog.Warning(nameof(Strings.LogGenericAssociateCreationHasFailedFor),
+        if (CoreLog.IsLogged(Orm.Logging.LogLevel.Warning)) {
+          CoreLog.Warning(nameof(Strings.LogGenericAssociateCreationHasFailedFor),
           BaseComparerWrapperType.GetShortName(),
-          typeof (TKey).GetShortName(),
+          typeof(TKey).GetShortName(),
           foundFor.GetShortName(),
-          typeof (TKey).GetShortName());
+          typeof(TKey).GetShortName());
+        }
         return null;
       }
     }

--- a/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
@@ -27,7 +27,7 @@ namespace Xtensive.IoC
   [Serializable]
   public class ServiceContainer : ServiceContainerBase
   {
-    private static readonly Type typeofIServiceContainer = typeof(IServiceContainer);
+    private static readonly Type iServiceContainerType = typeof(IServiceContainer);
 
     private static readonly Func<ServiceRegistration, Pair<ConstructorInfo, ParameterInfo[]>> ConstructorFactory = serviceInfo => {
       var mappedType = serviceInfo.MappedType;
@@ -187,9 +187,9 @@ namespace Xtensive.IoC
     public static IServiceContainer Create(Type containerType, object configuration, IServiceContainer parent)
     {
       ArgumentValidator.EnsureArgumentNotNull(containerType, "containerType");
-      if (!typeofIServiceContainer.IsAssignableFrom(containerType))
+      if (!iServiceContainerType.IsAssignableFrom(containerType))
         throw new ArgumentException(string.Format(
-          Strings.ExContainerTypeMustImplementX, typeofIServiceContainer.GetShortName()), "containerType");
+          Strings.ExContainerTypeMustImplementX, iServiceContainerType.Name), "containerType");
 
       Type configurationType = configuration?.GetType(),
         parentType = parent?.GetType();

--- a/Orm/Xtensive.Orm/Modelling/Actions/NodeAction.cs
+++ b/Orm/Xtensive.Orm/Modelling/Actions/NodeAction.cs
@@ -105,8 +105,7 @@ namespace Xtensive.Modelling.Actions
     /// <returns>The name of the action.</returns>
     protected virtual string GetActionName()
     {
-      string sn = GetType().GetShortName();
-      return sn.TryCutSuffix("Action");
+      return GetType().Name.TryCutSuffix("Action");
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Difference.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Difference.cs
@@ -43,8 +43,10 @@ namespace Xtensive.Modelling.Comparison
     /// <inheritdoc/>
     public override string ToString()
     {
+      var diffType = GetType();
       return string.Format(Strings.DifferenceFormat,
-        GetType().GetShortName(), Source, Target, ParametersToString());
+        diffType.IsGenericType ? diffType.GetShortName() : diffType.Name,
+        Source, Target, ParametersToString());
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Upgrader.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Upgrader.cs
@@ -160,18 +160,20 @@ namespace Xtensive.Modelling.Comparison
             .ForEach(validationHints.Add);
           var diff = comparer.Compare(CurrentModel, TargetModel, validationHints);
           if (diff != null) {
-            using (CoreLog.InfoRegion(nameof(Strings.LogAutomaticUpgradeSequenceValidation))) {
-              CoreLog.Info(nameof(Strings.LogValidationFailed));
-              CoreLog.Info(nameof(Strings.LogItemFormat), Strings.Difference);
-              CoreLog.Info(diff.ToString());
-              CoreLog.Info(Strings.LogItemFormat + "\r\n{1}", Strings.UpgradeSequence,
-                new ActionSequence() { actions });
-              CoreLog.Info(nameof(Strings.LogItemFormat), Strings.ExpectedTargetModel);
-              TargetModel.Dump();
-              CoreLog.Info(nameof(Strings.LogItemFormat), Strings.ActualTargetModel);
-              CurrentModel.Dump();
-              throw new InvalidOperationException(Strings.ExUpgradeSequenceValidationFailure);
+            if (CoreLog.IsLogged(Orm.Logging.LogLevel.Info)) {
+              using (CoreLog.InfoRegion(nameof(Strings.LogAutomaticUpgradeSequenceValidation))) {
+                CoreLog.Info(nameof(Strings.LogValidationFailed));
+                CoreLog.Info(nameof(Strings.LogItemFormat), Strings.Difference);
+                CoreLog.Info(diff.ToString());
+                CoreLog.Info(Strings.LogItemFormat + "\r\n{1}", Strings.UpgradeSequence,
+                  new ActionSequence() { actions });
+                CoreLog.Info(nameof(Strings.LogItemFormat), Strings.ExpectedTargetModel);
+                TargetModel.Dump();
+                CoreLog.Info(nameof(Strings.LogItemFormat), Strings.ActualTargetModel);
+                CurrentModel.Dump();
+              }
             }
+            throw new InvalidOperationException(Strings.ExUpgradeSequenceValidationFailure);
           }
 
           return new ReadOnlyCollection<NodeAction>(actions.Actions.ToArray());

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/DomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/DomainBuilder.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Building.Builders
       ArgumentValidator.EnsureArgumentNotNull(builderConfiguration, nameof(builderConfiguration));
 
       var context = new BuildingContext(builderConfiguration);
-      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), typeof(Domain).GetShortName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogBuildingX), typeof(Domain).Name)) {
         new DomainBuilder(context).Run();
       }
 
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void CreateDomain()
     {
-      using (BuildLog.InfoRegion(nameof(Strings.LogCreatingX), typeof(Domain).GetShortName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogCreatingX), typeof(Domain).Name)) {
         var services = context.BuilderConfiguration.Services;
         var useSingleConnection =
           services.ProviderInfo.Supports(ProviderFeatures.SingleConnection)
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Building.Builders
       var handlers = context.Domain.Handlers;
       var services = context.BuilderConfiguration.Services;
 
-      using (BuildLog.InfoRegion(nameof(Strings.LogCreatingX), typeof(DomainHandler).GetShortName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogCreatingX), typeof(DomainHandler).Name)) {
         // HandlerFactory
         handlers.Factory = services.HandlerFactory;
 
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void CreateServices()
     {
-      using (BuildLog.InfoRegion(nameof(Strings.LogCreatingX), typeof(IServiceContainer).GetShortName())) {
+      using (BuildLog.InfoRegion(nameof(Strings.LogCreatingX), typeof(IServiceContainer).Name)) {
         var domain = context.Domain;
         var configuration = domain.Configuration;
         var userContainerType = configuration.ServiceContainerType ?? typeof(ServiceContainer);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
@@ -92,19 +92,18 @@ namespace Xtensive.Orm.Building.Builders
 
       foreach (var type in typesToProcess) {
         var underlyingType = type.UnderlyingType;
-        if (verbose)
-          if (BuildLog.IsLogged(LogLevel.Info))
-            BuildLog.Info(nameof(Strings.LogProcessingX), underlyingType.GetShortName());
+        if (verbose && BuildLog.IsLogged(LogLevel.Info)) {
+          BuildLog.Info(nameof(Strings.LogProcessingX), underlyingType.GetShortName());
+        }
         var request = new MappingRequest(underlyingType.Assembly, underlyingType.Namespace);
-        MappingResult result;
-        if (!mappingCache.TryGetValue(request, out result)) {
+        if (!mappingCache.TryGetValue(request, out var result)) {
           result = Process(underlyingType);
           mappingCache.Add(request, result);
         }
         else {
-          if (verbose)
-            if (BuildLog.IsLogged(LogLevel.Info))
-              BuildLog.Info(nameof(Strings.LogReusingCachedMappingInformationForX), underlyingType.GetShortName());
+          if (verbose && BuildLog.IsLogged(LogLevel.Info)) {
+            BuildLog.Info(nameof(Strings.LogReusingCachedMappingInformationForX), underlyingType.GetShortName());
+          }
         }
         type.MappingDatabase = result.MappingDatabase;
         type.MappingSchema = result.MappingSchema;
@@ -118,9 +117,9 @@ namespace Xtensive.Orm.Building.Builders
       var resultDatabase = !string.IsNullOrEmpty(rule.Database) ? rule.Database : defaultDatabase;
       var resultSchema = !string.IsNullOrEmpty(rule.Schema) ? rule.Schema : defaultSchema;
 
-      if (verbose)
-        if (BuildLog.IsLogged(LogLevel.Info))
-          BuildLog.Info(nameof(Strings.ApplyingRuleXToY), rule, type.GetShortName());
+      if (verbose && BuildLog.IsLogged(LogLevel.Info)) {
+        BuildLog.Info(nameof(Strings.ApplyingRuleXToY), rule, type.GetShortName());
+      }
 
       return new MappingResult(resultDatabase, resultSchema);
     }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
@@ -93,7 +93,8 @@ namespace Xtensive.Orm.Building.Builders
       foreach (var type in typesToProcess) {
         var underlyingType = type.UnderlyingType;
         if (verbose)
-          BuildLog.Info(nameof(Strings.LogProcessingX), underlyingType.GetShortName());
+          if (BuildLog.IsLogged(LogLevel.Info))
+            BuildLog.Info(nameof(Strings.LogProcessingX), underlyingType.GetShortName());
         var request = new MappingRequest(underlyingType.Assembly, underlyingType.Namespace);
         MappingResult result;
         if (!mappingCache.TryGetValue(request, out result)) {
@@ -102,7 +103,8 @@ namespace Xtensive.Orm.Building.Builders
         }
         else {
           if (verbose)
-            BuildLog.Info(nameof(Strings.LogReusingCachedMappingInformationForX), underlyingType.GetShortName());
+            if (BuildLog.IsLogged(LogLevel.Info))
+              BuildLog.Info(nameof(Strings.LogReusingCachedMappingInformationForX), underlyingType.GetShortName());
         }
         type.MappingDatabase = result.MappingDatabase;
         type.MappingSchema = result.MappingSchema;
@@ -117,7 +119,8 @@ namespace Xtensive.Orm.Building.Builders
       var resultSchema = !string.IsNullOrEmpty(rule.Schema) ? rule.Schema : defaultSchema;
 
       if (verbose)
-        BuildLog.Info(nameof(Strings.ApplyingRuleXToY), rule, type.GetShortName());
+        if (BuildLog.IsLogged(LogLevel.Info))
+          BuildLog.Info(nameof(Strings.ApplyingRuleXToY), rule, type.GetShortName());
 
       return new MappingResult(resultDatabase, resultSchema);
     }

--- a/Orm/Xtensive.Orm/Orm/Key.cs
+++ b/Orm/Xtensive.Orm/Orm/Key.cs
@@ -305,15 +305,16 @@ namespace Xtensive.Orm
     /// <inheritdoc/>
     public override string ToString()
     {
+      var underlyingType = TypeInfo?.UnderlyingType ?? TypeReference.Type.UnderlyingType;
       if (TypeInfo!=null)
         return string.Format(
           Strings.KeyFormat,
-          TypeInfo.UnderlyingType.GetShortName(),
+          underlyingType.IsGenericType || underlyingType.IsNested ? underlyingType.GetShortName() : underlyingType.Name,
           Value.ToRegular());
 
       return string.Format(
         Strings.KeyFormatUnknownKeyType,
-        TypeReference.Type.UnderlyingType.GetShortName(),
+        underlyingType.IsGenericType || underlyingType.IsNested ? underlyingType.GetShortName() : underlyingType.Name,
         Value.ToRegular());
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatorContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatorContext.cs
@@ -80,7 +80,8 @@ namespace Xtensive.Orm.Linq
     {
       ApplyParameter parameter;
       if (!applyParameters.TryGetValue(provider, out parameter)) {
-        parameter = new ApplyParameter(provider.GetType().GetShortName());
+        var providerType = provider.GetType();
+        parameter = new ApplyParameter(providerType.IsGenericType ? providerType.GetShortName() : providerType.Name);
         // parameter = new ApplyParameter(provider.ToString()); 
         // ENABLE ONLY FOR DEBUGGING! 
         // May lead TO entity.ToString() calls, while ToString can be overriden.

--- a/Orm/Xtensive.Orm/Orm/Model/Node.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Node.cs
@@ -92,8 +92,11 @@ namespace Xtensive.Orm.Model
     /// <inheritdoc/>
     public override string ToString()
     {
-      return string.Format(Strings.NodeFormat, 
-        name ?? Strings.UnnamedNodeDisplayName, GetType().GetShortName());
+      var type = GetType();
+
+      return string.Format(Strings.NodeFormat,
+        name ?? Strings.UnnamedNodeDisplayName,
+        type.IsGenericType ? type.GetShortName() : type.Name);
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Provider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Provider.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Rse.Providers
     protected abstract RecordSetHeader BuildHeader();
 
     private string DebuggerDisplayName {
-      get { return GetType().GetShortName(); }
+      get { return GetType().Name; }
     }
 
     /// <summary>
@@ -98,8 +98,9 @@ namespace Xtensive.Orm.Rse.Providers
     private string TitleToString()
     {
       var sb = new StringBuilder();
-      string providerName = GetType().GetShortName().TryCutSuffix(ToString_ProviderTypeSuffix);
-      string parameters = ParametersToString();
+      var type = GetType();
+      var providerName = (type.IsGenericType ? type.GetShortName() : type.Name).TryCutSuffix(ToString_ProviderTypeSuffix);
+      var parameters = ParametersToString();
 
       sb.Append(providerName);
       if (!parameters.IsNullOrEmpty())

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Provider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Provider.cs
@@ -60,7 +60,12 @@ namespace Xtensive.Orm.Rse.Providers
     protected abstract RecordSetHeader BuildHeader();
 
     private string DebuggerDisplayName {
-      get { return GetType().Name; }
+      get {
+        var type = GetType();
+        return type.IsGenericType
+          ? type.GetShortName()
+          : type.Name;
+      }
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -362,7 +362,7 @@ namespace Xtensive.Orm.Upgrade
         var candidates = group.ToList();
         if (candidates.Count > 1) {
           throw new DomainBuilderException(
-            string.Format(Strings.ExMoreThanOneEnabledXIsProvidedForAssemblyY, typeof (IUpgradeHandler).GetShortName(), @group.Key));
+            string.Format(Strings.ExMoreThanOneEnabledXIsProvidedForAssemblyY, typeof(IUpgradeHandler).Name, @group.Key));
         }
         handlers.Add(group.Key, candidates[0]);
       }
@@ -398,12 +398,12 @@ namespace Xtensive.Orm.Upgrade
       //Getting user resolvers
       var candidates = from r in serviceContainer.GetAll<IFullTextCatalogNameBuilder>()
         let assembly = r.GetType().Assembly
-        where r.IsEnabled && assembly!=typeof (IFullTextCatalogNameBuilder).Assembly
+        where r.IsEnabled && assembly!=typeof(IFullTextCatalogNameBuilder).Assembly
         select r;
 
       var userResolversCount = candidates.Count();
       if (userResolversCount > 1)
-        throw new DomainBuilderException(string.Format(Strings.ExMoreThanOneEnabledXIsProvided, typeof (IFullTextCatalogNameBuilder).GetShortName()));
+        throw new DomainBuilderException(string.Format(Strings.ExMoreThanOneEnabledXIsProvided, typeof(IFullTextCatalogNameBuilder).Name));
 
       var resolver = (userResolversCount==0)
         ? new FullTextCatalogNameBuilder()

--- a/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
@@ -357,7 +357,7 @@ namespace Xtensive.Reflection
       Type delegateType = typeof (TDelegate);
       if (!WellKnownTypes.Delegate.IsAssignableFrom(delegateType))
         throw new ArgumentException(string.Format(Strings.ExGenericParameterShouldBeOfTypeT,
-          "TDelegate", WellKnownTypes.Delegate.GetShortName()));
+          "TDelegate", WellKnownTypes.Delegate.Name));
 
       BindingFlags bindingFlags =
         BindingFlags.Public |
@@ -404,7 +404,7 @@ namespace Xtensive.Reflection
       Type delegateType = typeof (TDelegate);
       if (!WellKnownTypes.Delegate.IsAssignableFrom(delegateType))
         throw new ArgumentException(string.Format(Strings.ExGenericParameterShouldBeOfTypeT,
-          "TDelegate", WellKnownTypes.Delegate.GetShortName()));
+          "TDelegate", WellKnownTypes.Delegate.Name));
 
       int count = genericArgumentVariants.Count;
       TDelegate[] delegates = new TDelegate[count];

--- a/Orm/Xtensive.Orm/Tuples/Transform/CombineTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/CombineTransform.cs
@@ -47,9 +47,7 @@ namespace Xtensive.Tuples.Transform
     public override string ToString()
     {
       string description = $"{sources.ToDelimitedString(" + ")}, {(IsReadOnly ? Strings.ReadOnlyShort : Strings.ReadWriteShort)}";
-      return string.Format(Strings.TupleTransformFormat, 
-        GetType().GetShortName(), 
-        description);
+      return string.Format(Strings.TupleTransformFormat, GetType().Name, description);
     }
 
 

--- a/Orm/Xtensive.Orm/Tuples/Transform/CutInTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/CutInTransform.cs
@@ -49,8 +49,7 @@ namespace Xtensive.Tuples.Transform
     public override string ToString()
     {
       string description = $"{sources.ToDelimitedString(" + ")}, {(IsReadOnly ? Strings.ReadOnlyShort : Strings.ReadWriteShort)}";
-      return string.Format(Strings.TupleTransformFormat,
-        GetType().GetShortName(),
+      return string.Format(Strings.TupleTransformFormat, GetType().Name,
         description);
     }
 

--- a/Orm/Xtensive.Orm/Tuples/Transform/CutOutTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/CutOutTransform.cs
@@ -40,9 +40,7 @@ namespace Xtensive.Tuples.Transform
     public override string ToString()
     {
       string description = $"{segment}, {(IsReadOnly ? Strings.ReadOnlyShort : Strings.ReadWriteShort)}";
-      return string.Format(Strings.TupleTransformFormat,
-        GetType().GetShortName(),
-        description);
+      return string.Format(Strings.TupleTransformFormat, GetType().Name, description);
     }
 
 

--- a/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
@@ -256,9 +256,7 @@ namespace Xtensive.Tuples.Transform
     public override string ToString()
     {
       string description = $"{SourceCount}: {(SourceCount == 1 ? singleSourceMap.ToCommaDelimitedString() : map.ToCommaDelimitedString())}, {(isReadOnly ? Strings.ReadOnlyShort : Strings.ReadWriteShort)}";
-      return string.Format(Strings.TupleTransformFormat, 
-        GetType().GetShortName(), 
-        description);
+      return string.Format(Strings.TupleTransformFormat, GetType().Name, description);
     }
 
     

--- a/Orm/Xtensive.Orm/Tuples/Transform/SegmentTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/SegmentTransform.cs
@@ -39,9 +39,7 @@ namespace Xtensive.Tuples.Transform
     public override string ToString()
     {
       string description = $"{segment}, {(IsReadOnly ? Strings.ReadOnlyShort : Strings.ReadWriteShort)}";
-      return string.Format(Strings.TupleTransformFormat, 
-        GetType().GetShortName(), 
-        description);
+      return string.Format(Strings.TupleTransformFormat, GetType().Name, description);
     }
 
 

--- a/Orm/Xtensive.Orm/Tuples/Transform/TupleTransformBase.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/TupleTransformBase.cs
@@ -50,7 +50,8 @@ namespace Xtensive.Tuples.Transform
     /// <inheritdoc/>
     public override string ToString()
     {
-      return GetType().GetShortName();
+      var type = GetType();
+      return type.IsGenericType ? type.GetShortName() : type.Name;
     }
   }
 }


### PR DESCRIPTION
- ```System.Type.Name``` instead of ```.GetShortName()``` extension in places where there it is obvious that short name is equal to ```Type.Name``` (type is not nested, it is class, and it is not generic), only for types we have created and control.
- avoid getting type name when logging is skipped.

```RuntimeType``` has names caching mechanisms so we can rely on it instead of having ours.