### PR TITLE
Helpers.TopologicalSorter issues fix

### DIFF
--- a/ChangeLog/7.1.2_dev.txt
+++ b/ChangeLog/7.1.2_dev.txt
@@ -1,0 +1,1 @@
+[main] Addressed issue when cycles in Entity dependency graph were not detected

--- a/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
+++ b/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
@@ -183,7 +183,13 @@ namespace Xtensive.Sorting
     /// In this case <paramref name="nodes"/> will contain only the loop edges.</returns>
     public static IEnumerable<TNodeItem> Sort<TNodeItem, TConnectionItem>(
       List<Node<TNodeItem, TConnectionItem>> nodes,
-      out List<Node<TNodeItem, TConnectionItem>> loops) => SortInternal(nodes, out loops).sorted ?? Array.Empty<TNodeItem>();
+      out List<Node<TNodeItem, TConnectionItem>> loops)
+    {
+      var (sorted, count) = SortInternal(nodes, out loops) /* ?? Array.Empty<TNodeItem>()*/;
+      return (sorted is not null && count == 0)
+        ? Array.Empty<TNodeItem>()
+        : sorted;
+    }
 
     /// <summary>
     /// Sorts the specified oriented graph of the nodes in their topological order
@@ -199,9 +205,11 @@ namespace Xtensive.Sorting
       out List<Node<TNodeItem, TConnectionItem>> loops)
     {
       var (sorted, count) = SortInternal(nodes, out loops);
-      return (sorted is null || count == 0)
-        ? Array.Empty<TNodeItem>()
-        : sorted.ToArray(count);
+      return (sorted is null)
+        ? null
+        : count == 0
+          ? Array.Empty<TNodeItem>()
+          : sorted.ToArray(count);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
+++ b/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
@@ -9,7 +9,9 @@ using System.Collections.Generic;
 using Xtensive.Collections;
 using System.Linq;
 using Xtensive.Core;
-
+using DotNetNotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
+using JBNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
+using JBCanBeNullAttribute = JetBrains.Annotations.CanBeNullAttribute;
 
 namespace Xtensive.Sorting
 {
@@ -29,6 +31,7 @@ namespace Xtensive.Sorting
     /// Sorting result, if there were no loops;
     /// otherwise, <see langword="null"/>.
     /// </returns>
+    [JBCanBeNull]
     public static IEnumerable<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector) =>
       Sort(items, connector, out List<Node<TNodeItem, object>> loops);
 
@@ -43,6 +46,7 @@ namespace Xtensive.Sorting
     /// Sorting result, if there were no loops;
     /// otherwise, <see langword="null"/>.
     /// </returns>
+    [JBCanBeNull]
     public static IReadOnlyList<TNodeItem> SortToList<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector) =>
       SortToList(items, connector, out List<Node<TNodeItem, object>> loops);
 
@@ -59,6 +63,7 @@ namespace Xtensive.Sorting
     /// otherwise, <see langword="null"/>.
     /// In this case <paramref name="loops"/> will contain only the loop edges.
     /// </returns>
+    [JBCanBeNull]
     public static IEnumerable<TNodeItem> Sort<TNodeItem>(
       IEnumerable<TNodeItem> items,
       Predicate<TNodeItem, TNodeItem> connector,
@@ -83,6 +88,7 @@ namespace Xtensive.Sorting
     /// otherwise, <see langword="null"/>.
     /// In this case <paramref name="loops"/> will contain only the loop edges.
     /// </returns>
+    [JBCanBeNull]
     public static IReadOnlyList<TNodeItem> SortToList<TNodeItem>(
       IEnumerable<TNodeItem> items,
       Predicate<TNodeItem, TNodeItem> connector,
@@ -105,6 +111,8 @@ namespace Xtensive.Sorting
     /// <returns>
     /// Sorting result
     /// </returns>
+    [return: DotNetNotNull]
+    [JBNotNull]
     public static IEnumerable<TNodeItem> Sort<TNodeItem>(
       IEnumerable<TNodeItem> items,
       Predicate<TNodeItem, TNodeItem> connector,
@@ -121,6 +129,8 @@ namespace Xtensive.Sorting
     /// <returns>
     /// Sorting result
     /// </returns>
+    [return: DotNetNotNull]
+    [JBNotNull]
     public static IReadOnlyList<TNodeItem> SortToList<TNodeItem>(
       IEnumerable<TNodeItem> items,
       Predicate<TNodeItem, TNodeItem> connector,
@@ -138,6 +148,8 @@ namespace Xtensive.Sorting
     /// <returns>
     /// Sorting result
     /// </returns>
+    [return: DotNetNotNull]
+    [JBNotNull]
     public static IEnumerable<TNodeItem> Sort<TNodeItem>(
       IEnumerable<TNodeItem> items,
       Predicate<TNodeItem, TNodeItem> connector,
@@ -161,6 +173,8 @@ namespace Xtensive.Sorting
     /// <returns>
     /// Sorting result
     /// </returns>
+    [return: DotNetNotNull]
+    [JBNotNull]
     public static IReadOnlyList<TNodeItem> SortToList<TNodeItem>(
       IEnumerable<TNodeItem> items,
       Predicate<TNodeItem, TNodeItem> connector,
@@ -181,6 +195,7 @@ namespace Xtensive.Sorting
     /// <returns>Sorting result, if there were no loops;
     /// otherwise, <see langword="null" />. 
     /// In this case <paramref name="nodes"/> will contain only the loop edges.</returns>
+    [JBCanBeNull]
     public static IEnumerable<TNodeItem> Sort<TNodeItem, TConnectionItem>(
       List<Node<TNodeItem, TConnectionItem>> nodes,
       out List<Node<TNodeItem, TConnectionItem>> loops)
@@ -200,6 +215,7 @@ namespace Xtensive.Sorting
     /// <returns>Sorting result, if there were no loops;
     /// otherwise, <see langword="null" />. 
     /// In this case <paramref name="nodes"/> will contain only the loop edges.</returns>
+    [JBCanBeNull]
     public static IReadOnlyList<TNodeItem> SortToList<TNodeItem, TConnectionItem>(
       List<Node<TNodeItem, TConnectionItem>> nodes,
       out List<Node<TNodeItem, TConnectionItem>> loops)
@@ -219,6 +235,8 @@ namespace Xtensive.Sorting
     /// <param name="nodes">The nodes.</param>
     /// <param name="removedEdges">Edges removed to make graph non-cyclic.</param>
     /// <returns>Sorting result.</returns>
+    [return: DotNetNotNull]
+    [JBNotNull]
     public static IEnumerable<TNodeItem> Sort<TNodeItem, TConnectionItem>(
       IEnumerable<Node<TNodeItem, TConnectionItem>> nodes,
       out List<NodeConnection<TNodeItem, TConnectionItem>> removedEdges) =>
@@ -231,6 +249,8 @@ namespace Xtensive.Sorting
     /// <param name="nodes">The nodes.</param>
     /// <param name="removedEdges">Edges removed to make graph non-cyclic.</param>
     /// <returns>Sorting result.</returns>
+    [return: DotNetNotNull]
+    [JBNotNull]
     public static IReadOnlyList<TNodeItem> SortToList<TNodeItem, TConnectionItem>(
       IEnumerable<Node<TNodeItem, TConnectionItem>> nodes,
       out List<NodeConnection<TNodeItem, TConnectionItem>> removedEdges) =>
@@ -244,6 +264,8 @@ namespace Xtensive.Sorting
     /// <param name="removedEdges">Edges removed to make graph non-cyclic.</param>
     /// <param name="removeWholeNode">If <see langword="true"/> removes whole node in the case of loop, otherwise removes only one edge.</param>
     /// <returns>Sorting result.</returns>
+    [return: DotNetNotNull]
+    [JBNotNull]
     public static IEnumerable<TNodeItem> Sort<TNodeItem, TConnectionItem>(
         IEnumerable<Node<TNodeItem, TConnectionItem>> nodes,
         out List<NodeConnection<TNodeItem, TConnectionItem>> removedEdges,
@@ -258,6 +280,8 @@ namespace Xtensive.Sorting
     /// <param name="removedEdges">Edges removed to make graph non-cyclic.</param>
     /// <param name="removeWholeNode">If <see langword="true"/> removes whole node in the case of loop, otherwise removes only one edge.</param>
     /// <returns>Sorting result.</returns>
+    [return: DotNetNotNull]
+    [JBNotNull]
     public static IReadOnlyList<TNodeItem> SortToList<TNodeItem, TConnectionItem>(
       IEnumerable<Node<TNodeItem, TConnectionItem>> nodes,
       out List<NodeConnection<TNodeItem, TConnectionItem>> removedEdges,


### PR DESCRIPTION
Sorter methods return values as declared, in some cases null is valid return result and the caller relies on in. This fixed rare issue of cycles in entities dependency graph which is not detected.
