### PR TITLE
Optimize code generated by Weaver using `.tail` prefix

### DIFF
--- a/Weaver/Xtensive.Orm.Weaver/Tasks/ImplementFieldAccessorTask.cs
+++ b/Weaver/Xtensive.Orm.Weaver/Tasks/ImplementFieldAccessorTask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -44,6 +44,7 @@ namespace Xtensive.Orm.Weaver.Tasks
       il.Emit(OpCodes.Ldarg_0);
       il.Emit(OpCodes.Ldstr, persistentName);
       il.Emit(OpCodes.Ldarg_1);
+      il.Emit(OpCodes.Tail);
       il.Emit(OpCodes.Call, accessor);
       il.Emit(OpCodes.Ret);
     }
@@ -57,6 +58,7 @@ namespace Xtensive.Orm.Weaver.Tasks
       var il = body.GetILProcessor();
       il.Emit(OpCodes.Ldarg_0);
       il.Emit(OpCodes.Ldstr, persistentName);
+      il.Emit(OpCodes.Tail);
       il.Emit(OpCodes.Call, accessor);
       il.Emit(OpCodes.Ret);
     }


### PR DESCRIPTION
Assembly code generated by JIT for Entity.Field getter:

before optimization (without `.tail`):
```
push        rbp  
sub         rsp,20h  
lea         rbp,[rsp+20h]  
mov         qword ptr [rbp+10h],rcx  
mov         r8,1914C813828h  
mov         r8,qword ptr [r8]  
mov         rcx,qword ptr [rbp+10h]  
mov         rdx,7FFA24FE6D40h  
call        qword ptr [CLRStub[MethodDescPrestub]@00007FFA24FCB078 (07FFA24FCB078h)]  ; GetFieldValue<>()
nop  
add         rsp,20h  
pop         rbp  
ret 
```

After optimization  (with `.tail`):
```
mov         r8,1F7CFC13828h  
mov         r8,qword ptr [r8]  
mov         rdx,7FFA24FE20B0h  
jmp         qword ptr [CLRStub[MethodDescPrestub]@00007FFA25001FA8 (07FFA25001FA8h)]   ; GetFieldValue<>()
```

The same effect for setters (`SetFieldValue()`)

The assembly was build with enabled optimization.

The JIT itself does not apply this kind of optimization
see https://stackoverflow.com/questions/491376/why-doesnt-net-c-optimize-for-tail-call-recursion
https://github.com/dotnet/csharplang/issues/2304



