### PR TITLE
Optimization: Dispatch Translator by virtual functions instead of swi…

### DIFF
--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Translator.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Translator.cs
@@ -231,34 +231,14 @@ namespace Xtensive.Sql.Drivers.Firebird.v2_5
       }
     }
 
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlSelect node, SelectSection section)
-    {
-      switch (section) {
-        case SelectSection.Limit:
-          _ = context.Output.Append("FIRST");
-          break;
-        case SelectSection.Offset:
-          _ = context.Output.Append("SKIP");
-          break;
-        default:
-          base.Translate(context, node, section);
-          break;
-      }
-    }
+    public override void SelectLimit(SqlCompilerContext context, SqlSelect node) =>
+      context.Output.AppendSpacePrefixed("FIRST ");
 
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlUpdate node, UpdateSection section)
-    {
-      switch (section) {
-        case UpdateSection.Limit:
-          _ = context.Output.Append("ROWS");
-          break;
-        default:
-          base.Translate(context, node, section);
-          break;
-      }
-    }
+    public override void SelectOffset(SqlCompilerContext context, SqlSelect node) =>
+      context.Output.AppendSpacePrefixed("SKIP ");
+
+    public override void UpdateLimit(SqlCompilerContext context) =>
+      context.Output.AppendSpaceIfNecessary().Append("ROWS").AppendSpaceIfNecessary();
 
     /// <inheritdoc />
     public override void Translate(SqlCompilerContext context, SqlDelete node, DeleteSection section)

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Compiler.cs
@@ -258,15 +258,15 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
     protected override void VisitSelectLimitOffset(SqlSelect node)
     {
       if (node.Limit is not null) {
-        AppendTranslated(node, SelectSection.Limit);
+        translator.SelectLimit(context, node);
         node.Limit.AcceptVisitor(this);
       }
       if (node.Offset is not null) {
         if (node.Limit is null) {
-          AppendTranslated(node, SelectSection.Limit);
+          translator.SelectLimit(context, node);
           _ = context.Output.Append(" 18446744073709551615 "); // magic number from http://dev.mysql.com/doc/refman/5.0/en/select.html
         }
-        AppendTranslated(node, SelectSection.Offset);
+        translator.SelectOffset(context, node);
         node.Offset.AcceptVisitor(this);
       }
     }
@@ -437,7 +437,7 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
           SqlDml.RawConcat(
             operand,
             SqlDml.Native("AS SIGNED"))));
-    
+
 
     #endregion
 

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/Translator.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/Translator.cs
@@ -70,24 +70,14 @@ namespace Xtensive.Sql.Drivers.Oracle.v09
       base.TranslateString(output, str);
     }
 
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlSelect node, SelectSection section)
-    {
-      switch (section) {
-        case SelectSection.HintsEntry:
-          _ = context.Output.Append("/*+");
-          break;
-        case SelectSection.HintsExit:
-          _ = context.Output.Append("*/");
-          break;
-        case SelectSection.Limit:
-        case SelectSection.Offset:
-          throw new NotSupportedException();
-        default:
-          base.Translate(context, node, section);
-          break;
-      }
-    }
+    public override void SelectLimit(SqlCompilerContext context, SqlSelect node) => throw new NotSupportedException();
+    public override void SelectOffset(SqlCompilerContext context, SqlSelect node) => throw new NotSupportedException();
+
+    public override void SelectHintsEntry(SqlCompilerContext context, SqlSelect node) =>
+      context.Output.AppendSpacePrefixed("/*+ ");
+
+    public override void SelectHintsExit(SqlCompilerContext context, SqlSelect node) =>
+      context.Output.AppendSpacePrefixed("*/ ");
 
     /// <inheritdoc/>
     public override string Translate(SqlJoinMethod method)

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v11/Translator.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v11/Translator.cs
@@ -13,13 +13,8 @@ namespace Xtensive.Sql.Drivers.Oracle.v11
 {
   internal class Translator : v10.Translator
   {
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlOrder node, NodeSection section)
-    {
-      if (section == NodeSection.Exit) {
-        _ = context.Output.Append(node.Ascending ? "ASC NULLS FIRST" : "DESC NULLS LAST");
-      }
-    }
+    public override void OrderExit(SqlCompilerContext context, SqlOrder node) =>
+      context.Output.Append(node.Ascending ? "ASC NULLS FIRST" : "DESC NULLS LAST");
 
     /// <inheritdoc/>
     public override string Translate(SqlValueType type)

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
@@ -453,23 +453,11 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       }
     }
 
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlFetch node, FetchSection section)
-    {
-      switch (section) {
-        case FetchSection.Entry:
-          _ = context.Output.Append("FETCH ").Append(node.Option.ToString().ToUpper());
-          return;
-        case FetchSection.Targets:
-          var output = context.Output;
-          _ = output.Append("FROM ");
-          TranslateIdentifier(output, node.Cursor.Name);
-          return;
-        case FetchSection.Exit:
-          break;
-      }
-      base.Translate(context, node, section);
-    }
+    public override void FetchEntry(SqlCompilerContext context, SqlFetch node) =>
+      context.Output.Append("FETCH ").Append(node.Option.ToString().ToUpper());
+
+    public override void FetchTarget(SqlCompilerContext context, SqlFetch node) =>
+      TranslateIdentifier(context.Output.AppendSpaceIfNecessary().Append("FROM "), node.Cursor.Name);
 
     /// <inheritdoc/>
     public override void Translate(SqlCompilerContext context, SqlOpenCursor node)

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_3/Translator.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_3/Translator.cs
@@ -44,13 +44,8 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_3
       }
     }
 
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlOrder node, NodeSection section)
-    {
-      if (section == NodeSection.Exit) {
-        _ = context.Output.Append(node.Ascending ? "ASC NULLS FIRST" : "DESC NULLS LAST");
-      }
-    }
+    public override void OrderExit(SqlCompilerContext context, SqlOrder node) =>
+      context.Output.Append(node.Ascending ? "ASC NULLS FIRST" : "DESC NULLS LAST");
 
     internal protected string GetFulltextVector(SqlCompilerContext context, FullTextIndex index)
     {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
@@ -83,7 +83,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
           throw new NotSupportedException(Strings.ExStorageDoesNotSupportLimitationOfRowCountToUpdate);
         }
 
-        AppendTranslated(node, UpdateSection.Limit);
+        translator.UpdateLimit(context);
         _ = context.Output.AppendOpeningPunctuation("(");
         node.Limit.AcceptVisitor(this);
         _ = context.Output.Append(")");

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Translator.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Translator.cs
@@ -314,42 +314,31 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       };
     }
 
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlSelect node, SelectSection section)
+    public override void SelectLimit(SqlCompilerContext context, SqlSelect node) =>
+      context.Output.AppendSpacePrefixed("TOP ");
+
+    public override void SelectOffset(SqlCompilerContext context, SqlSelect node) => throw new NotSupportedException();
+
+    public override void SelectExit(SqlCompilerContext context, SqlSelect node)
     {
       var output = context.Output;
-      switch (section) {
-        case SelectSection.Entry:
-          base.Translate(context, node, section);
-          break;
-        case SelectSection.Limit:
-          _ = output.Append("TOP");
-          break;
-        case SelectSection.Offset:
-          throw new NotSupportedException();
-        case SelectSection.Exit:
-          var hasHints = false;
-          foreach (var hint in node.Hints) {
-            switch (hint) {
-              case SqlForceJoinOrderHint:
-                AppendHint(output, "FORCE ORDER", ref hasHints);
-                break;
-              case SqlFastFirstRowsHint sqlFastFirstRowsHint:
-                AppendHint(output, "FAST ", ref hasHints);
-                _ = output.Append(sqlFastFirstRowsHint.Amount);
-                break;
-              case SqlNativeHint sqlNativeHint:
-                AppendHint(output, sqlNativeHint.HintText, ref hasHints);
-                break;
-            }
-          }
-          if (hasHints) {
-            _ = output.Append(")");
-          }
-          break;
-        default:
-          base.Translate(context, node, section);
-          break;
+      var hasHints = false;
+      foreach (var hint in node.Hints) {
+        switch (hint) {
+          case SqlForceJoinOrderHint:
+            AppendHint(output, "FORCE ORDER", ref hasHints);
+            break;
+          case SqlFastFirstRowsHint sqlFastFirstRowsHint:
+            AppendHint(output, "FAST ", ref hasHints);
+            _ = output.Append(sqlFastFirstRowsHint.Amount);
+            break;
+          case SqlNativeHint sqlNativeHint:
+            AppendHint(output, sqlNativeHint.HintText, ref hasHints);
+            break;
+        }
+      }
+      if (hasHints) {
+        _ = output.Append(")");
       }
 
       static void AppendHint(IOutput output, string hint, ref bool hasHints)
@@ -365,18 +354,8 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       }
     }
 
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlUpdate node, UpdateSection section)
-    {
-      switch (section) {
-        case UpdateSection.Limit:
-          _ = context.Output.Append("TOP");
-          break;
-        default:
-          base.Translate(context, node, section);
-          break;
-      }
-    }
+    public override void UpdateLimit(SqlCompilerContext context) =>
+      context.Output.AppendSpaceIfNecessary().Append("TOP").AppendSpaceIfNecessary();
 
     /// <inheritdoc/>
     public override void Translate(SqlCompilerContext context, SqlDelete node, DeleteSection section)
@@ -677,19 +656,19 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
     {
       return @"DECLARE @{0} VARCHAR(256)
         SELECT @{0} = {1}.sys.default_constraints.name
-      FROM 
+      FROM
         {1}.sys.all_columns
       INNER JOIN
         {1}.sys.tables
       ON all_columns.object_id = tables.object_id
-      INNER JOIN 
+      INNER JOIN
         {1}.sys.schemas
-      ON tables.schema_id = schemas.schema_id  
+      ON tables.schema_id = schemas.schema_id
       INNER JOIN
         {1}.sys.default_constraints
       ON all_columns.default_object_id = default_constraints.object_id
 
-      WHERE 
+      WHERE
         schemas.name = '{2}'
         AND tables.name = '{3}'
         AND all_columns.name = '{4}'";

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Compiler.cs
@@ -26,7 +26,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
         return; // Nothing to process.
       }
 
-      AppendTranslated(node, SelectSection.Offset);
+      translator.SelectOffset(context, node);
 
       if (node.HasOffset) {
         node.Offset.AcceptVisitor(this);
@@ -35,14 +35,12 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
         _ = context.Output.Append("0");
       }
 
-      AppendSpaceIfNecessary();
-      translator.Translate(context, node, SelectSection.OffsetEnd);
+      translator.SelectOffsetEnd(context, node);
 
       if (node.HasLimit) {
-        AppendTranslated(node, SelectSection.Limit);
+        translator.SelectLimit(context, node);
         node.Limit.AcceptVisitor(this);
-        AppendSpaceIfNecessary();
-        translator.Translate(context, node, SelectSection.LimitEnd);
+        translator.SelectLimitEnd(context, node);
       }
     }
 

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Translator.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v11/Translator.cs
@@ -50,28 +50,17 @@ namespace Xtensive.Sql.Drivers.SqlServer.v11
       }
     }
 
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlSelect node, SelectSection section)
-    {
-      var output = context.Output;
-      switch (section) {
-        case SelectSection.Limit:
-          _ = output.Append("FETCH NEXT");
-          break;
-        case SelectSection.LimitEnd:
-          _ = output.Append("ROWS ONLY");
-          break;
-        case SelectSection.Offset:
-          _ = output.Append("OFFSET");
-          break;
-        case SelectSection.OffsetEnd:
-          _ = output.Append("ROWS");
-          break;
-        default:
-          base.Translate(context, node, section);
-          break;
-      }
-    }
+    public override void SelectLimit(SqlCompilerContext context, SqlSelect node) =>
+      context.Output.AppendSpacePrefixed("FETCH NEXT ");
+
+    public override void SelectOffset(SqlCompilerContext context, SqlSelect node) =>
+      context.Output.AppendSpacePrefixed("OFFSET ");
+
+    public override void SelectLimitEnd(SqlCompilerContext context, SqlSelect node) =>
+      context.Output.AppendSpacePrefixed("ROWS ONLY ");
+
+    public override void SelectOffsetEnd(SqlCompilerContext context, SqlSelect node) =>
+      context.Output.AppendSpacePrefixed("ROWS ");
 
     private void TranslateSequenceStatement(SqlCompilerContext context, Sequence sequence, string action)
     {

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Compiler.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Compiler.cs
@@ -351,13 +351,13 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
         return;
       }
 
-      AppendTranslated(node, SelectSection.Limit);
+      translator.SelectLimit(context, node);
       SqlDml.Literal(-1).AcceptVisitor(this);
-      AppendTranslated(node, SelectSection.LimitEnd);
+      translator.SelectLimitEnd(context, node);
 
-      AppendTranslated(node, SelectSection.Offset);
+      translator.SelectOffset(context, node);
       node.Offset.AcceptVisitor(this);
-      AppendTranslated(node, SelectSection.OffsetEnd);
+      translator.SelectOffsetEnd(context, node);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Translator.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Translator.cs
@@ -274,17 +274,17 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
       }
     }
 
-    /// <inheritdoc/>
-    public override void Translate(SqlCompilerContext context, SqlUpdate node, UpdateSection section)
-    {
-      _ = context.Output.Append(section switch {
-        UpdateSection.Entry => "UPDATE",
-        UpdateSection.Set => "SET",
-        UpdateSection.From => "FROM",
-        UpdateSection.Where => "WHERE",
-        _ => string.Empty
-      });
-    }
+    public override void UpdateSet(SqlCompilerContext context) =>
+      context.Output.AppendSpaceIfNecessary().Append("SET").AppendSpaceIfNecessary();
+
+    public override void UpdateFrom(SqlCompilerContext context) =>
+      context.Output.AppendSpaceIfNecessary().Append("FROM").AppendSpaceIfNecessary();
+
+    public override void UpdateWhere(SqlCompilerContext context, SqlUpdate node) =>
+      context.Output.AppendSpaceIfNecessary().Append("WHERE").AppendSpaceIfNecessary();
+
+    public override void UpdateLimit(SqlCompilerContext context) =>
+      context.Output.AppendSpaceIfNecessary();
 
     /// <inheritdoc/>
     public override void Translate(SqlCompilerContext context, SqlCreateIndex node, CreateIndexSection section)

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -273,6 +273,9 @@ namespace Xtensive.Sql.Compiler
       return AppendSpace();
     }
 
+    public IOutput AppendSpacePrefixed(string text) =>
+      AppendSpaceIfNecessary().Append(text);
+
     /// <inheritdoc/>
     public IOutput AppendNewLine(string text)
     {

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlNodeSections.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlNodeSections.cs
@@ -44,14 +44,6 @@ namespace Xtensive.Sql.Compiler
     ForeignKey = 5,
     ReferencedColumns = 6,
   }
-  
-  public enum BetweenSection
-  {
-    Entry = 0,
-    Exit = 1,
-    Between = 2,
-    And = 3,
-  }
 
   public enum CaseSection
   {
@@ -61,13 +53,6 @@ namespace Xtensive.Sql.Compiler
     When = 3,
     Then = 4,
     Else = 5,
-  }
-
-  public enum ColumnSection
-  {
-    Entry = 0,
-    Exit = 1,
-    AliasDeclaration = 2,
   }
 
   public enum CreateDomainSection
@@ -123,13 +108,6 @@ namespace Xtensive.Sql.Compiler
     Limit = 4,
   }
 
-  public enum FetchSection
-  {
-    Entry = 0,
-    Exit = 1,
-    Targets = 2,
-  }
-  
   public enum FunctionCallSection
   {
     Entry = 0,
@@ -151,40 +129,11 @@ namespace Xtensive.Sql.Compiler
     AlterMinValue = 7,
   }
 
-  public enum IfSection
-  {
-    Entry = 0,
-    Exit = 1,
-    True = 2,
-    False = 3,
-  }
-
-  public enum InsertSection
-  {
-    Entry = 0,
-    Exit = 1,
-    ColumnsEntry = 2,
-    ColumnsExit = 4,
-    ValuesEntry = 3,
-    ValuesExit = 5,
-    DefaultValues = 6,
-    From = 7,
-  }
-
   public enum JoinSection
   {
     Entry = 0,
     Exit = 1,
     Specification = 2,
-    Condition = 3,
-  }
-
-  public enum LikeSection
-  {
-    Entry = 0,
-    Exit = 1,
-    Like = 2,
-    Escape = 3,
   }
 
   public enum MatchSection
@@ -192,23 +141,6 @@ namespace Xtensive.Sql.Compiler
     Entry = 0,
     Exit = 1,
     Specification = 2,
-  }
-
-  public enum SelectSection
-  {
-    Entry = 0,
-    Exit = 1,
-    From = 3,
-    Where = 4,
-    GroupBy = 5,
-    Having = 6,
-    OrderBy = 7,
-    HintsEntry = 8,
-    HintsExit = 9,
-    Limit = 10,
-    Offset = 11,
-    LimitEnd = 12,
-    OffsetEnd = 13,
   }
 
   public enum TableSection
@@ -254,23 +186,6 @@ namespace Xtensive.Sql.Compiler
     Entry = 0,
     Exit = 1,
     EmptyArray = 2,
-  }
-
-  public enum UpdateSection
-  {
-    Entry = 0,
-    Exit = 1,
-    Set = 2,
-    From = 3,
-    Where = 4,
-    Limit = 5,
-  }
-
-  public enum WhileSection
-  {
-    Entry = 0,
-    Exit = 1,
-    Statement = 2,
   }
 
   public enum QueryExpressionSection


### PR DESCRIPTION
Using Virtual-function dispatching minimizes number of branches, which is a bottleneck in CPU

This approach applied to `SELECT` translator only as an example.
Can be propagated to other frequently used SQL statements

Also:
* Add trailing spaces explicitly when we are sure they must be to avoid costly string analysis for pretty SQL presentation