### PR TITLE
Optimize IDisposable implementations

### DIFF
--- a/Orm/Xtensive.Orm/Collections/BindingCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/BindingCollection.cs
@@ -112,9 +112,7 @@ namespace Xtensive.Collections
     public virtual void PermanentAdd(TKey key, TValue value)
     {
       bindings[key] = value;
-      if (!permanentBindings.Contains(key)) {
-        permanentBindings.Add(key);
-      }
+      permanentBindings.Add(key);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Collections/Graphs/Graph.cs
+++ b/Orm/Xtensive.Orm/Collections/Graphs/Graph.cs
@@ -56,9 +56,8 @@ namespace Xtensive.Collections.Graphs
       foreach (var rNode in copy.Nodes) {
         var node = rNode.Value;
         foreach (var edge in node.Edges) {
-          if (!processedEdges.Contains(edge)) {
+          if (processedEdges.Add(edge)) {
             var rEdge = new Edge<TEdge>(nodeMap[edge.Source], nodeMap[edge.Target], (TEdge) edge);
-            processedEdges.Add(edge);
           }
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Entity.cs
+++ b/Orm/Xtensive.Orm/Orm/Entity.cs
@@ -138,8 +138,7 @@ namespace Xtensive.Orm
         List<PrefetchFieldDescriptor> columnsToPrefetch = null;
         foreach (var columnInfo in versionColumns) {
           if (!tuple.GetFieldState(columnInfo.Field.MappingInfo.Offset).IsAvailable()) {
-            if (columnsToPrefetch==null)
-              columnsToPrefetch = new List<PrefetchFieldDescriptor>();
+            columnsToPrefetch ??= new List<PrefetchFieldDescriptor>(1);
             columnsToPrefetch.Add(new PrefetchFieldDescriptor(columnInfo.Field));
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Model/FullTextIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FullTextIndexInfoCollection.cs
@@ -54,8 +54,7 @@ namespace Xtensive.Orm.Model
     public void Add(TypeInfo typeInfo, FullTextIndexInfo fullTextIndexInfo)
     {
       EnsureNotLocked();
-      if (!container.Contains(fullTextIndexInfo))
-        container.Add(fullTextIndexInfo);
+      container.Add(fullTextIndexInfo);
       indexMap.Add(typeInfo, fullTextIndexInfo);
     }
 

--- a/Orm/Xtensive.Orm/Orm/OperationLog.cs
+++ b/Orm/Xtensive.Orm/Orm/OperationLog.cs
@@ -61,7 +61,7 @@ namespace Xtensive.Orm
       KeyMapping keyMapping;
 
       using (session.Activate()) {
-        using (isSystemOperationLog ? session.OpenSystemLogicOnlyRegion() : null) 
+        using (isSystemOperationLog ? (IDisposable) session.OpenSystemLogicOnlyRegion() : null)
         using (var tx = session.OpenTransaction(TransactionOpenMode.New)) {
 
           foreach (var operation in operations)

--- a/Orm/Xtensive.Orm/Orm/Services/DirectSessionAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/DirectSessionAccessor.cs
@@ -28,10 +28,7 @@ namespace Xtensive.Orm.Services
     /// disposal will restore previous state of
     /// <see cref="Session.IsSystemLogicOnly"/> property.
     /// </returns>
-    public IDisposable OpenSystemLogicOnlyRegion()
-    {
-      return Session.OpenSystemLogicOnlyRegion();
-    }
+    public Session.SystemLogicOnlyRegionScope OpenSystemLogicOnlyRegion() => Session.OpenSystemLogicOnlyRegion();
 
     /// <summary>
     /// Changes the value of <see cref="Session.Handler"/>.

--- a/Orm/Xtensive.Orm/Orm/Session.Persist.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Persist.cs
@@ -18,8 +18,6 @@ namespace Xtensive.Orm
 {
   public partial class Session
   {
-    private static readonly IDisposable EmptyDisposable = new Disposable(b => { return; });
-
     private bool disableAutoSaveChanges;
     private KeyRemapper remapper;
     private bool persistingIsFailed;
@@ -246,7 +244,7 @@ namespace Xtensive.Orm
       targetEntity.EnsureNotRemoved();
       return Configuration.Supports(SessionOptions.AutoSaveChanges)
         ? pinner.RegisterRoot(targetEntity.State)
-        : EmptyDisposable; // No need to pin in this case
+        : null; // No need to pin in this case
     }
 
     /// <summary>
@@ -260,7 +258,7 @@ namespace Xtensive.Orm
     public IDisposable DisableSaveChanges()
     {
       if (!Configuration.Supports(SessionOptions.AutoSaveChanges)) {
-        return EmptyDisposable; // No need to pin in this case
+        return null; // No need to pin in this case
       }
       if (disableAutoSaveChanges)
         return null;

--- a/Orm/Xtensive.Orm/Orm/Session.Persist.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Persist.cs
@@ -18,6 +18,8 @@ namespace Xtensive.Orm
 {
   public partial class Session
   {
+    private static readonly IDisposable EmptyDisposable = new Disposable(b => { return; });
+
     private bool disableAutoSaveChanges;
     private KeyRemapper remapper;
     private bool persistingIsFailed;
@@ -242,9 +244,9 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(target, "target");
       var targetEntity = (Entity) target;
       targetEntity.EnsureNotRemoved();
-      if (!Configuration.Supports(SessionOptions.AutoSaveChanges))
-        return new Disposable(b => {return;}); // No need to pin in this case
-      return pinner.RegisterRoot(targetEntity.State);
+      return Configuration.Supports(SessionOptions.AutoSaveChanges)
+        ? pinner.RegisterRoot(targetEntity.State)
+        : EmptyDisposable; // No need to pin in this case
     }
 
     /// <summary>
@@ -257,8 +259,9 @@ namespace Xtensive.Orm
     /// </summary>
     public IDisposable DisableSaveChanges()
     {
-      if (!Configuration.Supports(SessionOptions.AutoSaveChanges))
-        return new Disposable(b => { return; }); // No need to pin in this case
+      if (!Configuration.Supports(SessionOptions.AutoSaveChanges)) {
+        return EmptyDisposable; // No need to pin in this case
+      }
       if (disableAutoSaveChanges)
         return null;
 

--- a/Orm/Xtensive.Orm/Orm/Session.Persist.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Persist.cs
@@ -224,7 +224,7 @@ namespace Xtensive.Orm
     }
 
     /// <summary>
-    /// Temporarily disables all save changes operations (both explicit ant automatic) 
+    /// Temporarily disables all save changes operations (both explicit ant automatic)
     /// for specified <paramref name="target"/>.
     /// Such entity is prevented from being persisted to the database,
     /// when <see cref="SaveChanges"/> is called or query is executed.
@@ -234,17 +234,21 @@ namespace Xtensive.Orm
     /// all entities that reference <paramref name="target"/> are also pinned automatically.
     /// </summary>
     /// <param name="target">The entity to disable persisting.</param>
-    /// <returns>A special object that controls lifetime of such behavior if <paramref name="target"/> was not previously processed by the method,
-    /// otherwise <see langword="null"/>.</returns>
+    /// <returns>
+    /// A special object that controls lifetime of such behavior if <paramref name="target"/> was not previously processed by the method
+    /// and automatic saving of changes is enabled (<see cref="SessionOptions.AutoSaveChanges"/>),
+    /// otherwise <see langword="null"/>.
+    /// </returns>
     public IDisposable DisableSaveChanges(IEntity target)
     {
       EnsureNotDisposed();
       ArgumentValidator.EnsureArgumentNotNull(target, "target");
+      if (!Configuration.Supports(SessionOptions.AutoSaveChanges))
+        return null; // No need to pin in this case
+
       var targetEntity = (Entity) target;
       targetEntity.EnsureNotRemoved();
-      return Configuration.Supports(SessionOptions.AutoSaveChanges)
-        ? pinner.RegisterRoot(targetEntity.State)
-        : null; // No need to pin in this case
+      return pinner.RegisterRoot(targetEntity.State);
     }
 
     /// <summary>
@@ -252,16 +256,15 @@ namespace Xtensive.Orm
     /// Explicit call of <see cref="SaveChanges"/> will lead to flush changes anyway.
     /// If save changes is to be performed due to starting a nested transaction or committing a transaction,
     /// active disabling save changes scope will lead to failure.
-    /// <returns>A special object that controls lifetime of such behavior if there is no active scope,
+    /// <returns>A special object that controls lifetime of such behavior if there is no active scope
+    /// and automatic saving of changes is enabled (<see cref="SessionOptions.AutoSaveChanges"/>),
     /// otherwise <see langword="null"/>.</returns>
     /// </summary>
     public IDisposable DisableSaveChanges()
     {
-      if (!Configuration.Supports(SessionOptions.AutoSaveChanges)) {
-        return null; // No need to pin in this case
+      if (!Configuration.Supports(SessionOptions.AutoSaveChanges) || disableAutoSaveChanges) {
+        return null; // No need to pin in these cases
       }
-      if (disableAutoSaveChanges)
-        return null;
 
       disableAutoSaveChanges = true;
       return new Disposable(_ => {
@@ -318,7 +321,7 @@ namespace Xtensive.Orm
         newEntity.Update(null);
         newEntity.PersistenceState = PersistenceState.Removed;
       }
-      
+
       foreach (var modifiedEntity in EntityChangeRegistry.GetItems(PersistenceState.Modified)) {
         modifiedEntity.RollbackDifference();
         modifiedEntity.PersistenceState = PersistenceState.Synchronized;

--- a/Orm/Xtensive.Orm/Orm/Session.SystemLogic.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.SystemLogic.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Orm
       private readonly Session session;
       private readonly bool prevIsSystemLogicOnly;
 
-      public SystemLogicOnlyRegionScope(Session session)
+      internal SystemLogicOnlyRegionScope(Session session)
       {
         this.session = session;
         prevIsSystemLogicOnly = session.IsSystemLogicOnly;

--- a/Orm/Xtensive.Orm/Orm/Session.SystemLogic.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.SystemLogic.cs
@@ -11,17 +11,26 @@ namespace Xtensive.Orm
 {
   public partial class Session
   {
+    public readonly struct SystemLogicOnlyRegionScope : IDisposable
+    {
+      private readonly Session session;
+      private readonly bool prevIsSystemLogicOnly;
+
+      public SystemLogicOnlyRegionScope(Session session)
+      {
+        this.session = session;
+        prevIsSystemLogicOnly = session.IsSystemLogicOnly;
+        session.IsSystemLogicOnly = true;
+      }
+
+      public void Dispose() => session.IsSystemLogicOnly = prevIsSystemLogicOnly;
+    }
+
     /// <summary>
     /// Gets a value indicating whether only a system logic is enabled.
     /// </summary>
     internal bool IsSystemLogicOnly { get; set; }
 
-    internal IDisposable OpenSystemLogicOnlyRegion()
-    {
-      var result = new Disposable<Session, bool>(this, IsSystemLogicOnly,
-        (disposing, session, previousState) => session.IsSystemLogicOnly = previousState);
-      IsSystemLogicOnly = true;
-      return result;
-    }
+    internal SystemLogicOnlyRegionScope OpenSystemLogicOnlyRegion() => new(this);
   }
 }


### PR DESCRIPTION
* Make frequently invoked methods  `OpenSystemLogicOnlyRegion()`, `EnableSystemOperationRegistration()`, `DisableSystemOperationRegistration()` alloc-less  (there were 2 allocations: for `Disposable<>` & closure)
* Optimize `RegisterRoot()`
* Use static `EmptyDisposable` where possible
* Refactor `if (!hashSet.Contains(x)) hashSet.Add(x);` pattern into `hashSet.Add(x)` to avoid double search
* Fix `PrefetchManagerBasicTest`: prohibit JIT to inline the function