### PR TITLE
ARCH-6354: Optimize `Get/SetFieldValue()` to use integer indexes inst…

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Persistent.cs
+++ b/Orm/Xtensive.Orm/Orm/Persistent.cs
@@ -165,6 +165,9 @@ namespace Xtensive.Orm
       return GetFieldValue(TypeInfo.Fields[fieldName]);
     }
 
+    protected internal T GetFieldValue<T>(int fieldIndex) =>
+      GetNormalizedFieldValue<T>(TypeInfo.PersistentFields[fieldIndex]);
+
     /// <summary>
     /// Gets the field value.
     /// Field value type must be specified precisely.
@@ -173,7 +176,10 @@ namespace Xtensive.Orm
     /// <typeparam name="T">Field value type.</typeparam>
     /// <param name="field">The field.</param>
     /// <returns>Field value.</returns>
-    protected internal T GetFieldValue<T>(FieldInfo field)
+    protected internal T GetFieldValue<T>(FieldInfo field) =>
+      GetNormalizedFieldValue<T>(field.ReflectedType.IsInterface ? TypeInfo.FieldMap[field] : field);
+
+    protected internal T GetNormalizedFieldValue<T>(FieldInfo field)
     {
       if (field.ReflectedType.IsInterface)
         field = TypeInfo.FieldMap[field];
@@ -356,6 +362,9 @@ namespace Xtensive.Orm
       SetFieldValue(TypeInfo.Fields[fieldName], value);
     }
 
+    protected internal void SetFieldValue<T>(int fieldIndex, T value) =>
+      SetNormalizedFieldValue(TypeInfo.PersistentFields[fieldIndex], value, null, null);
+
     /// <summary>
     /// Sets the field value.
     /// Field value type must be specified precisely.
@@ -383,10 +392,11 @@ namespace Xtensive.Orm
       SetFieldValue(field, value, null, null);
     }
 
-    internal void SetFieldValue(FieldInfo field, object value, SyncContext syncContext, RemovalContext removalContext)
+    internal void SetFieldValue(FieldInfo field, object value, SyncContext syncContext, RemovalContext removalContext) =>
+      SetNormalizedFieldValue(field.ReflectedType.IsInterface ? TypeInfo.FieldMap[field] : field, value, syncContext, removalContext);
+
+    internal void SetNormalizedFieldValue(FieldInfo field, object value, SyncContext syncContext, RemovalContext removalContext)
     {
-      if (field.ReflectedType.IsInterface)
-        field = TypeInfo.FieldMap[field];
       SystemSetValueAttempt(field, value);
       var fieldAccessor = GetFieldAccessor(field);
       object oldValue = GetFieldValue(field);

--- a/Weaver/Xtensive.Orm.Weaver/Stages/ImportReferencesStage.cs
+++ b/Weaver/Xtensive.Orm.Weaver/Stages/ImportReferencesStage.cs
@@ -25,6 +25,7 @@ namespace Xtensive.Orm.Weaver.Stages
       }
       registry.OrmAssembly = ormAssembly;
 
+      var intType = context.TargetModule.TypeSystem.Int32;
       var stringType = context.TargetModule.TypeSystem.String;
       var voidType = context.TargetModule.TypeSystem.Void;
 
@@ -59,13 +60,13 @@ namespace Xtensive.Orm.Weaver.Stages
       var persistentGetter = new MethodReference("GetFieldValue", voidType, persistentType) {HasThis = true};
       var getterType = new GenericParameter("!!T", persistentGetter);
       persistentGetter.ReturnType = getterType;
-      persistentGetter.Parameters.Add(new ParameterDefinition(stringType));
+      persistentGetter.Parameters.Add(new ParameterDefinition(intType));
       persistentGetter.GenericParameters.Add(getterType);
       registry.PersistentGetterDefinition = context.TargetModule.ImportReference(persistentGetter);
 
       var persistentSetter = new MethodReference("SetFieldValue", voidType, persistentType) {HasThis = true};
       var setterType = new GenericParameter("!!T", persistentSetter);
-      persistentSetter.Parameters.Add(new ParameterDefinition(stringType));
+      persistentSetter.Parameters.Add(new ParameterDefinition(intType));
       persistentSetter.Parameters.Add(new ParameterDefinition(setterType));
       persistentSetter.GenericParameters.Add(setterType);
       registry.PersistentSetterDefinition = context.TargetModule.ImportReference(persistentSetter);

--- a/Weaver/Xtensive.Orm.Weaver/Tasks/ImplementFieldAccessorTask.cs
+++ b/Weaver/Xtensive.Orm.Weaver/Tasks/ImplementFieldAccessorTask.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Orm.Weaver.Tasks
   {
     private readonly TypeDefinition type;
     private readonly PropertyDefinition property;
-    private readonly string persistentName;
+    private readonly int persistentIndex;
     private readonly AccessorKind kind;
 
     public override ActionResult Execute(ProcessorContext context)
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Weaver.Tasks
       body.Instructions.Clear();
       var il = body.GetILProcessor();
       il.Emit(OpCodes.Ldarg_0);
-      il.Emit(OpCodes.Ldstr, persistentName);
+      il.Emit(OpCodes.Ldc_I4, persistentIndex);
       il.Emit(OpCodes.Ldarg_1);
       il.Emit(OpCodes.Call, accessor);
       il.Emit(OpCodes.Ret);
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Weaver.Tasks
       body.Instructions.Clear();
       var il = body.GetILProcessor();
       il.Emit(OpCodes.Ldarg_0);
-      il.Emit(OpCodes.Ldstr, persistentName);
+      il.Emit(OpCodes.Ldc_I4, persistentIndex);
       il.Emit(OpCodes.Call, accessor);
       il.Emit(OpCodes.Ret);
     }
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Weaver.Tasks
       return result;
     }
 
-    public ImplementFieldAccessorTask(AccessorKind kind, TypeDefinition type, PropertyDefinition property, string persistentName)
+    public ImplementFieldAccessorTask(AccessorKind kind, TypeDefinition type, PropertyDefinition property, int persistentIndex)
     {
       if (type==null)
         throw new ArgumentNullException("type");
@@ -85,7 +85,7 @@ namespace Xtensive.Orm.Weaver.Tasks
       this.kind = kind;
       this.type = type;
       this.property = property;
-      this.persistentName = persistentName;
+      this.persistentIndex = persistentIndex;
     }
   }
 }


### PR DESCRIPTION
The [Field] properties inside class are sorted in order of MetadataToken value.

Properties, inherited from base class are first.