### PR TITLE
Disable `.ConfigureAwait(false)` by conditional compilation constant `DO_CONFIGURE_AWAIT_FALSE`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -128,4 +128,8 @@
   </ItemGroup>
 
   <Import Condition="Exists('User.Directory.Build.props')" Project="User.Directory.Build.props" />
+
+  <PropertyGroup>
+    <DefineConstants Condition="'$(DO_CONFIGURE_AWAIT_FALSE)'!='false'">$(DefineConstants);DO_CONFIGURE_AWAIT_FALSE</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/Connection.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/Connection.cs
@@ -10,6 +10,7 @@ using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 using SqlServerConnection = Microsoft.Data.SqlClient.SqlConnection;
 
 namespace Xtensive.Sql.Drivers.SqlServer
@@ -143,11 +144,11 @@ namespace Xtensive.Sql.Drivers.SqlServer
 
       try {
         if (!IsTransactionZombied()) {
-          await ActiveTransaction.RollbackAsync(token).ConfigureAwait(false);
+          await ActiveTransaction.RollbackAsync(token).ConfigureAwaitFalse();
         }
       }
       finally {
-        await ActiveTransaction.DisposeAsync().ConfigureAwait(false);
+        await ActiveTransaction.DisposeAsync().ConfigureAwaitFalse();
         ClearActiveTransaction();
       }
     }
@@ -265,12 +266,12 @@ namespace Xtensive.Sql.Drivers.SqlServer
 
       while (!connectionChecked) {
         cancellationToken.ThrowIfCancellationRequested();
-        await underlyingConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await underlyingConnection.OpenAsync(cancellationToken).ConfigureAwaitFalse();
         try {
           var command = underlyingConnection.CreateCommand();
-          await using (command.ConfigureAwait(false)) {
+          await using (command.ConfigureAwaitFalse()) {
             command.CommandText = checkQueryString;
-            _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwaitFalse();
           }
           connectionChecked = true;
         }
@@ -308,27 +309,27 @@ namespace Xtensive.Sql.Drivers.SqlServer
 
         await SqlHelper.NotifyConnectionOpeningAsync(accessors,
             UnderlyingConnection, (!connectionChecked && !restoreTriggered), cancellationToken)
-          .ConfigureAwait(false);
+          .ConfigureAwaitFalse();
 
-        await underlyingConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await underlyingConnection.OpenAsync(cancellationToken).ConfigureAwaitFalse();
         try {
           await SqlHelper.NotifyConnectionInitializingAsync(accessors,
               UnderlyingConnection, checkQueryString, (!connectionChecked && !restoreTriggered), cancellationToken)
-            .ConfigureAwait(false);
+            .ConfigureAwaitFalse();
 
           var command = underlyingConnection.CreateCommand();
-          await using (command.ConfigureAwait(false)) {
+          await using (command.ConfigureAwaitFalse()) {
             command.CommandText = checkQueryString;
-            _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwaitFalse();
           }
           connectionChecked = true;
           await SqlHelper.NotifyConnectionOpenedAsync(accessors, UnderlyingConnection, (!connectionChecked && !restoreTriggered), cancellationToken)
-            .ConfigureAwait(false);
+            .ConfigureAwaitFalse();
         }
         catch (Exception exception) {
           await SqlHelper.NotifyConnectionOpeningFailedAsync(accessors,
               UnderlyingConnection, exception, (!connectionChecked && !restoreTriggered), cancellationToken)
-            .ConfigureAwait(false);
+            .ConfigureAwaitFalse();
 
           if (InternalHelpers.ShouldRetryOn(exception)) {
             if (restoreTriggered) {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Extractor.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Extractor.cs
@@ -92,7 +92,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       string catalogName, string[] schemaNames, CancellationToken token = default)
     {
       var context = CreateContext(catalogName, schemaNames);
-      await ExtractCatalogContentsAsync(context, token).ConfigureAwait(false);
+      await ExtractCatalogContentsAsync(context, token).ConfigureAwaitFalse();
       return context.Catalog;
     }
 
@@ -110,14 +110,14 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
 
     protected virtual async Task ExtractCatalogContentsAsync(ExtractionContext context, CancellationToken token)
     {
-      await ExtractSchemasAsync(context, token).ConfigureAwait(false);
+      await ExtractSchemasAsync(context, token).ConfigureAwaitFalse();
       RegisterReplacements(context);
-      await ExtractTypesAsync(context, token).ConfigureAwait(false);
-      await ExtractTablesAndViewsAsync(context, token).ConfigureAwait(false);
-      await ExtractColumnsAsync(context, token).ConfigureAwait(false);
-      await ExtractIndexesAsync(context, token).ConfigureAwait(false);
-      await ExtractForeignKeysAsync(context, token).ConfigureAwait(false);
-      await ExtractFulltextIndexesAsync(context, token).ConfigureAwait(false);
+      await ExtractTypesAsync(context, token).ConfigureAwaitFalse();
+      await ExtractTablesAndViewsAsync(context, token).ConfigureAwaitFalse();
+      await ExtractColumnsAsync(context, token).ConfigureAwaitFalse();
+      await ExtractIndexesAsync(context, token).ConfigureAwaitFalse();
+      await ExtractForeignKeysAsync(context, token).ConfigureAwaitFalse();
+      await ExtractFulltextIndexesAsync(context, token).ConfigureAwaitFalse();
     }
 
     protected virtual void RegisterReplacements(ExtractionContext context)
@@ -154,10 +154,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       var query = BuildExtractSchemasQuery(context);
 
       var cmd = Connection.CreateCommand(query);
-      await using (cmd.ConfigureAwait(false)) {
-        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+      await using (cmd.ConfigureAwaitFalse()) {
+        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             ReadSchemaData(reader, context);
           }
         }
@@ -207,10 +207,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       var query = BuildExtractTypesQuery(context);
 
       var command = Connection.CreateCommand(query);
-      await using (command.ConfigureAwait(false)) {
-        var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+      await using (command.ConfigureAwaitFalse()) {
+        var reader = await command.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             ReadTypeData(reader, context);
           }
         }
@@ -277,10 +277,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       var query = BuildExtractTablesAndViewsQuery(context);
 
       var cmd = Connection.CreateCommand(query);
-      await using (cmd.ConfigureAwait(false)) {
-        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+      await using (cmd.ConfigureAwaitFalse()) {
+        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             ReadTableOrViewData(reader, context);
           }
         }
@@ -362,10 +362,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       var currentTableId = 0;
       var cmd = Connection.CreateCommand(query);
       ColumnResolver columnResolver = null;
-      await using (cmd.ConfigureAwait(false)) {
-        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+      await using (cmd.ConfigureAwaitFalse()) {
+        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             ReadColumnData(context, reader, ref currentTableId, ref columnResolver);
           }
         }
@@ -374,10 +374,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       query = BuildExtractIdentityColumnsQuery(context);
 
       cmd = Connection.CreateCommand(query);
-      await using (cmd.ConfigureAwait(false)) {
-        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+      await using (cmd.ConfigureAwaitFalse()) {
+        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             ReadIdentityColumnData(reader, context);
           }
         }
@@ -613,10 +613,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       PrimaryKey primaryKey = null;
       UniqueConstraint uniqueConstraint = null;
       var cmd = Connection.CreateCommand(query);
-      await using (cmd.ConfigureAwait(false)) {
-        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+      await using (cmd.ConfigureAwaitFalse()) {
+        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             ReadIndexColumnData(reader, context,
               ref tableId, spatialIndexType, ref primaryKey, ref uniqueConstraint, ref index, ref table);
           }
@@ -724,10 +724,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       ColumnResolver referencedTable = null;
       ForeignKey foreignKey = null;
       var cmd = Connection.CreateCommand(query);
-      await using (cmd.ConfigureAwait(false)) {
-        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+      await using (cmd.ConfigureAwaitFalse()) {
+        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             ReadForeignKeyColumnData(reader, context, ref tableId, ref foreignKey, ref referencingTable, ref referencedTable);
           }
         }
@@ -800,10 +800,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       ColumnResolver table = null;
       FullTextIndex index = null;
       var cmd = Connection.CreateCommand(query);
-      await using (cmd.ConfigureAwait(false)) {
-        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+      await using (cmd.ConfigureAwaitFalse()) {
+        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             ReadFullTextIndexColumnData(reader, context, ref currentTableId, ref table, ref index);
           }
         }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Extractor.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Extractor.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 
 namespace Xtensive.Sql.Drivers.SqlServer.v11
 {
@@ -24,8 +25,8 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
 
     protected override async Task ExtractCatalogContentsAsync(ExtractionContext context, CancellationToken token)
     {
-      await base.ExtractCatalogContentsAsync(context, token).ConfigureAwait(false);
-      await ExtractSequencesAsync(context, token).ConfigureAwait(false);
+      await base.ExtractCatalogContentsAsync(context, token).ConfigureAwaitFalse();
+      await ExtractSequencesAsync(context, token).ConfigureAwaitFalse();
     }
 
     private void ExtractSequences(ExtractionContext context)
@@ -44,10 +45,10 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
       var query = BuildExtractSequencesQuery(context);
 
       var cmd = Connection.CreateCommand(query);
-      await using (cmd.ConfigureAwait(false)) {
-        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+      await using (cmd.ConfigureAwaitFalse()) {
+        var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             ReadSequenceData(reader, context);
           }
         }

--- a/Orm/Xtensive.Orm/Core/AsyncFutureResult.cs
+++ b/Orm/Xtensive.Orm/Core/AsyncFutureResult.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Core
       var localTask = task ?? worker();
       task = null;
       worker = null;
-      return await localTask.ConfigureAwait(false);
+      return await localTask.ConfigureAwaitFalse();
     }
 
     public override void Dispose()
@@ -64,7 +64,7 @@ namespace Xtensive.Core
       }
 
       try {
-        await GetAsync().ConfigureAwait(false);
+        await GetAsync().ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         logger?.Warning(nameof(Strings.LogAsyncOperationError), exception: exception);

--- a/Orm/Xtensive.Orm/Core/DisposableSet.cs
+++ b/Orm/Xtensive.Orm/Core/DisposableSet.cs
@@ -132,7 +132,7 @@ namespace Xtensive.Core
           for (var i = list.Count - 1; i >= 0; i--) {
             var disposable = list[i];
             if (disposable is IAsyncDisposable asyncDisposable) {
-              await aggregator.ExecuteAsync(d => d.DisposeAsync(), asyncDisposable).ConfigureAwait(false);
+              await aggregator.ExecuteAsync(d => d.DisposeAsync(), asyncDisposable).ConfigureAwaitFalse();
             }
             else {
               aggregator.Execute(d => d.Dispose(), disposable);

--- a/Orm/Xtensive.Orm/Core/ExceptionAggregator.cs
+++ b/Orm/Xtensive.Orm/Core/ExceptionAggregator.cs
@@ -152,7 +152,7 @@ namespace Xtensive.Core
       }
 
       try {
-        await action(argument).ConfigureAwait(false);
+        await action(argument).ConfigureAwaitFalse();
       }
       catch (Exception e) {
         HandleException(e);

--- a/Orm/Xtensive.Orm/Core/Extensions/DisposableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/DisposableExtensions.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Core
     {
       try {
         if (disposable!=null) {
-          await disposable.DisposeAsync().ConfigureAwait(false);
+          await disposable.DisposeAsync().ConfigureAwaitFalse();
         }
       }
       catch {

--- a/Orm/Xtensive.Orm/Core/Extensions/TaskExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/TaskExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Xtensive.Core
+{
+  public static class TaskExtensions
+  {
+#if DO_CONFIGURE_AWAIT_FALSE
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ConfiguredTaskAwaitable ConfigureAwaitFalse(this Task task) => task.ConfigureAwait(false);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ConfiguredTaskAwaitable<T> ConfigureAwaitFalse<T>(this Task<T> task) => task.ConfigureAwait(false);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ConfiguredValueTaskAwaitable ConfigureAwaitFalse(this ValueTask task) => task.ConfigureAwait(false);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ConfiguredValueTaskAwaitable<T> ConfigureAwaitFalse<T>(this ValueTask<T> task) => task.ConfigureAwait(false);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ConfiguredAsyncDisposable ConfigureAwaitFalse(this IAsyncDisposable source) => source.ConfigureAwait(false);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ConfiguredCancelableAsyncEnumerable<T> ConfigureAwaitFalse<T>(this IAsyncEnumerable<T> source) => source.ConfigureAwait(false);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ConfiguredCancelableAsyncEnumerable<T> ConfigureAwaitFalse<T>(this ConfiguredCancelableAsyncEnumerable<T> source) => source.ConfigureAwait(false);
+#else
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static Task ConfigureAwaitFalse(this Task task) => task;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static Task<T> ConfigureAwaitFalse<T>(this Task<T> task) => task;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ValueTask ConfigureAwaitFalse(this ValueTask task) => task;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ValueTask<T> ConfigureAwaitFalse<T>(this ValueTask<T> task) => task;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static IAsyncDisposable ConfigureAwaitFalse(this IAsyncDisposable source) => source;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static IAsyncEnumerable<T> ConfigureAwaitFalse<T>(this IAsyncEnumerable<T> source) => source;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ConfiguredCancelableAsyncEnumerable<T> ConfigureAwaitFalse<T>(this ConfiguredCancelableAsyncEnumerable<T> source) => source;
+#endif
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/DelayedQuery.cs
+++ b/Orm/Xtensive.Orm/Orm/DelayedQuery.cs
@@ -73,7 +73,7 @@ namespace Xtensive.Orm.Internals
       }
 
       if (Task.Result==null) {
-        await Session.ExecuteUserDefinedDelayedQueriesAsync(false, token).ConfigureAwait(false);
+        await Session.ExecuteUserDefinedDelayedQueriesAsync(false, token).ConfigureAwaitFalse();
       }
 
       return materializer.Invoke<T>(RecordSetReader.Create(Task.Result), Session, parameterContext);

--- a/Orm/Xtensive.Orm/Orm/DelayedScalarQuery{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/DelayedScalarQuery{T}.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm
     /// <param name="token">Cancellation token.</param>
     /// <returns>Value representing scalar query execution result.</returns>
     public async ValueTask<TResult> ExecuteAsync(CancellationToken token = default) =>
-      (await MaterializeAsync<TResult>(token).ConfigureAwait(false)).ToScalar(resultAccessMethod);
+      (await MaterializeAsync<TResult>(token).ConfigureAwaitFalse()).ToScalar(resultAccessMethod);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -363,10 +363,10 @@ namespace Xtensive.Orm
                 exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
               }
             }, TaskContinuationOptions.NotOnCanceled | TaskContinuationOptions.ExecuteSynchronously)
-            .ConfigureAwait(false);
+            .ConfigureAwaitFalse();
         }
         catch (OperationCanceledException) {
-          await session.DisposeSafelyAsync().ConfigureAwait(false);
+          await session.DisposeSafelyAsync().ConfigureAwaitFalse();
           throw;
         }
         finally {
@@ -466,8 +466,8 @@ namespace Xtensive.Orm
 
       var driver = Handlers.StorageDriver;
       if (isAsync) {
-        await driver.CloseConnectionAsync(null, singleConnectionLocal).ConfigureAwait(false);
-        await driver.DisposeConnectionAsync(null, singleConnectionLocal).ConfigureAwait(false);
+        await driver.CloseConnectionAsync(null, singleConnectionLocal).ConfigureAwaitFalse();
+        await driver.DisposeConnectionAsync(null, singleConnectionLocal).ConfigureAwaitFalse();
       }
       else {
         driver.CloseConnection(null, singleConnectionLocal);

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         RegisterAllEntitySetTasks(containers);
 
         var isExecuted = isAsync
-          ? await manager.Owner.Session.ExecuteInternalDelayedQueriesAsync(skipPersist, token).ConfigureAwait(false)
+          ? await manager.Owner.Session.ExecuteInternalDelayedQueriesAsync(skipPersist, token).ConfigureAwaitFalse()
           : manager.Owner.Session.ExecuteInternalDelayedQueries(skipPersist);
         batchExecuted += isExecuted ? 1 : 0;
 
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         RegisterAllEntityGroupTasks();
 
         isExecuted = isAsync
-          ? await manager.Owner.Session.ExecuteInternalDelayedQueriesAsync(skipPersist, token).ConfigureAwait(false)
+          ? await manager.Owner.Session.ExecuteInternalDelayedQueriesAsync(skipPersist, token).ConfigureAwaitFalse()
           : manager.Owner.Session.ExecuteInternalDelayedQueries(skipPersist);
         batchExecuted += isExecuted ? 1 : 0;
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchKeyIterator.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchKeyIterator.cs
@@ -7,6 +7,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Internals.Prefetch
 {
@@ -92,7 +93,7 @@ namespace Xtensive.Orm.Internals.Prefetch
           resultQueue.Enqueue(key);
           var defaultDescriptors = PrefetchHelper.GetCachedDescriptorsForFieldsLoadedByDefault(session.Domain, type);
           container.JoinIfPossible(
-            await session.Handler.PrefetchAsync(key, type, defaultDescriptors, token).ConfigureAwait(false));
+            await session.Handler.PrefetchAsync(key, type, defaultDescriptors, token).ConfigureAwaitFalse());
         }
 
         if (exists && taskCount == session.Handler.PrefetchTaskExecutionCount) {
@@ -101,7 +102,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
         if (!exists) {
           container.JoinIfPossible(
-            await session.Handler.ExecutePrefetchTasksAsync(token).ConfigureAwait(false));
+            await session.Handler.ExecutePrefetchTasksAsync(token).ConfigureAwaitFalse());
         }
 
         if (unknownTypeQueue.Count > 0) {
@@ -110,10 +111,10 @@ namespace Xtensive.Orm.Internals.Prefetch
             var unknownDescriptors =
               PrefetchHelper.GetCachedDescriptorsForFieldsLoadedByDefault(session.Domain, unknownType);
             await session.Handler.PrefetchAsync(
-              unknownKey, unknownType, unknownDescriptors, token).ConfigureAwait(false);
+              unknownKey, unknownType, unknownDescriptors, token).ConfigureAwaitFalse();
           }
 
-          await session.Handler.ExecutePrefetchTasksAsync(token).ConfigureAwait(false);
+          await session.Handler.ExecutePrefetchTasksAsync(token).ConfigureAwaitFalse();
         }
 
         while (resultQueue.TryDequeue(out var item)) {

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
@@ -104,7 +104,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       IReadOnlyList<PrefetchFieldDescriptor> descriptors, CancellationToken token = default)
     {
       var prefetchTask = Prefetch(key, type, descriptors, true, token);
-      return await prefetchTask.ConfigureAwait(false);
+      return await prefetchTask.ConfigureAwaitFalse();
     }
 
     private async ValueTask<StrongReferenceContainer> Prefetch(
@@ -148,7 +148,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
         StrongReferenceContainer container = null;
         if (graphContainers.Count >= MaxContainerCount) {
-          container = await ExecuteTasks(false, isAsync, token).ConfigureAwait(false);
+          container = await ExecuteTasks(false, isAsync, token).ConfigureAwaitFalse();
         }
 
         if (referenceContainer != null) {
@@ -167,7 +167,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       ExecuteTasks(skipPersist, false, default).GetAwaiter().GetResult();
 
     public async Task<StrongReferenceContainer> ExecuteTasksAsync(bool skipPersist, CancellationToken token = default) =>
-      await ExecuteTasks(skipPersist, true, token).ConfigureAwait(false);
+      await ExecuteTasks(skipPersist, true, token).ConfigureAwaitFalse();
 
     private async ValueTask<StrongReferenceContainer> ExecuteTasks(bool skipPersist, bool isAsync, CancellationToken token)
     {
@@ -177,7 +177,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       }
       try {
         var batchExecuted =
-          await fetcher.ExecuteTasks(graphContainers.Values, skipPersist, isAsync, token).ConfigureAwait(false);
+          await fetcher.ExecuteTasks(graphContainers.Values, skipPersist, isAsync, token).ConfigureAwaitFalse();
         TaskExecutionCount += batchExecuted;
         foreach (var graphContainer in graphContainers.Values) {
           graphContainer.NotifyAboutExtractionOfKeysWithUnknownType();

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializingReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializingReader.cs
@@ -65,7 +65,7 @@ namespace Xtensive.Orm.Linq.Materialization
 
     public async ValueTask<bool> MoveNextAsync()
     {
-      while (await recordSetReader.MoveNextAsync().ConfigureAwait(false)) {
+      while (await recordSetReader.MoveNextAsync().ConfigureAwaitFalse()) {
         if (itemMaterializer.CanMaterialize(recordSetReader.Current)) {
           return true;
         }

--- a/Orm/Xtensive.Orm/Orm/Linq/QueryProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryProvider.cs
@@ -142,7 +142,7 @@ namespace Xtensive.Orm.Linq
       var query = Translate(expression);
       TResult result;
       try {
-        result = await runQuery(query, Session, new ParameterContext(), token).ConfigureAwait(false);
+        result = await runQuery(query, Session, new ParameterContext(), token).ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         Session.Events.NotifyQueryExecuted(expression, exception);

--- a/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
@@ -46,8 +46,8 @@ namespace Xtensive.Orm.Linq
     /// <inheritdoc/>
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
-      var result = await provider.ExecuteSequenceAsync<T>(expression, cancellationToken).ConfigureAwait(false);
-      var asyncSource = result.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false);
+      var result = await provider.ExecuteSequenceAsync<T>(expression, cancellationToken).ConfigureAwaitFalse();
+      var asyncSource = result.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse();
       await foreach (var element in asyncSource) {
         yield return element;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatedQuery.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatedQuery.cs
@@ -85,7 +85,7 @@ namespace Xtensive.Orm.Linq
     public async Task<TResult> ExecuteScalarAsync<TResult>(
       Session session, ParameterContext parameterContext, CancellationToken token)
     {
-      var sequenceResult = await ExecuteSequenceAsync<TResult>(session, parameterContext, token).ConfigureAwait(false);
+      var sequenceResult = await ExecuteSequenceAsync<TResult>(session, parameterContext, token).ConfigureAwaitFalse();
       return sequenceResult.ToScalar(ResultAccessMethod);
     }
 
@@ -103,7 +103,7 @@ namespace Xtensive.Orm.Linq
     {
       var newParameterContext = new ParameterContext(parameterContext, TupleParameterBindings);
       var recordSetReader =
-        await DataSource.GetRecordSetReaderAsync(session, newParameterContext, token).ConfigureAwait(false);
+        await DataSource.GetRecordSetReaderAsync(session, newParameterContext, token).ConfigureAwaitFalse();
       return Materializer.Invoke<T>(recordSetReader, session, newParameterContext);
     }
 

--- a/Orm/Xtensive.Orm/Orm/PrefetchQuery.cs
+++ b/Orm/Xtensive.Orm/Orm/PrefetchQuery.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 using Xtensive.Collections;
 using Xtensive.Orm.Internals.Prefetch;
 
@@ -82,7 +83,7 @@ namespace Xtensive.Orm
     {
       var list = new List<TElement>();
       var asyncEnumerable = new PrefetchQueryAsyncEnumerable<TElement>(session, source, nodes);
-      await foreach (var element in asyncEnumerable.WithCancellation(token).ConfigureAwait(false)) {
+      await foreach (var element in asyncEnumerable.WithCancellation(token).ConfigureAwaitFalse()) {
         list.Add(element);
       }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
@@ -69,11 +69,11 @@ namespace Xtensive.Orm.Providers
       PutTasksForExecution(context);
 
       while (context.ProcessingTasks.Count >= batchSize) {
-        _ = await ExecuteBatchAsync(batchSize, null, context, token).ConfigureAwait(false);
+        _ = await ExecuteBatchAsync(batchSize, null, context, token).ConfigureAwaitFalse();
       }
 
       while (!context.AllowPartialExecution && context.ProcessingTasks.Count > 0) {
-        _ = await ExecuteBatchAsync(context.ProcessingTasks.Count, null, context, token).ConfigureAwait(false);
+        _ = await ExecuteBatchAsync(context.ProcessingTasks.Count, null, context, token).ConfigureAwaitFalse();
       }
     }
 
@@ -101,11 +101,11 @@ namespace Xtensive.Orm.Providers
       PutTasksForExecution(context);
 
       while (context.ProcessingTasks.Count >= batchSize) {
-        _ = await ExecuteBatchAsync(batchSize, null, context, token).ConfigureAwait(false);
+        _ = await ExecuteBatchAsync(batchSize, null, context, token).ConfigureAwaitFalse();
       }
 
       for (; ; ) {
-        var result = await ExecuteBatchAsync(context.ProcessingTasks.Count, request, context, token).ConfigureAwait(false);
+        var result = await ExecuteBatchAsync(context.ProcessingTasks.Count, request, context, token).ConfigureAwaitFalse();
         if (result != null && context.ProcessingTasks.Count == 0) {
           return result.CreateReader(request.GetAccessor());
         }
@@ -222,11 +222,11 @@ namespace Xtensive.Orm.Providers
         }
         var hasQueryTasks = context.ActiveTasks.Count > 0;
         if (!hasQueryTasks && !shouldReturnReader) {
-          _ = await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+          _ = await command.ExecuteNonQueryAsync(token).ConfigureAwaitFalse();
           return null;
         }
 
-        await command.ExecuteReaderAsync(token).ConfigureAwait(false);
+        await command.ExecuteReaderAsync(token).ConfigureAwaitFalse();
         if (hasQueryTasks) {
           var currentQueryTask = 0;
           while (currentQueryTask < context.ActiveTasks.Count) {
@@ -245,7 +245,7 @@ namespace Xtensive.Orm.Providers
       }
       finally {
         if (!shouldReturnReader) {
-          await context.ActiveCommand.DisposeSafelyAsync().ConfigureAwait(false);
+          await context.ActiveCommand.DisposeSafelyAsync().ConfigureAwaitFalse();
         }
 
         ReleaseCommand(context);

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/Command.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/Command.cs
@@ -71,13 +71,13 @@ namespace Xtensive.Orm.Providers
     public async Task<int> ExecuteNonQueryAsync(CancellationToken token)
     {
       _ = Prepare();
-      return await origin.Driver.ExecuteNonQueryAsync(origin.Session, underlyingCommand, token).ConfigureAwait(false);
+      return await origin.Driver.ExecuteNonQueryAsync(origin.Session, underlyingCommand, token).ConfigureAwaitFalse();
     }
 
     public async Task ExecuteReaderAsync(CancellationToken token)
     {
       _ = Prepare();
-      reader = await origin.Driver.ExecuteReaderAsync(origin.Session, underlyingCommand, token).ConfigureAwait(false);
+      reader = await origin.Driver.ExecuteReaderAsync(origin.Session, underlyingCommand, token).ConfigureAwaitFalse();
     }
 
     public bool NextResult()
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Providers
     public async Task<bool> NextResultAsync(CancellationToken token = default)
     {
       try {
-        return await reader.NextResultAsync(token).ConfigureAwait(false);
+        return await reader.NextResultAsync(token).ConfigureAwaitFalse();
       }
       catch(Exception exception) {
         throw TranslateException(exception);
@@ -113,7 +113,7 @@ namespace Xtensive.Orm.Providers
     public async ValueTask<bool> NextRowAsync(CancellationToken token = default)
     {
       try {
-        return await reader.ReadAsync(token).ConfigureAwait(false);
+        return await reader.ReadAsync(token).ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw TranslateException(exception);
@@ -157,9 +157,9 @@ namespace Xtensive.Orm.Providers
     {
       if (!isDisposed) {
         isDisposed = true;
-        await reader.DisposeSafelyAsync().ConfigureAwait(false);
-        await resources.DisposeSafelyAsync().ConfigureAwait(false);
-        await underlyingCommand.DisposeSafelyAsync().ConfigureAwait(false);
+        await reader.DisposeSafelyAsync().ConfigureAwaitFalse();
+        await resources.DisposeSafelyAsync().ConfigureAwaitFalse();
+        await underlyingCommand.DisposeSafelyAsync().ConfigureAwaitFalse();
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandProcessorContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandProcessorContext.cs
@@ -68,7 +68,7 @@ namespace Xtensive.Orm.Providers
 
       if (ActiveCommand != null) {
         if (isAsync) {
-          await ActiveCommand.DisposeAsync().ConfigureAwait(false);
+          await ActiveCommand.DisposeAsync().ConfigureAwaitFalse();
         }
         else {
           ActiveCommand.Dispose();

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/DataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/DataReader.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 using Tuple = Xtensive.Tuples.Tuple;
 
 namespace Xtensive.Orm.Providers
@@ -59,12 +60,12 @@ namespace Xtensive.Orm.Providers
         return ((IEnumerator<Tuple>) source).MoveNext();
       }
 
-      if (await command.NextRowAsync(token).ConfigureAwait(false)) {
+      if (await command.NextRowAsync(token).ConfigureAwaitFalse()) {
         return true;
       }
 
       // We don't need the command anymore because all records are processed to the moment.
-      await command.DisposeAsync().ConfigureAwait(false);
+      await command.DisposeAsync().ConfigureAwaitFalse();
       return false;
     }
 
@@ -92,10 +93,10 @@ namespace Xtensive.Orm.Providers
     public async ValueTask DisposeAsync()
     {
       if (source is Command command) {
-        await command.DisposeAsync().ConfigureAwait(false);
+        await command.DisposeAsync().ConfigureAwaitFalse();
       }
       else {
-        await ((IAsyncEnumerator<Tuple>) source).DisposeAsync().ConfigureAwait(false);
+        await ((IAsyncEnumerator<Tuple>) source).DisposeAsync().ConfigureAwaitFalse();
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SimpleCommandProcessor.cs
@@ -93,10 +93,10 @@ namespace Xtensive.Orm.Providers
           task.ProcessWith(this, context);
           var loadTask = context.ActiveTasks.FirstOrDefault();
           if (loadTask!=null) {
-            await context.ActiveCommand.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await context.ActiveCommand.ExecuteReaderAsync(token).ConfigureAwaitFalse();
             var reader = context.ActiveCommand.CreateReader(loadTask.Request.GetAccessor(), token);
-            await using (reader.ConfigureAwait(false)) {
-              while (await reader.MoveNextAsync().ConfigureAwait(false)) {
+            await using (reader.ConfigureAwaitFalse()) {
+              while (await reader.MoveNextAsync().ConfigureAwaitFalse()) {
                 loadTask.Output.Add(reader.Current);
               }
             }
@@ -104,7 +104,7 @@ namespace Xtensive.Orm.Providers
           }
         }
         finally {
-          await context.ActiveCommand.DisposeSafelyAsync().ConfigureAwait(false);
+          await context.ActiveCommand.DisposeSafelyAsync().ConfigureAwaitFalse();
           ReleaseCommand(context);
         }
       }
@@ -132,7 +132,7 @@ namespace Xtensive.Orm.Providers
 
       token.ThrowIfCancellationRequested();
 
-      await ExecuteTasksAsync(context, token).ConfigureAwait(false);
+      await ExecuteTasksAsync(context, token).ConfigureAwaitFalse();
       context.AllowPartialExecution = oldValue;
 
       var lastRequestCommand = Factory.CreateCommand();
@@ -140,7 +140,7 @@ namespace Xtensive.Orm.Providers
       ValidateCommandParameters(commandPart);
       lastRequestCommand.AddPart(commandPart);
       token.ThrowIfCancellationRequested();
-      await lastRequestCommand.ExecuteReaderAsync(token).ConfigureAwait(false);
+      await lastRequestCommand.ExecuteReaderAsync(token).ConfigureAwaitFalse();
       return lastRequestCommand.CreateReader(lastRequest.GetAccessor());
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandWithDataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandWithDataReader.cs
@@ -26,8 +26,8 @@ namespace Xtensive.Orm.Providers
     public async ValueTask DisposeAsync()
     {
       // Dispose the reader first, at least firebird provider requires it
-      await Reader.DisposeAsync().ConfigureAwait(false);
-      await Command.DisposeAsync().ConfigureAwait(false);
+      await Reader.DisposeAsync().ConfigureAwaitFalse();
+      await Command.DisposeAsync().ConfigureAwaitFalse();
     }
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
@@ -40,9 +40,9 @@ namespace Xtensive.Orm.Providers
     public async Task<CommandWithDataReader> ExecuteReaderAsync(
       ISqlCompileUnit statement, CommandBehavior commandBehavior, CancellationToken token = default)
     {
-      await EnsureConnectionIsOpenAsync(token).ConfigureAwait(false);
+      await EnsureConnectionIsOpenAsync(token).ConfigureAwaitFalse();
       return await ExecuteReaderAsync(
-        connection.CreateCommand(Compile(statement)), commandBehavior, token).ConfigureAwait(false);
+        connection.CreateCommand(Compile(statement)), commandBehavior, token).ConfigureAwaitFalse();
     }
 
     public int ExecuteNonQuery(ISqlCompileUnit statement)
@@ -54,10 +54,10 @@ namespace Xtensive.Orm.Providers
 
     public async Task<int> ExecuteNonQueryAsync(ISqlCompileUnit statement, CancellationToken token = default)
     {
-      await EnsureConnectionIsOpenAsync(token).ConfigureAwait(false);
+      await EnsureConnectionIsOpenAsync(token).ConfigureAwaitFalse();
       var command = connection.CreateCommand(Compile(statement));
-      await using (command.ConfigureAwait(false)) {
-        return await driver.ExecuteNonQueryAsync(session, command, token).ConfigureAwait(false);
+      await using (command.ConfigureAwaitFalse()) {
+        return await driver.ExecuteNonQueryAsync(session, command, token).ConfigureAwaitFalse();
       }
     }
 
@@ -70,10 +70,10 @@ namespace Xtensive.Orm.Providers
 
     public async Task<object> ExecuteScalarAsync(ISqlCompileUnit statement, CancellationToken token = default)
     {
-      await EnsureConnectionIsOpenAsync(token).ConfigureAwait(false);
+      await EnsureConnectionIsOpenAsync(token).ConfigureAwaitFalse();
       var command = connection.CreateCommand(Compile(statement));
-      await using (command.ConfigureAwait(false)) {
-        return await driver.ExecuteScalarAsync(session, command, token).ConfigureAwait(false);
+      await using (command.ConfigureAwaitFalse()) {
+        return await driver.ExecuteScalarAsync(session, command, token).ConfigureAwaitFalse();
       }
     }
 
@@ -90,9 +90,9 @@ namespace Xtensive.Orm.Providers
     public async Task<CommandWithDataReader> ExecuteReaderAsync(
       string commandText, CommandBehavior commandBehavior, CancellationToken token = default)
     {
-      await EnsureConnectionIsOpenAsync(token).ConfigureAwait(false);
+      await EnsureConnectionIsOpenAsync(token).ConfigureAwaitFalse();
       return await ExecuteReaderAsync(
-        connection.CreateCommand(commandText), commandBehavior, token).ConfigureAwait(false);
+        connection.CreateCommand(commandText), commandBehavior, token).ConfigureAwaitFalse();
     }
 
     public int ExecuteNonQuery(string commandText)
@@ -104,10 +104,10 @@ namespace Xtensive.Orm.Providers
 
     public async Task<int> ExecuteNonQueryAsync(string commandText, CancellationToken token = default)
     {
-      await EnsureConnectionIsOpenAsync(token).ConfigureAwait(false);
+      await EnsureConnectionIsOpenAsync(token).ConfigureAwaitFalse();
       var command = connection.CreateCommand(commandText);
-      await using (command.ConfigureAwait(false)) {
-        return await driver.ExecuteNonQueryAsync(session, command, token).ConfigureAwait(false);
+      await using (command.ConfigureAwaitFalse()) {
+        return await driver.ExecuteNonQueryAsync(session, command, token).ConfigureAwaitFalse();
       }
     }
 
@@ -120,10 +120,10 @@ namespace Xtensive.Orm.Providers
 
     public async Task<object> ExecuteScalarAsync(string commandText, CancellationToken token = default)
     {
-      await EnsureConnectionIsOpenAsync(token).ConfigureAwait(false);
+      await EnsureConnectionIsOpenAsync(token).ConfigureAwaitFalse();
       var command = connection.CreateCommand(commandText);
-      await using (command.ConfigureAwait(false)) {
-        return await driver.ExecuteScalarAsync(session, command, token).ConfigureAwait(false);
+      await using (command.ConfigureAwaitFalse()) {
+        return await driver.ExecuteScalarAsync(session, command, token).ConfigureAwaitFalse();
       }
     }
 
@@ -141,13 +141,13 @@ namespace Xtensive.Orm.Providers
 
     public async Task ExecuteManyAsync(IEnumerable<string> statements, CancellationToken token = default)
     {
-      await EnsureConnectionIsOpenAsync(token).ConfigureAwait(false);
+      await EnsureConnectionIsOpenAsync(token).ConfigureAwaitFalse();
 
       if (driver.ProviderInfo.Supports(ProviderFeatures.Batches)) {
-        await ExecuteManyBatchedAsync(statements, token).ConfigureAwait(false);
+        await ExecuteManyBatchedAsync(statements, token).ConfigureAwaitFalse();
       }
       else {
-        await ExecuteManyByOneAsync(statements, token).ConfigureAwait(false);
+        await ExecuteManyByOneAsync(statements, token).ConfigureAwaitFalse();
       }
     }
 
@@ -160,8 +160,8 @@ namespace Xtensive.Orm.Providers
     public async Task<SqlExtractionResult> ExtractAsync(
       IEnumerable<SqlExtractionTask> tasks, CancellationToken token = default)
     {
-      await EnsureConnectionIsOpenAsync(token).ConfigureAwait(false);
-      return await driver.ExtractAsync(connection, tasks, token).ConfigureAwait(false);
+      await EnsureConnectionIsOpenAsync(token).ConfigureAwaitFalse();
+      return await driver.ExtractAsync(connection, tasks, token).ConfigureAwaitFalse();
     }
 
     #region Private / internal methods
@@ -186,8 +186,8 @@ namespace Xtensive.Orm.Providers
         }
 
         var command = connection.CreateCommand(statement);
-        await using (command.ConfigureAwait(false)) {
-          await driver.ExecuteNonQueryAsync(session, command, token).ConfigureAwait(false);
+        await using (command.ConfigureAwaitFalse()) {
+          await driver.ExecuteNonQueryAsync(session, command, token).ConfigureAwaitFalse();
         }
       }
     }
@@ -216,8 +216,8 @@ namespace Xtensive.Orm.Providers
         }
 
         var command = connection.CreateCommand(batch);
-        await using (command.ConfigureAwait(false)) {
-          await driver.ExecuteNonQueryAsync(session, command, token).ConfigureAwait(false);
+        await using (command.ConfigureAwaitFalse()) {
+          await driver.ExecuteNonQueryAsync(session, command, token).ConfigureAwaitFalse();
         }
       }
     }
@@ -274,10 +274,10 @@ namespace Xtensive.Orm.Providers
     {
       DbDataReader reader;
       try {
-        reader = await driver.ExecuteReaderAsync(session, command, commandBehavior, token).ConfigureAwait(false);
+        reader = await driver.ExecuteReaderAsync(session, command, commandBehavior, token).ConfigureAwaitFalse();
       }
       catch {
-        await command.DisposeAsync().ConfigureAwait(false);
+        await command.DisposeAsync().ConfigureAwaitFalse();
         throw;
       }
       return new CommandWithDataReader(command, reader);

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlIncludeProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlIncludeProvider.cs
@@ -76,13 +76,13 @@ namespace Xtensive.Orm.Providers
 
     protected internal override async Task OnBeforeEnumerateAsync(Rse.Providers.EnumerationContext context, CancellationToken token)
     {
-      await base.OnBeforeEnumerateAsync(context, token).ConfigureAwait(false);
+      await base.OnBeforeEnumerateAsync(context, token).ConfigureAwaitFalse();
       var parameterContext = ((EnumerationContext) context).ParameterContext;
       switch (Origin.Algorithm) {
         case IncludeAlgorithm.Auto:
           var filterData = filterDataSource.Invoke(parameterContext).ToList();
           if (filterData.Count > DomainHandler.Domain.Configuration.MaxNumberOfConditions)
-            await LockAndStoreAsync(context, filterData, token).ConfigureAwait(false);
+            await LockAndStoreAsync(context, filterData, token).ConfigureAwaitFalse();
           else
             parameterContext.SetValue(CreateFilterParameter(tableDescriptor), filterData);
           break;
@@ -90,7 +90,7 @@ namespace Xtensive.Orm.Providers
           // nothing
           break;
         case IncludeAlgorithm.TemporaryTable:
-          await LockAndStoreAsync(context, filterDataSource.Invoke(parameterContext), token).ConfigureAwait(false);
+          await LockAndStoreAsync(context, filterDataSource.Invoke(parameterContext), token).ConfigureAwaitFalse();
           break;
         default:
           throw new ArgumentOutOfRangeException("Origin.Algorithm");

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlProvider.cs
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Providers
     {
       var storageContext = (EnumerationContext)context;
       var executor = storageContext.Session.Services.Demand<IProviderExecutor>();
-      return await executor.ExecuteTupleReaderAsync(Request, storageContext.ParameterContext, token).ConfigureAwait(false);
+      return await executor.ExecuteTupleReaderAsync(Request, storageContext.ParameterContext, token).ConfigureAwaitFalse();
     }
 
     #region ToString related methods

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.Fetching.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.Fetching.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 using Xtensive.Orm.Internals.Prefetch;
 using Xtensive.Orm.Model;
 using TypeInfo = Xtensive.Orm.Model.TypeInfo;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IProviderExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IProviderExecutor.cs
@@ -31,10 +31,10 @@ namespace Xtensive.Orm.Providers
     async Task<DataReader> IProviderExecutor.ExecuteTupleReaderAsync(QueryRequest request,
       ParameterContext parameterContext, CancellationToken token)
     {
-      await PrepareAsync(token).ConfigureAwait(false);
+      await PrepareAsync(token).ConfigureAwaitFalse();
       var context = new CommandProcessorContext(parameterContext);
-      await using (context.ConfigureAwait(false)) {
-        return await commandProcessor.ExecuteTasksWithReaderAsync(request, context, token).ConfigureAwait(false);
+      await using (context.ConfigureAwaitFalse()) {
+        return await commandProcessor.ExecuteTasksWithReaderAsync(request, context, token).ConfigureAwaitFalse();
       }
     }
 
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Providers
     async Task IProviderExecutor.StoreAsync(IPersistDescriptor descriptor, IEnumerable<Tuple> tuples,
       ParameterContext parameterContext, CancellationToken token)
     {
-      await PrepareAsync(token).ConfigureAwait(false);
+      await PrepareAsync(token).ConfigureAwaitFalse();
 
       StoreInternal(descriptor, tuples);
 
@@ -79,7 +79,7 @@ namespace Xtensive.Orm.Providers
     {
       using (var context = new CommandProcessorContext(parameterContext)) {
         if (isAsync) {
-          await commandProcessor.ExecuteTasksAsync(context, token).ConfigureAwait(false);
+          await commandProcessor.ExecuteTasksAsync(context, token).ConfigureAwaitFalse();
         }
         else {
           commandProcessor.ExecuteTasks(context);

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlStoreProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlStoreProvider.cs
@@ -6,6 +6,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 using Xtensive.Orm.Rse.Providers;
 
 namespace Xtensive.Orm.Providers
@@ -35,8 +36,8 @@ namespace Xtensive.Orm.Providers
     /// <inheritdoc/>
     protected internal override async Task OnBeforeEnumerateAsync(Rse.Providers.EnumerationContext context, CancellationToken token)
     {
-      await base.OnBeforeEnumerateAsync(context, token).ConfigureAwait(false);
-      await LockAndStoreAsync(context, Source.ToEnumerable(context), token).ConfigureAwait(false);
+      await base.OnBeforeEnumerateAsync(context, token).ConfigureAwaitFalse();
+      await LockAndStoreAsync(context, Source.ToEnumerable(context), token).ConfigureAwaitFalse();
     }
 
     protected internal override void OnAfterEnumerate(Rse.Providers.EnumerationContext context)

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlTemporaryDataProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlTemporaryDataProvider.cs
@@ -43,7 +43,7 @@ namespace Xtensive.Orm.Providers
         return;
       storageContext.SetValue(this, TemporaryTableLockName, tableLock);
       var executor = storageContext.Session.Services.Demand<IProviderExecutor>();
-      await executor.StoreAsync(tableDescriptor, data, storageContext.ParameterContext, token).ConfigureAwait(false);
+      await executor.StoreAsync(tableDescriptor, data, storageContext.ParameterContext, token).ConfigureAwaitFalse();
     }
 
     protected bool ClearAndUnlock(Rse.Providers.EnumerationContext context)

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -9,6 +9,7 @@ using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 using Xtensive.Sql;
 
@@ -105,10 +106,10 @@ namespace Xtensive.Orm.Providers
 
       try {
         if (!string.IsNullOrEmpty(script)) {
-          await connection.OpenAndInitializeAsync(script, cancellationToken).ConfigureAwait(false);
+          await connection.OpenAndInitializeAsync(script, cancellationToken).ConfigureAwaitFalse();
         }
         else {
-          await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+          await connection.OpenAsync(cancellationToken).ConfigureAwaitFalse();
         }
       }
       catch (OperationCanceledException) {
@@ -130,7 +131,7 @@ namespace Xtensive.Orm.Providers
       Session session, SqlConnection connection, CancellationToken cancellationToken)
     {
       if (connection.State != ConnectionState.Open) {
-        await OpenConnectionAsync(session, connection, cancellationToken).ConfigureAwait(false);
+        await OpenConnectionAsync(session, connection, cancellationToken).ConfigureAwaitFalse();
       }
     }
 
@@ -163,7 +164,7 @@ namespace Xtensive.Orm.Providers
       }
 
       try {
-        await connection.CloseAsync().ConfigureAwait(false);
+        await connection.CloseAsync().ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
@@ -191,7 +192,7 @@ namespace Xtensive.Orm.Providers
       }
 
       try {
-        await connection.DisposeAsync().ConfigureAwait(false);
+        await connection.DisposeAsync().ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
@@ -226,7 +227,7 @@ namespace Xtensive.Orm.Providers
       isolationLevel ??= IsolationLevelConverter.Convert(GetConfiguration(session).DefaultIsolationLevel);
 
       try {
-        await connection.BeginTransactionAsync(isolationLevel.Value, token).ConfigureAwait(false);
+        await connection.BeginTransactionAsync(isolationLevel.Value, token).ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
@@ -255,7 +256,7 @@ namespace Xtensive.Orm.Providers
       }
 
       try {
-        await connection.CommitAsync(token).ConfigureAwait(false);
+        await connection.CommitAsync(token).ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
@@ -284,7 +285,7 @@ namespace Xtensive.Orm.Providers
       }
 
       try {
-        await connection.RollbackAsync(token).ConfigureAwait(false);
+        await connection.RollbackAsync(token).ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
@@ -321,7 +322,7 @@ namespace Xtensive.Orm.Providers
       }
 
       try {
-        await connection.MakeSavepointAsync(name, token).ConfigureAwait(false);
+        await connection.MakeSavepointAsync(name, token).ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
@@ -358,7 +359,7 @@ namespace Xtensive.Orm.Providers
       }
 
       try {
-        await connection.RollbackToSavepointAsync(name, token).ConfigureAwait(false);
+        await connection.RollbackToSavepointAsync(name, token).ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
@@ -387,7 +388,7 @@ namespace Xtensive.Orm.Providers
       }
 
       try {
-        await connection.ReleaseSavepointAsync(name, token).ConfigureAwait(false);
+        await connection.ReleaseSavepointAsync(name, token).ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
@@ -466,7 +467,7 @@ namespace Xtensive.Orm.Providers
 
       TResult result;
       try {
-        result = await action(command, commandBehavior, cancellationToken).ConfigureAwait(false);
+        result = await action(command, commandBehavior, cancellationToken).ConfigureAwaitFalse();
       }
       catch (OperationCanceledException) {
         throw;

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Providers
     public async Task<SqlExtractionResult> ExtractAsync(
       SqlConnection connection, IEnumerable<SqlExtractionTask> tasks, CancellationToken token)
     {
-      var result = await underlyingDriver.ExtractAsync(connection, tasks, token).ConfigureAwait(false);
+      var result = await underlyingDriver.ExtractAsync(connection, tasks, token).ConfigureAwaitFalse();
       FixExtractionResult(result);
       return result;
     }
@@ -239,7 +239,7 @@ namespace Xtensive.Orm.Providers
       };
 
       var driver = await driverFactory.GetDriverAsync(configuration.ConnectionInfo, driverConfiguration, token)
-        .ConfigureAwait(false);
+        .ConfigureAwaitFalse();
       var providerInfo = ProviderInfoBuilder.Build(configuration.ConnectionInfo.Provider, driver);
 
       return new StorageDriver(driver, providerInfo, configuration, GetNullModel, factories);

--- a/Orm/Xtensive.Orm/Orm/QueryResult.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryResult.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Xtensive.Core;
 using Xtensive.Orm.Linq.Materialization;
 
 namespace Xtensive.Orm
@@ -55,7 +56,7 @@ namespace Xtensive.Orm
     {
       EnsureResultsAlive();
       var enumerator = reader.AsAsyncEnumerator();
-      while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
+      while (await enumerator.MoveNextAsync().ConfigureAwaitFalse()) {
         yield return enumerator.Current;
       }
     }

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -1460,7 +1460,7 @@ namespace Xtensive.Orm
       CancellationToken cancellationToken = default)
     {
       var list = new List<TSource>();
-      var asyncSource = source.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false);
+      var asyncSource = source.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse();
       await foreach (var element in asyncSource) {
         list.Add(element);
       }
@@ -1482,7 +1482,7 @@ namespace Xtensive.Orm
     /// array that contains values from the input sequence.</returns>
     public static async Task<TSource[]> ToArrayAsync<TSource>(this IQueryable<TSource> source,
       CancellationToken cancellationToken = default) =>
-      (await source.ToListAsync(cancellationToken).ConfigureAwait(false)).ToArray();
+      (await source.ToListAsync(cancellationToken).ConfigureAwaitFalse()).ToArray();
 
     /// <summary>
     /// Creates a <see cref="Dictionary{TKey, TSource}"/> from an <see cref="IQueryable{TSource}"/>
@@ -1510,7 +1510,7 @@ namespace Xtensive.Orm
         itemParam[0]);
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TSource>>>(body, itemParam));
       var dictionary = new Dictionary<TKey, TSource>();
-      var asyncSource = query.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false);
+      var asyncSource = query.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse();
       await foreach (var tuple in asyncSource) {
         dictionary.Add(tuple.Item1, tuple.Item2);
       }
@@ -1548,7 +1548,7 @@ namespace Xtensive.Orm
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TValue>>>(body, itemParam));
       var dictionary = new Dictionary<TKey, TValue>();
-      var asyncSource = query.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false);
+      var asyncSource = query.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse();
       await foreach (var tuple in asyncSource) {
         dictionary.Add(tuple.Item1, tuple.Item2);
       }
@@ -1572,7 +1572,7 @@ namespace Xtensive.Orm
       CancellationToken cancellationToken = default)
     {
       var hashSet = new HashSet<TSource>();
-      var asyncSource = source.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false);
+      var asyncSource = source.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse();
       await foreach (var element in asyncSource) {
         hashSet.Add(element);
       }
@@ -1604,7 +1604,7 @@ namespace Xtensive.Orm
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         itemParam[0]);
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TSource>>>(body, itemParam));
-      var queryResult = await query.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+      var queryResult = await query.ExecuteAsync(cancellationToken).ConfigureAwaitFalse();
       return queryResult.ToLookup(tuple => tuple.Item1, tuple => tuple.Item2);
     }
 
@@ -1637,7 +1637,7 @@ namespace Xtensive.Orm
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TValue>>>(body, itemParam));
-      var queryResult = await query.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+      var queryResult = await query.ExecuteAsync(cancellationToken).ConfigureAwaitFalse();
       return queryResult.ToLookup(tuple => tuple.Item1, tuple => tuple.Item2);
     }
 

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -316,7 +316,7 @@ namespace Xtensive.Orm
     public static async Task<QueryResult<T>> ExecuteAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
     {
       return source.Provider is QueryProvider queryProvider
-        ? await queryProvider.ExecuteSequenceAsync<T>(source.Expression, cancellationToken).ConfigureAwait(false)
+        ? await queryProvider.ExecuteSequenceAsync<T>(source.Expression, cancellationToken).ConfigureAwaitFalse()
         : new QueryResult<T>(source.AsEnumerable());
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Executable/ExecutableRawProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Executable/ExecutableRawProvider.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 using Xtensive.Orm.Providers;
 using Tuple = Xtensive.Tuples.Tuple;
 
@@ -32,7 +33,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <inheritdoc/>
     protected internal override async Task OnBeforeEnumerateAsync(EnumerationContext context, CancellationToken token)
     {
-      await base.OnBeforeEnumerateAsync(context, token).ConfigureAwait(false);
+      await base.OnBeforeEnumerateAsync(context, token).ConfigureAwaitFalse();
       var parameterContext = ((Xtensive.Orm.Providers.EnumerationContext) context).ParameterContext;
       SetValue(context, CachedSourceName, Origin.CompiledSource.Invoke(parameterContext));
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/ExecutableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/ExecutableProvider.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Rse.Providers
       token.ThrowIfCancellationRequested();
       foreach (var source in Sources) {
         if (source is ExecutableProvider ep) {
-          await ep.OnBeforeEnumerateAsync(context, token).ConfigureAwait(false);
+          await ep.OnBeforeEnumerateAsync(context, token).ConfigureAwaitFalse();
         }
       }
     }
@@ -162,8 +162,8 @@ namespace Xtensive.Orm.Rse.Providers
     {
       ArgumentValidator.EnsureArgumentNotNull(session, nameof(session));
       var enumerationContext =
-        await session.CreateEnumerationContextAsync(parameterContext, token).ConfigureAwait(false);
-      return await RecordSetReader.CreateAsync(enumerationContext, this, token).ConfigureAwait(false);
+        await session.CreateEnumerationContextAsync(parameterContext, token).ConfigureAwaitFalse();
+      return await RecordSetReader.CreateAsync(enumerationContext, this, token).ConfigureAwaitFalse();
     }
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetReader.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 using Xtensive.Orm.Providers;
 using Xtensive.Orm.Rse.Providers;
 using EnumerationContext = Xtensive.Orm.Rse.Providers.EnumerationContext;
@@ -106,7 +107,7 @@ namespace Xtensive.Orm.Rse
           goto case State.InProgress;
         case State.InProgress:
           try {
-            if (await dataReader.MoveNextAsync().ConfigureAwait(false)) {
+            if (await dataReader.MoveNextAsync().ConfigureAwaitFalse()) {
               return true;
             }
           }
@@ -141,14 +142,14 @@ namespace Xtensive.Orm.Rse
 
       try {
         dataReader = executeAsync
-          ? await provider.OnEnumerateAsync(context, token).ConfigureAwait(false)
+          ? await provider.OnEnumerateAsync(context, token).ConfigureAwaitFalse()
           : provider.OnEnumerate(context);
 
         if (isGreedy && !dataReader.IsInMemory) {
           var tuples = new List<Tuple>();
           if (executeAsync) {
-            await using (dataReader.ConfigureAwait(false)) {
-              while (await dataReader.MoveNextAsync().ConfigureAwait(false)) {
+            await using (dataReader.ConfigureAwaitFalse()) {
+              while (await dataReader.MoveNextAsync().ConfigureAwaitFalse()) {
                 tuples.Add(dataReader.Current);
               }
             }
@@ -194,7 +195,7 @@ namespace Xtensive.Orm.Rse
     public async ValueTask DisposeAsync()
     {
       if (state != State.New) {
-        await dataReader.DisposeAsync().ConfigureAwait(false);
+        await dataReader.DisposeAsync().ConfigureAwaitFalse();
       }
       enumerationScope?.Dispose();
     }
@@ -242,7 +243,7 @@ namespace Xtensive.Orm.Rse
       EnumerationContext context, ExecutableProvider provider, CancellationToken token)
     {
       var recordSet = new RecordSetReader(context, provider, token);
-      await recordSet.Prepare(true).ConfigureAwait(false);
+      await recordSet.Prepare(true).ConfigureAwaitFalse();
       return recordSet;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Session.Cache.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Cache.cs
@@ -71,7 +71,7 @@ namespace Xtensive.Orm
         return;
       using (Activate()) {
         if (!LazyKeyGenerationIsEnabled) {
-          await Persist(PersistReason.RemapEntityKeys, isAsync, token).ConfigureAwait(false);
+          await Persist(PersistReason.RemapEntityKeys, isAsync, token).ConfigureAwaitFalse();
           Invalidate();
         }
         if (IsDebugEventLoggingEnabled) {

--- a/Orm/Xtensive.Orm/Orm/Session.Persist.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Persist.cs
@@ -81,10 +81,10 @@ namespace Xtensive.Orm
     public async Task SaveChangesAsync(CancellationToken token = default)
     {
       if (Configuration.Supports(SessionOptions.NonTransactionalEntityStates)) {
-        await SaveLocalChangesAsync(token).ConfigureAwait(false);
+        await SaveLocalChangesAsync(token).ConfigureAwaitFalse();
       }
       else {
-        await PersistAsync(PersistReason.Manual, token).ConfigureAwait(false);
+        await PersistAsync(PersistReason.Manual, token).ConfigureAwaitFalse();
       }
     }
 
@@ -109,7 +109,7 @@ namespace Xtensive.Orm
     internal void Persist(PersistReason reason) => Persist(reason, false).GetAwaiter().GetResult();
 
     internal async Task PersistAsync(PersistReason reason, CancellationToken token = default) =>
-      await Persist(reason, true, token).ConfigureAwait(false);
+      await Persist(reason, true, token).ConfigureAwaitFalse();
 
     private async ValueTask Persist(PersistReason reason, bool isAsync, CancellationToken token = default)
     {
@@ -155,14 +155,14 @@ namespace Xtensive.Orm
           }
 
           if (LazyKeyGenerationIsEnabled) {
-            await RemapEntityKeys(remapper.Remap(itemsToPersist), isAsync, token).ConfigureAwait(false);
+            await RemapEntityKeys(remapper.Remap(itemsToPersist), isAsync, token).ConfigureAwaitFalse();
           }
 
           ApplyEntitySetsChanges();
           var persistIsSuccessful = false;
           try {
             if (isAsync) {
-              await Handler.PersistAsync(itemsToPersist, reason == PersistReason.Query, token).ConfigureAwait(false);
+              await Handler.PersistAsync(itemsToPersist, reason == PersistReason.Query, token).ConfigureAwaitFalse();
             }
             else {
               Handler.Persist(itemsToPersist, reason == PersistReason.Query);
@@ -215,7 +215,7 @@ namespace Xtensive.Orm
       finally {
         IsPersisting = false;
         if (isAsync) {
-          await ts.DisposeAsync().ConfigureAwait(false);
+          await ts.DisposeAsync().ConfigureAwaitFalse();
         }
         else {
           ts.Dispose();
@@ -301,9 +301,9 @@ namespace Xtensive.Orm
     {
       Validate();
       var transaction = OpenTransaction(TransactionOpenMode.New);
-      await using (transaction.ConfigureAwait(false)) {
+      await using (transaction.ConfigureAwaitFalse()) {
         try {
-          await PersistAsync(PersistReason.Manual, token).ConfigureAwait(false);
+          await PersistAsync(PersistReason.Manual, token).ConfigureAwaitFalse();
         }
         finally {
           transaction.Complete();

--- a/Orm/Xtensive.Orm/Orm/Session.QueryTasks.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.QueryTasks.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 using Xtensive.Orm.Internals;
 
 
@@ -41,10 +42,10 @@ namespace Xtensive.Orm
     internal async Task<bool> ExecuteInternalDelayedQueriesAsync(bool skipPersist, CancellationToken token = default)
     {
       if (!skipPersist) {
-        await PersistAsync(PersistReason.Other, token).ConfigureAwait(false);
+        await PersistAsync(PersistReason.Other, token).ConfigureAwaitFalse();
       }
 
-      return await ProcessInternalDelayedQueriesAsync(false, token).ConfigureAwait(false);
+      return await ProcessInternalDelayedQueriesAsync(false, token).ConfigureAwaitFalse();
     }
 
     internal bool ExecuteUserDefinedDelayedQueries(bool skipPersist)
@@ -60,11 +61,11 @@ namespace Xtensive.Orm
     {
       token.ThrowIfCancellationRequested();
       if (!skipPersist) {
-        await PersistAsync(PersistReason.Other, token).ConfigureAwait(false);
+        await PersistAsync(PersistReason.Other, token).ConfigureAwaitFalse();
       }
 
       token.ThrowIfCancellationRequested();
-      return await ProcessUserDefinedDelayedQueriesAsync(false, token).ConfigureAwait(false);
+      return await ProcessUserDefinedDelayedQueriesAsync(false, token).ConfigureAwaitFalse();
     }
 
     private bool ProcessInternalDelayedQueries(bool allowPartialExecution)
@@ -90,7 +91,7 @@ namespace Xtensive.Orm
 
       try {
         await Handler.ExecuteQueryTasksAsync(
-          internalQueryTasks.Where(t=>t.LifetimeToken.IsActive), allowPartialExecution, token).ConfigureAwait(false);
+          internalQueryTasks.Where(t=>t.LifetimeToken.IsActive), allowPartialExecution, token).ConfigureAwaitFalse();
         return true;
       }
       finally {
@@ -122,7 +123,7 @@ namespace Xtensive.Orm
       var aliveTasks = new List<QueryTask>(userDefinedQueryTasks.Count);
       aliveTasks.AddRange(userDefinedQueryTasks.Where(t => t.LifetimeToken.IsActive));
       userDefinedQueryTasks.Clear();
-      await Handler.ExecuteQueryTasksAsync(aliveTasks, allowPartialExecution, token).ConfigureAwait(false);
+      await Handler.ExecuteQueryTasksAsync(aliveTasks, allowPartialExecution, token).ConfigureAwaitFalse();
       return true;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
@@ -8,6 +8,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Internals;
 using Xtensive.Orm.Providers;
@@ -167,7 +168,7 @@ namespace Xtensive.Orm
 
           return
             isAsync
-              ? await CreateOutermostTransactionAsync(isolationLevel, isAutomatic, token).ConfigureAwait(false)
+              ? await CreateOutermostTransactionAsync(isolationLevel, isAutomatic, token).ConfigureAwaitFalse()
               : CreateOutermostTransaction(isolationLevel, isAutomatic);
         case TransactionOpenMode.New:
           if (isolationLevel == IsolationLevel.Unspecified) {
@@ -177,8 +178,8 @@ namespace Xtensive.Orm
           return
             isAsync
               ? transaction != null
-                ? await CreateNestedTransactionAsync(isolationLevel, isAutomatic, token).ConfigureAwait(false)
-                : await CreateOutermostTransactionAsync(isolationLevel, isAutomatic, token).ConfigureAwait(false)
+                ? await CreateNestedTransactionAsync(isolationLevel, isAutomatic, token).ConfigureAwaitFalse()
+                : await CreateOutermostTransactionAsync(isolationLevel, isAutomatic, token).ConfigureAwaitFalse()
               : transaction != null
                 ? CreateNestedTransaction(isolationLevel, isAutomatic)
                 : CreateOutermostTransaction(isolationLevel, isAutomatic);
@@ -231,8 +232,8 @@ namespace Xtensive.Orm
     internal async Task BeginTransactionAsync(Transaction transaction, CancellationToken token)
     {
       if (transaction.IsNested) {
-        await PersistAsync(PersistReason.NestedTransaction, token).ConfigureAwait(false);
-        await Handler.CreateSavepointAsync(transaction, token).ConfigureAwait(false);
+        await PersistAsync(PersistReason.NestedTransaction, token).ConfigureAwaitFalse();
+        await Handler.CreateSavepointAsync(transaction, token).ConfigureAwaitFalse();
       }
       else {
         Handler.BeginTransaction(transaction);
@@ -249,7 +250,7 @@ namespace Xtensive.Orm
       Events.NotifyTransactionPrecommitting(transaction);
 
       if (isAsync) {
-        await PersistAsync(PersistReason.Commit).ConfigureAwait(false);
+        await PersistAsync(PersistReason.Commit).ConfigureAwaitFalse();
       }
       else {
         Persist(PersistReason.Commit);
@@ -263,7 +264,7 @@ namespace Xtensive.Orm
       Handler.CompletingTransaction(transaction);
       if (transaction.IsNested) {
         if (isAsync) {
-          await Handler.ReleaseSavepointAsync(transaction).ConfigureAwait(false);
+          await Handler.ReleaseSavepointAsync(transaction).ConfigureAwaitFalse();
         }
         else {
           Handler.ReleaseSavepoint(transaction);
@@ -271,7 +272,7 @@ namespace Xtensive.Orm
       }
       else {
         if (isAsync) {
-          await Handler.CommitTransactionAsync(transaction).ConfigureAwait(false);
+          await Handler.CommitTransactionAsync(transaction).ConfigureAwaitFalse();
         }
         else {
           Handler.CommitTransaction(transaction);
@@ -296,11 +297,11 @@ namespace Xtensive.Orm
         finally {
           try {
             if (Configuration.Supports(SessionOptions.SuppressRollbackExceptions)) {
-              await RollbackWithSuppression(transaction, isAsync).ConfigureAwait(false);
+              await RollbackWithSuppression(transaction, isAsync).ConfigureAwaitFalse();
             }
             else {
               if (isAsync) {
-                await RollbackAsync(transaction).ConfigureAwait(false);
+                await RollbackAsync(transaction).ConfigureAwaitFalse();
               }
               else {
                 Rollback(transaction);
@@ -324,7 +325,7 @@ namespace Xtensive.Orm
     {
       try {
         if (isAsync) {
-          await RollbackAsync(transaction).ConfigureAwait(false);
+          await RollbackAsync(transaction).ConfigureAwaitFalse();
         }
         else {
           Rollback(transaction);
@@ -348,10 +349,10 @@ namespace Xtensive.Orm
     private async ValueTask RollbackAsync(Transaction transaction)
     {
       if (transaction.IsNested) {
-        await Handler.RollbackToSavepointAsync(transaction).ConfigureAwait(false);
+        await Handler.RollbackToSavepointAsync(transaction).ConfigureAwaitFalse();
       }
       else {
-        await Handler.RollbackTransactionAsync(transaction).ConfigureAwait(false);
+        await Handler.RollbackTransactionAsync(transaction).ConfigureAwaitFalse();
       }
     }
 
@@ -461,7 +462,7 @@ namespace Xtensive.Orm
 
       Transaction = transaction;
       if (isAsync) {
-        await transaction.BeginAsync(token).ConfigureAwait(false);
+        await transaction.BeginAsync(token).ConfigureAwaitFalse();
       }
       else {
         transaction.Begin();

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -264,8 +264,8 @@ namespace Xtensive.Orm
 
     internal async Task<EnumerationContext> CreateEnumerationContextAsync(ParameterContext parameterContext, CancellationToken token)
     {
-      await PersistAsync(PersistReason.Query, token).ConfigureAwait(false);
-      _ = await ProcessUserDefinedDelayedQueriesAsync(true, token).ConfigureAwait(false);
+      await PersistAsync(PersistReason.Query, token).ConfigureAwaitFalse();
+      _ = await ProcessUserDefinedDelayedQueriesAsync(true, token).ConfigureAwaitFalse();
       return new Providers.EnumerationContext(this, parameterContext, GetEnumerationContextOptions());
     }
 
@@ -629,7 +629,7 @@ namespace Xtensive.Orm
 
         Services.DisposeSafely();
         if (isAsync) {
-          await Handler.DisposeSafelyAsync().ConfigureAwait(false);
+          await Handler.DisposeSafelyAsync().ConfigureAwaitFalse();
         }
         else {
           Handler.DisposeSafely();

--- a/Orm/Xtensive.Orm/Orm/StorageNodeManager.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNodeManager.cs
@@ -43,7 +43,7 @@ namespace Xtensive.Orm
     public async Task<bool> AddNodeAsync([NotNull] NodeConfiguration configuration, CancellationToken token = default)
     {
       var node = await UpgradingDomainBuilder.BuildNodeAsync(handlers.Domain, configuration, token)
-        .ConfigureAwait(false);
+        .ConfigureAwaitFalse();
       return handlers.StorageNodeRegistry.Add(node);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Transaction.cs
+++ b/Orm/Xtensive.Orm/Orm/Transaction.cs
@@ -182,7 +182,7 @@ namespace Xtensive.Orm
 
     internal async ValueTask BeginAsync(CancellationToken token)
     {
-      await Session.BeginTransactionAsync(this, token).ConfigureAwait(false);
+      await Session.BeginTransactionAsync(this, token).ConfigureAwaitFalse();
       if (Outer != null) {
         Outer.inner = this;
       }
@@ -199,10 +199,10 @@ namespace Xtensive.Orm
           throw new InvalidOperationException(Strings.ExCanNotCompleteOuterTransactionInnerTransactionIsActive);
         }
 
-        await Session.CommitTransaction(this, isAsync).ConfigureAwait(false);
+        await Session.CommitTransaction(this, isAsync).ConfigureAwaitFalse();
       }
       catch {
-        await Rollback(isAsync).ConfigureAwait(false);
+        await Rollback(isAsync).ConfigureAwaitFalse();
         throw;
       }
 
@@ -227,11 +227,11 @@ namespace Xtensive.Orm
       try {
         try {
           if (inner != null) {
-            await inner.Rollback(isAsync).ConfigureAwait(false);
+            await inner.Rollback(isAsync).ConfigureAwaitFalse();
           }
         }
         finally {
-          await Session.RollbackTransaction(this, isAsync).ConfigureAwait(false);
+          await Session.RollbackTransaction(this, isAsync).ConfigureAwaitFalse();
         }
       }
       finally {

--- a/Orm/Xtensive.Orm/Orm/TransactionScope.cs
+++ b/Orm/Xtensive.Orm/Orm/TransactionScope.cs
@@ -67,10 +67,10 @@ namespace Xtensive.Orm
         }
 
         if (IsCompleted) {
-          await Transaction.Commit(isAsync).ConfigureAwait(false);
+          await Transaction.Commit(isAsync).ConfigureAwaitFalse();
         }
         else {
-          await Transaction.Rollback(isAsync).ConfigureAwait(false);
+          await Transaction.Rollback(isAsync).ConfigureAwaitFalse();
         }
       }
       finally {

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataExtractor.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataExtractor.cs
@@ -32,7 +32,7 @@ namespace Xtensive.Orm.Upgrade
     public async Task ExtractTypesAsync(MetadataSet output, SqlExtractionTask task, CancellationToken token = default)
     {
       var types = new List<TypeMetadata>();
-      await ExtractTypesAsync(types, task, token).ConfigureAwait(false);
+      await ExtractTypesAsync(types, task, token).ConfigureAwaitFalse();
       output.Types.AddRange(types);
     }
 
@@ -45,7 +45,7 @@ namespace Xtensive.Orm.Upgrade
       CancellationToken token = default)
     {
       var assemblies = new List<AssemblyMetadata>();
-      await ExtractAssembliesAsync(assemblies, task, token).ConfigureAwait(false);
+      await ExtractAssembliesAsync(assemblies, task, token).ConfigureAwaitFalse();
       output.Assemblies.AddRange(assemblies);
     }
 
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Upgrade
       CancellationToken token = default)
     {
       var extensions = new List<ExtensionMetadata>();
-      await ExtractExtensionsAsync(extensions, task, token).ConfigureAwait(false);
+      await ExtractExtensionsAsync(extensions, task, token).ConfigureAwaitFalse();
       output.Extensions.AddRange(extensions);
     }
 
@@ -134,10 +134,10 @@ namespace Xtensive.Orm.Upgrade
     private async Task ExecuteQueryAsync<T>(ICollection<T> output, ISqlCompileUnit query, Func<DbDataReader, T> parser,
       CancellationToken token)
     {
-      var command = await executor.ExecuteReaderAsync(query, CommandBehavior.SequentialAccess, token).ConfigureAwait(false);
-      await using (command.ConfigureAwait(false)) {
+      var command = await executor.ExecuteReaderAsync(query, CommandBehavior.SequentialAccess, token).ConfigureAwaitFalse();
+      await using (command.ConfigureAwaitFalse()) {
         var reader = command.Reader;
-        while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+        while (await reader.ReadAsync(token).ConfigureAwaitFalse()) {
           output.Add(parser.Invoke(reader));
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaExtractor.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaExtractor.cs
@@ -38,7 +38,7 @@ namespace Xtensive.Orm.Upgrade
       if (context.ExtractedModelCache!=null)
         return context.ExtractedModelCache;
 
-      var schemaExtractionResult = await GetSqlSchemaAsync(token).ConfigureAwait(false);
+      var schemaExtractionResult = await GetSqlSchemaAsync(token).ConfigureAwaitFalse();
       var converter = new SqlModelConverter(services, schemaExtractionResult, GetPartialIndexes());
       var result =  converter.Run();
       context.ExtractedModelCache = result;
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Upgrade
       }
 
       var sqlExtractionTasks = services.MappingResolver.GetSchemaTasks();
-      var sqlExtractionResult = await executor.ExtractAsync(sqlExtractionTasks, token).ConfigureAwait(false);
+      var sqlExtractionResult = await executor.ExtractAsync(sqlExtractionTasks, token).ConfigureAwaitFalse();
       var schema = new SchemaExtractionResult(sqlExtractionResult);
       var handledSchema = new IgnoreRulesHandler(schema, services.Configuration, services.MappingResolver).Handle();
       context.ExtractedSqlModelCache = handledSchema;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaUpgrader.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaUpgrader.cs
@@ -49,11 +49,11 @@ namespace Xtensive.Orm.Upgrade
       var result = TranslateActions(extractedSchema, sourceModel, targetModel, upgradeActions);
 
       foreach (var handler in context.OrderedUpgradeHandlers) {
-        await handler.OnBeforeExecuteActionsAsync(result, token).ConfigureAwait(false);
+        await handler.OnBeforeExecuteActionsAsync(result, token).ConfigureAwaitFalse();
       }
 
       await result.ProcessWithAsync(asyncStatementProcessor, ExecuteNonTransactionallyAsync, token)
-        .ConfigureAwait(false);
+        .ConfigureAwaitFalse();
     }
 
     private UpgradeActionSequence TranslateActions(SchemaExtractionResult extractedSchema, StorageModel sourceModel,
@@ -91,9 +91,9 @@ namespace Xtensive.Orm.Upgrade
 
     private async Task ExecuteNonTransactionallyAsync(IEnumerable<string> batch, CancellationToken token)
     {
-      await driver.CommitTransactionAsync(null, connection, token).ConfigureAwait(false);
-      await executor.ExecuteManyAsync(batch, token).ConfigureAwait(false);
-      await driver.BeginTransactionAsync(null, connection, null, token).ConfigureAwait(false);
+      await driver.CommitTransactionAsync(null, connection, token).ConfigureAwaitFalse();
+      await executor.ExecuteManyAsync(batch, token).ConfigureAwaitFalse();
+      await driver.BeginTransactionAsync(null, connection, null, token).ConfigureAwaitFalse();
     }
 
     private void ExecuteTransactionally(IEnumerable<string> batch) => executor.ExecuteMany(batch);

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlAsyncWorker.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlAsyncWorker.cs
@@ -26,15 +26,15 @@ namespace Xtensive.Orm.Upgrade
       var result = new SqlWorkerResult();
       var executor = new SqlExecutor(services.StorageDriver, services.Connection);
       if ((task & SqlWorkerTask.DropSchema) > 0) {
-        await DropSchemaAsync(services, executor, token).ConfigureAwait(false);
+        await DropSchemaAsync(services, executor, token).ConfigureAwaitFalse();
       }
 
       if ((task & SqlWorkerTask.ExtractSchema) > 0) {
-        result.Schema = await ExtractSchemaAsync(services, executor, token).ConfigureAwait(false);
+        result.Schema = await ExtractSchemaAsync(services, executor, token).ConfigureAwaitFalse();
       }
 
       if ((task & (SqlWorkerTask.ExtractMetadataTypes | SqlWorkerTask.ExtractMetadataAssemblies | SqlWorkerTask.ExtractMetadataExtension)) > 0) {
-        await ExtractMetadataAsync(services, executor, result, task, token).ConfigureAwait(false);
+        await ExtractMetadataAsync(services, executor, result, task, token).ConfigureAwaitFalse();
       }
 
       return result;
@@ -51,15 +51,15 @@ namespace Xtensive.Orm.Upgrade
         .Where(metadataTask => !ShouldSkipMetadataExtraction(mapping, result, metadataTask))) {
         try {
           if (task.HasFlag(SqlWorkerTask.ExtractMetadataAssemblies)) {
-            await metadataExtractor.ExtractAssembliesAsync(set, metadataTask, token).ConfigureAwait(false);
+            await metadataExtractor.ExtractAssembliesAsync(set, metadataTask, token).ConfigureAwaitFalse();
           }
 
           if (task.HasFlag(SqlWorkerTask.ExtractMetadataTypes)) {
-            await metadataExtractor.ExtractTypesAsync(set, metadataTask, token).ConfigureAwait(false);
+            await metadataExtractor.ExtractTypesAsync(set, metadataTask, token).ConfigureAwaitFalse();
           }
 
           if (task.HasFlag(SqlWorkerTask.ExtractMetadataExtension)) {
-            await metadataExtractor.ExtractExtensionsAsync(set, metadataTask, token).ConfigureAwait(false);
+            await metadataExtractor.ExtractExtensionsAsync(set, metadataTask, token).ConfigureAwaitFalse();
           }
         }
         catch (Exception exception) {
@@ -102,7 +102,7 @@ namespace Xtensive.Orm.Upgrade
       UpgradeServiceAccessor services, ISqlExecutor executor, CancellationToken token)
     {
       var extractionTasks = services.MappingResolver.GetSchemaTasks();
-      var extractionResult = await executor.ExtractAsync(extractionTasks, token).ConfigureAwait(false);
+      var extractionResult = await executor.ExtractAsync(extractionTasks, token).ConfigureAwaitFalse();
       var schema = new SchemaExtractionResult(extractionResult);
       return new IgnoreRulesHandler(schema, services.Configuration, services.MappingResolver).Handle();
     }
@@ -111,14 +111,14 @@ namespace Xtensive.Orm.Upgrade
       UpgradeServiceAccessor services, ISqlExecutor executor, CancellationToken token)
     {
       var driver = services.StorageDriver;
-      var extractionResult = await ExtractSchemaAsync(services, executor, token).ConfigureAwait(false);
+      var extractionResult = await ExtractSchemaAsync(services, executor, token).ConfigureAwaitFalse();
       var schemas = extractionResult.Catalogs.SelectMany(c => c.Schemas).ToList();
       var tables = schemas.SelectMany(s => s.Tables).ToList();
       var sequences = schemas.SelectMany(s => s.Sequences);
 
-      await DropForeignKeysAsync(driver, tables, executor, token).ConfigureAwait(false);
-      await DropTablesAsync(driver, tables, executor, token).ConfigureAwait(false);
-      await DropSequencesAsync(driver, sequences, executor,token).ConfigureAwait(false);
+      await DropForeignKeysAsync(driver, tables, executor, token).ConfigureAwaitFalse();
+      await DropTablesAsync(driver, tables, executor, token).ConfigureAwaitFalse();
+      await DropSequencesAsync(driver, sequences, executor,token).ConfigureAwaitFalse();
     }
 
     private static Task DropSequencesAsync(

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradeActionSequence.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradeActionSequence.cs
@@ -127,15 +127,15 @@ namespace Xtensive.Orm.Upgrade
       ArgumentValidator.EnsureArgumentNotNull(nonTransactionalProcessor, nameof(nonTransactionalProcessor));
 
       if (NonTransactionalPrologCommands.Count > 0) {
-        await nonTransactionalProcessor.Invoke(NonTransactionalPrologCommands, token).ConfigureAwait(false);
+        await nonTransactionalProcessor.Invoke(NonTransactionalPrologCommands, token).ConfigureAwaitFalse();
       }
 
       foreach (var batch in EnumerateTransactionalCommandBatches()) {
-        await regularProcessor.Invoke(batch, token).ConfigureAwait(false);
+        await regularProcessor.Invoke(batch, token).ConfigureAwaitFalse();
       }
 
       if (NonTransactionalEpilogCommands.Count > 0) {
-        await nonTransactionalProcessor.Invoke(NonTransactionalEpilogCommands, token).ConfigureAwait(false);
+        await nonTransactionalProcessor.Invoke(NonTransactionalEpilogCommands, token).ConfigureAwaitFalse();
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradeHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradeHandler.cs
@@ -197,7 +197,7 @@ namespace Xtensive.Orm.Upgrade
       var context = UpgradeContext;
       switch (context.Stage) {
         case UpgradeStage.Upgrading:
-          await OnUpgradeAsync(token).ConfigureAwait(false);
+          await OnUpgradeAsync(token).ConfigureAwaitFalse();
           break;
         case UpgradeStage.Final:
           break;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -78,7 +78,7 @@ namespace Xtensive.Orm.Upgrade
 
       using (context.Activate())
       using (context.Services) {
-        return await new UpgradingDomainBuilder(context).RunAsync(token).ConfigureAwait(false);
+        return await new UpgradingDomainBuilder(context).RunAsync(token).ConfigureAwaitFalse();
       }
     }
 
@@ -116,7 +116,7 @@ namespace Xtensive.Orm.Upgrade
 
       using (context.Activate())
       using (context.Services) {
-        await new UpgradingDomainBuilder(context).RunAsync(token).ConfigureAwait(false);
+        await new UpgradingDomainBuilder(context).RunAsync(token).ConfigureAwaitFalse();
         return context.StorageNode;
       }
     }
@@ -137,15 +137,15 @@ namespace Xtensive.Orm.Upgrade
 
     private async Task<Domain> RunAsync(CancellationToken token = default)
     {
-      await BuildServices(true, token).ConfigureAwait(false);
-      await OnPrepareAsync(token).ConfigureAwait(false);
+      await BuildServices(true, token).ConfigureAwaitFalse();
+      await OnPrepareAsync(token).ConfigureAwaitFalse();
 
       var domain = upgradeMode.IsMultistage()
-        ? await BuildMultistageDomainAsync(token).ConfigureAwait(false)
-        : await BuildSingleStageDomainAsync(token).ConfigureAwait(false);
+        ? await BuildMultistageDomainAsync(token).ConfigureAwaitFalse()
+        : await BuildSingleStageDomainAsync(token).ConfigureAwaitFalse();
 
-      await OnCompleteAsync(domain, token).ConfigureAwait(false);
-      await CompleteUpgradeTransactionAsync(token).ConfigureAwait(false);
+      await OnCompleteAsync(domain, token).ConfigureAwaitFalse();
+      await CompleteUpgradeTransactionAsync(token).ConfigureAwaitFalse();
       context.Services.ClearTemporaryResources();
 
       return domain;
@@ -209,19 +209,19 @@ namespace Xtensive.Orm.Upgrade
     {
       Domain finalDomain;
       var sqlAsyncWorker = StartSqlAsyncWorker(token);
-      await using (sqlAsyncWorker.ConfigureAwait(false)) {
+      await using (sqlAsyncWorker.ConfigureAwaitFalse()) {
         var domainBuilder = CreateDomainBuilder(UpgradeStage.Final);
         var finalDomainResult = CreateResult(domainBuilder);
-        await using (finalDomainResult.ConfigureAwait(false)) {
+        await using (finalDomainResult.ConfigureAwaitFalse()) {
           OnConfigureUpgradeDomain();
           using (var upgradeDomain = CreateDomainBuilder(UpgradeStage.Upgrading).Invoke()) {
-            await CompleteSqlWorkerAsync().ConfigureAwait(false);
-            await PerformUpgradeAsync(upgradeDomain, UpgradeStage.Upgrading, token).ConfigureAwait(false);
+            await CompleteSqlWorkerAsync().ConfigureAwaitFalse();
+            await PerformUpgradeAsync(upgradeDomain, UpgradeStage.Upgrading, token).ConfigureAwaitFalse();
           }
-          finalDomain = await finalDomainResult.GetAsync().ConfigureAwait(false);
+          finalDomain = await finalDomainResult.GetAsync().ConfigureAwaitFalse();
         }
       }
-      await PerformUpgradeAsync(finalDomain, UpgradeStage.Final, token).ConfigureAwait(false);
+      await PerformUpgradeAsync(finalDomain, UpgradeStage.Final, token).ConfigureAwaitFalse();
       return finalDomain;
     }
 
@@ -238,10 +238,10 @@ namespace Xtensive.Orm.Upgrade
     private async Task<Domain> BuildSingleStageDomainAsync(CancellationToken token)
     {
       var sqlAsyncWorker = StartSqlAsyncWorker(token);
-      await using (sqlAsyncWorker.ConfigureAwait(false)) {
+      await using (sqlAsyncWorker.ConfigureAwaitFalse()) {
         var domain = CreateDomainBuilder(UpgradeStage.Final).Invoke();
-        await CompleteSqlWorkerAsync().ConfigureAwait(false);
-        await PerformUpgradeAsync(domain, UpgradeStage.Final, token).ConfigureAwait(false);
+        await CompleteSqlWorkerAsync().ConfigureAwaitFalse();
+        await PerformUpgradeAsync(domain, UpgradeStage.Final, token).ConfigureAwaitFalse();
         return domain;
       }
     }
@@ -259,7 +259,7 @@ namespace Xtensive.Orm.Upgrade
         var driverFactory = (SqlDriverFactory) Activator.CreateInstance(descriptor.DriverFactory);
         var handlerFactory = (HandlerFactory) Activator.CreateInstance(descriptor.HandlerFactory);
         var driver = isAsync
-          ? await StorageDriver.CreateAsync(driverFactory, configuration, token).ConfigureAwait(false)
+          ? await StorageDriver.CreateAsync(driverFactory, configuration, token).ConfigureAwaitFalse()
           : StorageDriver.Create(driverFactory, configuration);
         services.HandlerFactory = handlerFactory;
         services.StorageDriver = driver;
@@ -272,9 +272,9 @@ namespace Xtensive.Orm.Upgrade
         services.NameBuilder = handlers.NameBuilder;
       }
 
-      await CreateConnection(services, isAsync, token).ConfigureAwait(false);
+      await CreateConnection(services, isAsync, token).ConfigureAwaitFalse();
       context.DefaultSchemaInfo = defaultSchemaInfo = isAsync
-        ? await services.StorageDriver.GetDefaultSchemaAsync(services.Connection, token).ConfigureAwait(false)
+        ? await services.StorageDriver.GetDefaultSchemaAsync(services.Connection, token).ConfigureAwaitFalse()
         : services.StorageDriver.GetDefaultSchema(services.Connection);
       services.MappingResolver = MappingResolver.Create(configuration, context.NodeConfiguration, defaultSchemaInfo);
       BuildExternalServices(services, configuration);
@@ -293,8 +293,8 @@ namespace Xtensive.Orm.Upgrade
 
       try {
         if (isAsync) {
-          await driver.OpenConnectionAsync(null, connection, token).ConfigureAwait(false);
-          await driver.BeginTransactionAsync(null, connection, null, token).ConfigureAwait(false);
+          await driver.OpenConnectionAsync(null, connection, token).ConfigureAwaitFalse();
+          await driver.BeginTransactionAsync(null, connection, null, token).ConfigureAwaitFalse();
         }
         else {
           driver.OpenConnection(null, connection);
@@ -303,7 +303,7 @@ namespace Xtensive.Orm.Upgrade
       }
       catch {
         if (isAsync) {
-          await connection.DisposeAsync().ConfigureAwait(false);
+          await connection.DisposeAsync().ConfigureAwaitFalse();
         }
         else {
           connection.Dispose();
@@ -436,19 +436,19 @@ namespace Xtensive.Orm.Upgrade
     {
       context.Stage = stage;
 
-      await OnBeforeStageAsync(token).ConfigureAwait(false);
+      await OnBeforeStageAsync(token).ConfigureAwaitFalse();
 
-      var session = await domain.OpenSessionAsync(SessionType.System, token).ConfigureAwait(false);
-      await using (session.ConfigureAwait(false)) {
+      var session = await domain.OpenSessionAsync(SessionType.System, token).ConfigureAwaitFalse();
+      await using (session.ConfigureAwaitFalse()) {
         using (session.Activate()) {
           var transaction = session.OpenTransaction();
-          await using (transaction.ConfigureAwait(false)) {
+          await using (transaction.ConfigureAwaitFalse()) {
             var upgrader = new SchemaUpgrader(context, session);
             var extractor = new SchemaExtractor(context, session);
-            await SynchronizeSchemaAsync(domain, upgrader, extractor, GetUpgradeMode(stage), token).ConfigureAwait(false);
-            var storageNode = BuildStorageNode(domain, await extractor.GetSqlSchemaAsync(token).ConfigureAwait(false));
+            await SynchronizeSchemaAsync(domain, upgrader, extractor, GetUpgradeMode(stage), token).ConfigureAwaitFalse();
+            var storageNode = BuildStorageNode(domain, await extractor.GetSqlSchemaAsync(token).ConfigureAwaitFalse());
             session.SetStorageNode(storageNode);
-            await OnStageAsync(session, token).ConfigureAwait(false);
+            await OnStageAsync(session, token).ConfigureAwaitFalse();
             transaction.Complete();
           }
         }
@@ -657,11 +657,11 @@ namespace Xtensive.Orm.Upgrade
           }
           var builder = ExtractedModelBuilderFactory.GetBuilder(context);
           context.ExtractedSqlModelCache = builder.Run();
-          await OnSchemaReadyAsync(token).ConfigureAwait(false);
+          await OnSchemaReadyAsync(token).ConfigureAwaitFalse();
           return; // Skipping comparison completely
         }
 
-        var extractedSchema = await extractor.GetSchemaAsync(token).ConfigureAwait(false);
+        var extractedSchema = await extractor.GetSchemaAsync(token).ConfigureAwaitFalse();
 
         // Hints
         var triplet = BuildTargetModelAndHints(extractedSchema);
@@ -676,7 +676,7 @@ namespace Xtensive.Orm.Upgrade
           UpgradeLog.Info(nameof(Strings.LogTargetSchema));
           targetSchema.Dump();
         }
-        await OnSchemaReadyAsync(token).ConfigureAwait(false);
+        await OnSchemaReadyAsync(token).ConfigureAwaitFalse();
 
         var briefExceptionFormat = domain.Configuration.SchemaSyncExceptionFormat==SchemaSyncExceptionFormat.Brief;
         var result = SchemaComparer.Compare(extractedSchema, targetSchema,
@@ -709,9 +709,9 @@ namespace Xtensive.Orm.Upgrade
             goto case SchemaUpgradeMode.Perform;
           case SchemaUpgradeMode.Recreate:
           case SchemaUpgradeMode.Perform:
-            var extractedSqlSchema = await extractor.GetSqlSchemaAsync(token).ConfigureAwait(false);
+            var extractedSqlSchema = await extractor.GetSqlSchemaAsync(token).ConfigureAwaitFalse();
             await upgrader.UpgradeSchemaAsync(
-              extractedSqlSchema, extractedSchema, targetSchema, result.UpgradeActions, token).ConfigureAwait(false);
+              extractedSqlSchema, extractedSchema, targetSchema, result.UpgradeActions, token).ConfigureAwaitFalse();
             if (result.UpgradeActions.Any())
               extractor.ClearCache();
             break;
@@ -755,7 +755,7 @@ namespace Xtensive.Orm.Upgrade
     private async ValueTask OnSchemaReadyAsync(CancellationToken token)
     {
       foreach (var handler in context.OrderedUpgradeHandlers) {
-        await handler.OnSchemaReadyAsync(token).ConfigureAwait(false);
+        await handler.OnSchemaReadyAsync(token).ConfigureAwaitFalse();
       }
     }
 
@@ -769,7 +769,7 @@ namespace Xtensive.Orm.Upgrade
     private async ValueTask OnPrepareAsync(CancellationToken token)
     {
       foreach (var handler in context.OrderedUpgradeHandlers) {
-        await handler.OnPrepareAsync(token).ConfigureAwait(false);
+        await handler.OnPrepareAsync(token).ConfigureAwaitFalse();
       }
     }
 
@@ -811,7 +811,7 @@ namespace Xtensive.Orm.Upgrade
         return;
       }
 
-      var result = await workerResult.GetAsync().ConfigureAwait(false);
+      var result = await workerResult.GetAsync().ConfigureAwaitFalse();
       context.Metadata = result.Metadata;
       if (result.Schema!=null) {
         context.ExtractedSqlModelCache = result.Schema;
@@ -828,7 +828,7 @@ namespace Xtensive.Orm.Upgrade
     private async ValueTask OnBeforeStageAsync(CancellationToken token)
     {
       foreach (var handler in context.OrderedUpgradeHandlers) {
-        await handler.OnBeforeStageAsync(token).ConfigureAwait(false);
+        await handler.OnBeforeStageAsync(token).ConfigureAwaitFalse();
       }
     }
 
@@ -850,7 +850,7 @@ namespace Xtensive.Orm.Upgrade
       context.Session = session;
       try {
         foreach (var handler in context.OrderedUpgradeHandlers) {
-          await handler.OnStageAsync(token).ConfigureAwait(false);
+          await handler.OnStageAsync(token).ConfigureAwaitFalse();
         }
       }
       finally {
@@ -872,7 +872,7 @@ namespace Xtensive.Orm.Upgrade
     private async ValueTask OnCompleteAsync(Domain domain, CancellationToken token)
     {
       foreach (var handler in context.OrderedUpgradeHandlers) {
-        await handler.OnCompleteAsync(domain, token).ConfigureAwait(false);
+        await handler.OnCompleteAsync(domain, token).ConfigureAwaitFalse();
       }
 
       foreach (var module in context.Modules) {

--- a/Orm/Xtensive.Orm/Sql/Model/Extractor.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/Extractor.cs
@@ -5,6 +5,7 @@
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Xtensive.Core;
 
 namespace Xtensive.Sql.Model
 {
@@ -130,8 +131,8 @@ namespace Xtensive.Sql.Model
       ISqlCompileUnit statement, CancellationToken token = default)
     {
       var command = Connection.CreateCommand(statement);
-      await using (command.ConfigureAwait(false)) {
-        return await command.ExecuteReaderAsync(token).ConfigureAwait(false);
+      await using (command.ConfigureAwaitFalse()) {
+        return await command.ExecuteReaderAsync(token).ConfigureAwaitFalse();
       }
     }
 
@@ -157,8 +158,8 @@ namespace Xtensive.Sql.Model
     protected virtual async Task<DbDataReader> ExecuteReaderAsync(string commandText, CancellationToken token = default)
     {
       var command = Connection.CreateCommand(commandText);
-      await using (command.ConfigureAwait(false)) {
-        return await command.ExecuteReaderAsync(token).ConfigureAwait(false);
+      await using (command.ConfigureAwaitFalse()) {
+        return await command.ExecuteReaderAsync(token).ConfigureAwaitFalse();
       }
     }
 

--- a/Orm/Xtensive.Orm/Sql/SqlConnection.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlConnection.cs
@@ -237,7 +237,7 @@ namespace Xtensive.Sql
       EnsureIsNotDisposed();
       var connectionAccessorEx = Extensions.Get<DbConnectionAccessorExtension>();
       if (connectionAccessorEx == null) {
-        await UnderlyingConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await UnderlyingConnection.OpenAsync(cancellationToken).ConfigureAwaitFalse();
       }
       else {
         var accessors = connectionAccessorEx.Accessors;
@@ -267,27 +267,27 @@ namespace Xtensive.Sql
       EnsureIsNotDisposed();
       var connectionAccessorEx = Extensions.Get<DbConnectionAccessorExtension>();
       if (connectionAccessorEx == null) {
-        await UnderlyingConnection.OpenAsync(token).ConfigureAwait(false);
+        await UnderlyingConnection.OpenAsync(token).ConfigureAwaitFalse();
         if (string.IsNullOrEmpty(initializationScript)) {
           return;
         }
 
         try {
           var command = UnderlyingConnection.CreateCommand();
-          await using (command.ConfigureAwait(false)) {
+          await using (command.ConfigureAwaitFalse()) {
             command.CommandText = initializationScript;
-            _ = await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            _ = await command.ExecuteNonQueryAsync(token).ConfigureAwaitFalse();
           }
         }
         catch (OperationCanceledException) {
-          await UnderlyingConnection.CloseAsync().ConfigureAwait(false);
+          await UnderlyingConnection.CloseAsync().ConfigureAwaitFalse();
           throw;
         }
       }
       else {
         var accessors = connectionAccessorEx.Accessors;
         await SqlHelper.NotifyConnectionOpeningAsync(accessors, UnderlyingConnection, false, token);
-        await UnderlyingConnection.OpenAsync(token).ConfigureAwait(false);
+        await UnderlyingConnection.OpenAsync(token).ConfigureAwaitFalse();
         if (string.IsNullOrEmpty(initializationScript)) {
           await SqlHelper.NotifyConnectionOpenedAsync(accessors, UnderlyingConnection, false, token);
           return;
@@ -296,15 +296,15 @@ namespace Xtensive.Sql
         try {
           await SqlHelper.NotifyConnectionInitializingAsync(accessors, UnderlyingConnection, initializationScript, false, token);
           var command = UnderlyingConnection.CreateCommand();
-          await using (command.ConfigureAwait(false)) {
+          await using (command.ConfigureAwaitFalse()) {
             command.CommandText = initializationScript;
-            _ = await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            _ = await command.ExecuteNonQueryAsync(token).ConfigureAwaitFalse();
           }
           await SqlHelper.NotifyConnectionOpenedAsync(accessors, UnderlyingConnection, false, token);
         }
         catch (OperationCanceledException ex) {
           await SqlHelper.NotifyConnectionOpeningFailedAsync(accessors, UnderlyingConnection, ex, false, token);
-          await UnderlyingConnection.CloseAsync().ConfigureAwait(false);
+          await UnderlyingConnection.CloseAsync().ConfigureAwaitFalse();
           throw;
         }
         catch (Exception ex) {
@@ -397,10 +397,10 @@ namespace Xtensive.Sql
       EnsureIsNotDisposed();
       EnsureTransactionIsActive();
       try {
-        await ActiveTransaction.CommitAsync(token).ConfigureAwait(false);
+        await ActiveTransaction.CommitAsync(token).ConfigureAwaitFalse();
       }
       finally {
-        await ActiveTransaction.DisposeAsync().ConfigureAwait(false);
+        await ActiveTransaction.DisposeAsync().ConfigureAwaitFalse();
         ClearActiveTransaction();
       }
     }
@@ -432,10 +432,10 @@ namespace Xtensive.Sql
       EnsureIsNotDisposed();
       EnsureTransactionIsActive();
       try {
-        await ActiveTransaction.RollbackAsync(token).ConfigureAwait(false);
+        await ActiveTransaction.RollbackAsync(token).ConfigureAwaitFalse();
       }
       finally {
-        await ActiveTransaction.DisposeAsync().ConfigureAwait(false);
+        await ActiveTransaction.DisposeAsync().ConfigureAwaitFalse();
         ClearActiveTransaction();
       }
     }
@@ -538,12 +538,12 @@ namespace Xtensive.Sql
       isDisposed = true;
       try {
         if (ActiveTransaction != null) {
-          await ActiveTransaction.DisposeAsync().ConfigureAwait(false);
+          await ActiveTransaction.DisposeAsync().ConfigureAwaitFalse();
           ClearActiveTransaction();
         }
       }
       finally {
-        await UnderlyingConnection.DisposeAsync().ConfigureAwait(false);
+        await UnderlyingConnection.DisposeAsync().ConfigureAwaitFalse();
         ClearUnderlyingConnection();
       }
     }

--- a/Orm/Xtensive.Orm/Sql/SqlDriver.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriver.cs
@@ -179,17 +179,17 @@ namespace Xtensive.Sql
       var result = new SqlExtractionResult();
 
       foreach (var (catalogName, sqlExtractionTasks) in taskGroups) {
-        var extractor = await BuildExtractorAsync(connection, token).ConfigureAwait(false);
+        var extractor = await BuildExtractorAsync(connection, token).ConfigureAwaitFalse();
         if (sqlExtractionTasks.All(t => !t.AllSchemas)) {
           // extracting all the schemes we need
           var schemasToExtract = sqlExtractionTasks.Select(t => t.Schema).ToArray();
-          var catalog = await extractor.ExtractSchemesAsync(catalogName, schemasToExtract, token).ConfigureAwait(false);
+          var catalog = await extractor.ExtractSchemesAsync(catalogName, schemasToExtract, token).ConfigureAwaitFalse();
           CleanSchemas(catalog, schemasToExtract);
           result.Catalogs.Add(catalog);
         }
         else {
           // Extracting whole catalog
-          var catalog = await extractor.ExtractCatalogAsync(catalogName, token).ConfigureAwait(false);
+          var catalog = await extractor.ExtractCatalogAsync(catalogName, token).ConfigureAwaitFalse();
           result.Catalogs.Add(catalog);
         }
       }
@@ -223,9 +223,9 @@ namespace Xtensive.Sql
     /// </returns>
     public async Task<Catalog> ExtractCatalogAsync(SqlConnection connection, CancellationToken token = default)
     {
-      var defaultSchema = await GetDefaultSchemaAsync(connection, token).ConfigureAwait(false);
+      var defaultSchema = await GetDefaultSchemaAsync(connection, token).ConfigureAwaitFalse();
       var task = new SqlExtractionTask(defaultSchema.Database);
-      return (await ExtractAsync(connection, new[] {task}, token).ConfigureAwait(false)).Catalogs.Single();
+      return (await ExtractAsync(connection, new[] {task}, token).ConfigureAwaitFalse()).Catalogs.Single();
     }
 
     /// <summary>
@@ -253,9 +253,9 @@ namespace Xtensive.Sql
     /// </returns>
     public async Task<Schema> ExtractDefaultSchemaAsync(SqlConnection connection, CancellationToken token = default)
     {
-      var defaultSchema = await GetDefaultSchemaAsync(connection, token).ConfigureAwait(false);
+      var defaultSchema = await GetDefaultSchemaAsync(connection, token).ConfigureAwaitFalse();
       return await ExtractSchemaAsync(connection, defaultSchema.Database, defaultSchema.Schema, token)
-        .ConfigureAwait(false);
+        .ConfigureAwaitFalse();
     }
 
     /// <summary>
@@ -286,8 +286,8 @@ namespace Xtensive.Sql
     public async Task<Schema> ExtractSchemaAsync(
       SqlConnection connection, string schemaName, CancellationToken token = default)
     {
-      var defaultSchema = await GetDefaultSchemaAsync(connection, token).ConfigureAwait(false);
-      return await ExtractSchemaAsync(connection, defaultSchema.Database, schemaName, token).ConfigureAwait(false);
+      var defaultSchema = await GetDefaultSchemaAsync(connection, token).ConfigureAwaitFalse();
+      return await ExtractSchemaAsync(connection, defaultSchema.Database, schemaName, token).ConfigureAwaitFalse();
     }
 
     /// <summary>
@@ -466,7 +466,7 @@ namespace Xtensive.Sql
     private async Task<Extractor> BuildExtractorAsync(SqlConnection connection, CancellationToken token = default)
     {
       var extractor = CreateExtractor();
-      await extractor.InitializeAsync(connection, token).ConfigureAwait(false);
+      await extractor.InitializeAsync(connection, token).ConfigureAwaitFalse();
       return extractor;
     }
 
@@ -490,7 +490,7 @@ namespace Xtensive.Sql
       CancellationToken token = default)
     {
       var task = new SqlExtractionTask(databaseName, schemaName);
-      return (await ExtractAsync(connection, new[] {task}, token).ConfigureAwait(false))
+      return (await ExtractAsync(connection, new[] {task}, token).ConfigureAwaitFalse())
         .Catalogs[databaseName].Schemas.FirstOrDefault(el => el.Name == schemaName);
     }
 

--- a/Orm/Xtensive.Orm/Sql/SqlDriverFactory.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriverFactory.cs
@@ -96,7 +96,7 @@ namespace Xtensive.Sql
 
       var connectionString = GetConnectionString(connectionInfo);
       configuration = configuration.Clone();
-      var driver = await CreateDriverAsync(connectionString, configuration, token).ConfigureAwait(false);
+      var driver = await CreateDriverAsync(connectionString, configuration, token).ConfigureAwaitFalse();
       driver.Initialize(this, connectionInfo);
       return driver;
     }

--- a/Orm/Xtensive.Orm/Sql/SqlHelper.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlHelper.cs
@@ -396,12 +396,12 @@ namespace Xtensive.Sql
       ArgumentValidator.EnsureArgumentNotNullOrEmpty(queryText, nameof(queryText));
 
       var command = connection.CreateCommand();
-      await using (command.ConfigureAwait(false)) {
+      await using (command.ConfigureAwaitFalse()) {
         command.CommandText = queryText;
         command.Transaction = transaction;
-        var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          if (!await reader.ReadAsync(token).ConfigureAwait(false)) {
+        var reader = await command.ExecuteReaderAsync(token).ConfigureAwaitFalse();
+        await using (reader.ConfigureAwaitFalse()) {
+          if (!await reader.ReadAsync(token).ConfigureAwaitFalse()) {
             throw new InvalidOperationException(Strings.ExCanNotReadDatabaseAndSchemaNames);
           }
 
@@ -457,9 +457,9 @@ namespace Xtensive.Sql
       }
 
       var command = connection.CreateCommand();
-      await using (command.ConfigureAwait(false)) {
+      await using (command.ConfigureAwaitFalse()) {
         command.CommandText = configuration.ConnectionInitializationSql;
-        await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        await command.ExecuteNonQueryAsync(token).ConfigureAwaitFalse();
       }
     }
 
@@ -479,9 +479,9 @@ namespace Xtensive.Sql
       }
 
       var command = connection.CreateCommand();
-      await using (command.ConfigureAwait(false)) {
+      await using (command.ConfigureAwaitFalse()) {
         command.CommandText = initializationSql;
-        _ = await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        _ = await command.ExecuteNonQueryAsync(token).ConfigureAwaitFalse();
       }
     }
 
@@ -582,7 +582,7 @@ namespace Xtensive.Sql
       foreach (var accessor in connectionAccessors) {
         await accessor.ConnectionOpeningAsync(
           new ConnectionEventData(connection, reconnect), token)
-          .ConfigureAwait(false);
+          .ConfigureAwaitFalse();
       }
     }
 
@@ -621,7 +621,7 @@ namespace Xtensive.Sql
       foreach (var accessor in connectionAccessors) {
         await accessor.ConnectionInitializationAsync(
           new ConnectionInitEventData(initializationScript, connection, reconnect), token)
-          .ConfigureAwait(false);
+          .ConfigureAwaitFalse();
       }
     }
 
@@ -657,7 +657,7 @@ namespace Xtensive.Sql
       foreach (var accessor in connectionAccessors) {
         await accessor.ConnectionOpenedAsync(
           new ConnectionEventData(connection, reconnect), token)
-          .ConfigureAwait(false);
+          .ConfigureAwaitFalse();
       }
     }
 
@@ -696,7 +696,7 @@ namespace Xtensive.Sql
       foreach (var accessor in connectionAccessors) {
         await accessor.ConnectionOpeningFailedAsync(
           new ConnectionErrorEventData(exception, connection, reconnect), token)
-          .ConfigureAwait(false);
+          .ConfigureAwaitFalse();
       }
     }
 


### PR DESCRIPTION
In typical .NET apps `.ConfigureAwait(false)` creates unnecessary overhead.

This can be switchched of by setting environment variable `DO_CONFIGURE_AWAIT_FALSE=false` at compile time