### PR TITLE
TagTest improvements

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Framework/AutoBuildTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/AutoBuildTest.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2008.07.31
 
@@ -72,14 +72,15 @@ namespace Xtensive.Orm.Tests
     {
     }
 
-    protected void CreateSessionAndTransaction()
+    protected (Session, TransactionScope) CreateSessionAndTransaction()
     {
       try {
         disposables = new DisposableSet();
         var session = Domain.OpenSession();
-        disposables.Add(session);
         var transaction = session.OpenTransaction();
-        disposables.Add(transaction);
+        _ = disposables.Add(session);
+        _ = disposables.Add(transaction);
+        return (session, transaction);
       }
       catch {
         disposables.DisposeSafely();

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue0435_BatchingFail.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue0435_BatchingFail.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-20223 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -38,7 +38,7 @@ namespace Xtensive.Orm.Tests.Issues
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
     }
 
     [Test]

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0187_TypeCastInContain.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0187_TypeCastInContain.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2011 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2011-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2011.09.06
 
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Tests.Issues
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
     }
 
     [Test]

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0221_UnableToTranslateAggregate.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0221_UnableToTranslateAggregate.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2021 Xtensive LLC.
+// Copyright (C) 2011-2023 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Tests.Issues
     {
       base.TestFixtureSetUp();
 
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
 
       _ = new ZamesInfo {Owner = new Zames(), Rank = 1};
       _ = new ZamesInfo {Owner = new Zames(), Rank = 3};

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0242_LegacyExecuteMethodsDoNotWork.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0242_LegacyExecuteMethodsDoNotWork.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012-2020 Xtensive LLC.
+// Copyright (C) 2012-2023 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -16,7 +16,7 @@ namespace Xtensive.Orm.Tests.Issues
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
     }
 
     #region Compiled queries

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0746_LikeBehaviorDifferentOnClientSide.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0746_LikeBehaviorDifferentOnClientSide.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Xtensive LLC.
+// Copyright (C) 2018-2023 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Kudelin
@@ -87,7 +87,7 @@ namespace Xtensive.Orm.Tests.Issues
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
     }
 
     protected override DomainConfiguration BuildConfiguration()

--- a/Orm/Xtensive.Orm.Tests/Linq/ConvariantQueriesTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/ConvariantQueriesTest.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2011 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2011-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2011.11.02
 
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Tests.Linq
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
     }
 
     [Test]

--- a/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Xtensive LLC.
+// Copyright (C) 2021-2023 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm.Tests/Storage/AggregateTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/AggregateTest.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2032 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.04.28
 
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.Tests.Storage
     {
       base.TestFixtureSetUp();
 
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
 
       for (int i = 0; i < 10; i++) {
         var x = new X();
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Tests.Storage
     {
       //"If Field is of an integer type, AVG is always rounded towards 0.
       // For instance, 6 non-null INT records with a sum of -11 yield an average of -1, not -2."
-      // © Firebird documentation
+      // Â© Firebird documentation
       // Funny, isn't it?
       if (Domain.Configuration.ConnectionInfo.Provider==WellKnown.Provider.Firebird) {
         Assert.AreEqual(Math.Truncate(all.Average(x => x.FByte)), Session.Demand().Query.All<X>().Average(x => x.FByte));

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessorContextProviderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessorContextProviderTest.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2019 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2019-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
 // Created:    2019.07.12
 
@@ -12,7 +12,7 @@ namespace Xtensive.Orm.Tests.Storage
   {
     protected override void PopulateData()
     {
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
     }
 
     [Test]

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/NullValuesTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/NullValuesTest.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2009-2023 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.04.25
 
@@ -21,7 +21,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
       emptyStringIsNull = ProviderInfo.Supports(ProviderFeatures.TreatEmptyStringAsNull);
       
       new X {FString = "Xtensive"};

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/RoundingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/RoundingTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2021 Xtensive LLC.
+// Copyright (C) 2009-2023 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -193,7 +193,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
 
       var testValues = new[] {
         1.3m, 1.5m, 1.6m,

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/StringOperationsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/StringOperationsTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2023 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      CreateSessionAndTransaction();
+      _ = CreateSessionAndTransaction();
       emptyStringIsNull = ProviderInfo.Supports(ProviderFeatures.TreatEmptyStringAsNull);
       var testValues = new[] {
         // test values for TrimStart, TrimEnd, Trim


### PR DESCRIPTION
To prevent fails when run against certain storages each test uses separate session.

Additionally, AutoBuildTest.CreateSessionAndTransaction method returns pair of Session and TransactionScope instances which gives an opportunity to not use Session.Current or Session.Demand() to get opened session instance.