### PR TITLE
Fixes translation issue of calculated expression with conditional expressions 

### DIFF
--- a/ChangeLog/6.0.13_dev.txt
+++ b/ChangeLog/6.0.13_dev.txt
@@ -1,2 +1,4 @@
 [main] Fixed certain cases of bad translation of casts via 'as' operator in LINQ queries
 [main] Addressed certain issues of translation connected with comparison with local entity instace within LINQ queries
+[main] Fixed rare issues of incorrect translation of filtered index expressions including conditional expressions
+[postgresql] Fixed issue of incorrect translation of contitional expressions including comparison with nullable fields

--- a/Orm/Xtensive.Orm.Tests.Framework/NUnitFrameworkExtensions/RequireProviderAttributes.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/NUnitFrameworkExtensions/RequireProviderAttributes.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace Xtensive.Orm.Tests
+{
+  /// <summary>
+  /// Base attribute for test storage requirement
+  /// </summary>
+  public abstract class RequireProvderAttribute : Attribute, ITestAction
+  {
+    private Version minVersion = null;
+    private Version maxVersion = null;
+
+    /// <summary>
+    /// Gets or sets Minimal version that required for test.
+    /// If not set, version check is not applied
+    /// </summary>
+    public virtual string MinVersion
+    {
+      get { return (minVersion == null) ? null : minVersion.ToString(); }
+      set {
+        if (value == null)
+          minVersion = null;
+        else if (!Version.TryParse(value, out minVersion))
+          throw new ArgumentException("Not a version string", nameof(value));
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets Maximal version that required for test.
+    /// If not set, version check is not applied.
+    /// </summary>
+    public virtual string MaxVersion
+    {
+      get { return (maxVersion == null) ? null : maxVersion.ToString(); }
+      set {
+        if (value == null)
+          maxVersion = null;
+        else if (!Version.TryParse(value, out maxVersion))
+          throw new ArgumentException("Not a version string", nameof(value));
+      }
+    }
+
+    protected abstract StorageProvider RequiredProviders { get; }
+
+    public ActionTargets Targets => ActionTargets.Test;
+
+    public void AfterTest(ITest test)
+    {
+      Require.ProviderIs(RequiredProviders);
+      if (minVersion != null)
+        Require.ProviderVersionAtLeast(minVersion);
+      if (maxVersion != null)
+        Require.ProviderVersionAtMost(maxVersion);
+    }
+
+    public void BeforeTest(ITest test) { }
+  }
+
+  [AttributeUsage(AttributeTargets.Method)]
+  public class RequireSqlServerAttribute : RequireProvderAttribute
+  {
+    protected override StorageProvider RequiredProviders => StorageProvider.SqlServer;
+  }
+
+  [AttributeUsage(AttributeTargets.Method)]
+  public class RequirePostgreSqlAttribute : RequireProvderAttribute
+  {
+    protected override StorageProvider RequiredProviders => StorageProvider.PostgreSql;
+  }
+
+  [AttributeUsage(AttributeTargets.Method)]
+  public class RequireMySqlAttribute : RequireProvderAttribute
+  {
+    protected override StorageProvider RequiredProviders => StorageProvider.MySql;
+  }
+
+  [AttributeUsage(AttributeTargets.Method)]
+  public class RequireFirebirdAttribute : RequireProvderAttribute
+  {
+    protected override StorageProvider RequiredProviders => StorageProvider.Firebird;
+  }
+
+  [AttributeUsage(AttributeTargets.Method)]
+  public class RequireOracleSqlAttribute : RequireProvderAttribute
+  {
+    protected override StorageProvider RequiredProviders => StorageProvider.Oracle;
+  }
+
+  [AttributeUsage(AttributeTargets.Method)]
+  public class RequireSqliteAttribute : RequireProvderAttribute
+  {
+    protected override StorageProvider RequiredProviders => StorageProvider.Sqlite;
+  }
+
+  [AttributeUsage(AttributeTargets.Method)]
+  public class RequireSeveralProvidersAttribute : RequireProvderAttribute
+  {
+    private readonly StorageProvider providers;
+
+    protected override StorageProvider RequiredProviders => providers;
+
+    public override string MinVersion
+    {
+      get => throw new NotSupportedException();
+      set => throw new NotSupportedException();
+    }
+
+    public override string MaxVersion
+    {
+      get => throw new NotSupportedException();
+      set => throw new NotSupportedException();
+    }
+
+    public RequireSeveralProvidersAttribute(StorageProvider allowedProviders)
+    {
+      providers = allowedProviders;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0802_PostgreOrderByWithConditionalIssue.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0802_PostgreOrderByWithConditionalIssue.cs
@@ -1,0 +1,1531 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+// Created by: Alexey Kulakov
+// Created:    2024.01.17
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Xtensive.Core;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Tests.Issues.IssueJira0802_PostgreOrderByWithConditionalIssueModel;
+
+namespace Xtensive.Orm.Tests.Issues
+{
+  public sealed class IssueJira0802_PostgreOrderByWithConditionalIssue : AutoBuildTest
+  {
+    protected override void CheckRequirements() => Require.ProviderIs(StorageProvider.PostgreSql);
+
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var config = base.BuildConfiguration();
+      config.Types.Register(typeof(MesObject).Assembly, typeof(MesObject).Namespace);
+      config.UpgradeMode = DomainUpgradeMode.Recreate;
+      return config;
+    }
+
+    protected override void PopulateData()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var sharedFlow = new LogisticFlow(session, 1000);
+        var uniqueFlow = new LogisticFlow(session, 1100);
+
+        _ = new PickingProductRequirement(session, 10) {
+          Quantity = new DimensionalField(session, 36),
+          InventoryAction = new InventoryAction(session, 100) {
+            LogisticFlow = sharedFlow,
+            NullableField = "a"
+          }
+        };
+
+        _ = new PickingProductRequirement(session, 20) {
+          Quantity = new DimensionalField(session, 35),
+          InventoryAction = new InventoryAction(session, 200) {
+            LogisticFlow = sharedFlow,
+            NullableField = "b"
+          }
+        };
+
+        _ = new PickingProductRequirement(session, 30) {
+          Quantity = new DimensionalField(session, 34),
+          InventoryAction = new InventoryAction(session, 300) {
+            LogisticFlow = sharedFlow,
+            NullableField = "a"
+          }
+        };
+
+        _ = new PickingProductRequirement(session, 40) {
+          Quantity = new DimensionalField(session, 34),
+          InventoryAction = new InventoryAction(session, 400) {
+            LogisticFlow = uniqueFlow,
+            NullableField = null
+          }
+        };
+
+        transaction.Complete();
+      }
+    }
+
+
+    [Test]
+    public void ComplexConditionalByEntityInOrderBy()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var sharedFlow = session.Query.All<LogisticFlow>().First(f => f.ID == 1000);
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.LogisticFlow == sharedFlow ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.LogisticFlow == sharedFlow ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 < 40), Is.False);
+        Assert.That(results.Skip(1).All(a => a.V2 > 40 && a.V2 < 75), Is.True);
+        Assert.That(results[0].V2, Is.LessThan(40));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNumberInOrderBy1()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.ID > 100 ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.ID > 100 ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 < 40), Is.False);
+        Assert.That(results.Skip(1).All(a => a.V2 > 40 && a.V2 < 75), Is.True);
+        Assert.That(results[0].V2, Is.LessThan(40));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNumberInOrderBy2()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.ID == 100 ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.ID == 100 ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Skip(3).All(a => a.V2 > 40 && a.V2 < 75), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderBy1()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 < 40), Is.True);
+        Assert.That(results[3].V2, Is.GreaterThan(40));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderBy2()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField != null ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField != null ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 > 40), Is.True);
+        Assert.That(results[0].V2, Is.LessThan(40));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderBy3()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == "a" ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == "a" ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(2).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Skip(2).All(a => a.V2 > 40 && a.V2 < 75), Is.True);
+        Assert.That(results[0].V2, Is.LessThan(40));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderBy4()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue *
+                (p.InventoryAction.NullableField != "a" || p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue *
+                (p.InventoryAction.NullableField != "a" || p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(2).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Skip(2).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderBy5()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == "b" ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == "b" ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Skip(3).All(a => a.V2 > 40 && a.V2 < 75), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderBy6()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue *
+                (p.InventoryAction.NullableField != "b" || p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue *
+                (p.InventoryAction.NullableField != "b" || p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(1).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Skip(1).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+
+    [Test]
+    public void ComplexConditionalByEntityInOrderByDesc()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var sharedFlow = session.Query.All<LogisticFlow>().First(f => f.ID == 1000);
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.LogisticFlow == sharedFlow ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.LogisticFlow == sharedFlow ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(3).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Take(3).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNumberInOrderByDesc2()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.ID > 100 ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.ID > 100 ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(3).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Take(3).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNumberInOrderByDesc3()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.ID == 100 ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.ID == 100 ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Take(1).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderByDesc1()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(1).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.Skip(1).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderByDesc2()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField != null ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField != null ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.Skip(3).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderByDesc3()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == "a" ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == "a" ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(2).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Take(2).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderByDesc4()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue *
+                (p.InventoryAction.NullableField != "a" || p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue *
+                (p.InventoryAction.NullableField != "a" || p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(2).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.Skip(2).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderByDesc5()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == "b" ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue * (p.InventoryAction.NullableField == "b" ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(1).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.Skip(1).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void ComplexConditionalByNullableFieldInOrderByDesc6()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue *
+                (p.InventoryAction.NullableField != "b" || p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.Quantity.NormalizedValue *
+                (p.InventoryAction.NullableField != "b" || p.InventoryAction.NullableField == null ? margin : 1))
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(3).All(a => a.V2 < 40), Is.True);
+        Assert.That(results.Take(3).All(a => a.V2 > 40), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+
+    [Test]
+    public void SimpleConditionalByEntityInOrderBy()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var sharedFlow = session.Query.All<LogisticFlow>().First(f => f.ID == 1000);
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.LogisticFlow == sharedFlow ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.LogisticFlow == sharedFlow ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.Take(1).All(a => a.V2 == 1), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalByNumberInOrderBy1()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.ID > 100 ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.ID > 100 ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.Take(1).All(a => a.V2 == 1), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalByNumberInOrderBy2()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.ID == 100 ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.ID == 100 ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 == 1), Is.True);
+        Assert.That(results[3].V2, Is.EqualTo(2));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+
+
+    [Test]
+    public void SimpleConditionalWithNullableFieldInOrderBy1()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t)=>t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 == 1), Is.True);
+        Assert.That(results.Skip(3).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalWithNullableFieldInOrderBy2()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != null ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != null ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(1).All(a => a.V2 == 1), Is.True);
+        Assert.That(results.Skip(1).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalWithNullableFieldInOrderBy3()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == "a" ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == "a" ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(2).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.Take(2).All(a => a.V2 == 1), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalWithNullableFieldInOrderBy4()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != "a" || p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != "a" || p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(2).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.Take(2).All(a => a.V2 == 1), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalWithNullableFieldInOrderBy5()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == "b" ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == "b" ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 == 1), Is.True);
+        Assert.That(results.Skip(3).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalWithNullableFieldInOrderBy6()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != "b" || p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != "b" || p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderBy(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.Take(1).All(a => a.V2 == 1), Is.True);
+        Assert.That(results[0].V2, Is.EqualTo(1));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+
+
+    [Test]
+    public void SimpleConditionalByEntityInOrderByDesc()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var sharedFlow = session.Query.All<LogisticFlow>().First(f => f.ID == 1000);
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.LogisticFlow == sharedFlow ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.LogisticFlow == sharedFlow ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 == 2), Is.True);
+        Assert.That(results[3].V2, Is.EqualTo(1));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalByNumberInOrderByDesc1()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.ID > 100 ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.ID > 100 ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 == 2), Is.True);
+        Assert.That(results[3].V2, Is.EqualTo(1));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalByNumberInOrderByDesc2()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.ID == 100 ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.ID == 100 ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 == 1), Is.True);
+        Assert.That(results[0].V2, Is.EqualTo(2));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+
+
+
+    [Test]
+    public void SimpleConditionalByNullableFieldInOrderByDesc1()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 == 1), Is.True);
+        Assert.That(results[0].V2, Is.EqualTo(2));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalByNullableFieldInOrderByDesc2()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != null ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != null ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 == 2), Is.True);
+        Assert.That(results[3].V2, Is.EqualTo(1));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalByNullableFieldInOrderByDesc3()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == "a" ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == "a" ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(2).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.Skip(2).All(a => a.V2 == 1), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalByNullableFieldInOrderByDesc4()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != "a" || p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != "a" || p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(2).All(a => a.V2 == 2), Is.True);
+        Assert.That(results.Skip(2).All(a => a.V2 == 1), Is.True);
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalByNullableFieldInOrderByDesc5()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == "b" ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField == "b" ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Skip(1).All(a => a.V2 == 1), Is.True);
+        Assert.That(results[0].V2, Is.EqualTo(2));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+    [Test]
+    public void SimpleConditionalByNullableFieldInOrderByDesc6()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+
+        session.Events.DbCommandExecuting += CommandExecutingEventHandler;
+        var margin = 2;
+        var results = session.Query.All<PickingProductRequirement>()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != "b" || p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+        session.Events.DbCommandExecuting -= CommandExecutingEventHandler;
+
+        var expected = session.Query.All<PickingProductRequirement>()
+          .AsEnumerable()
+          .Select(
+            p => new {
+              V2 = (int) (p.InventoryAction.NullableField != "b" || p.InventoryAction.NullableField == null ? margin : 1)
+            })
+          .OrderByDescending(t => t.V2)
+          .ToArray();
+
+        Assert.That(expected.Length, Is.EqualTo(4));
+        PrintExpected(expected, (t) => t.V2);
+
+        Assert.That(results.Length, Is.EqualTo(expected.Length));
+        Assert.That(results.Take(3).All(a => a.V2 == 2), Is.True);
+        Assert.That(results[3].V2, Is.EqualTo(1));
+        Assert.That(results.SequenceEqual(expected), Is.True);
+      }
+    }
+
+
+    private void PrintExpected<T>(T[] items, Func<T, int> accessor)
+    {
+      Console.WriteLine();
+      Console.WriteLine("Expected order of values:");
+
+      foreach (var item in items) {
+        Console.WriteLine(accessor(item));
+      }
+    }
+
+
+    private static void CommandExecutingEventHandler(object sender, DbCommandEventArgs e)
+    {
+      var command = e.Command;
+      var commandText = command.CommandText;
+      Console.WriteLine("No Modifications SQL Text:");
+      Console.WriteLine(commandText);
+      var parameters = command.Parameters;
+
+      Console.Write(" Parameters: ");
+      for (int i = 0, count = parameters.Count; i < count; i++) {
+        var parameter = parameters[0];
+        Console.WriteLine($"{parameter.ParameterName} = {parameter.Value.ToString()}");
+      }
+    }
+  }
+}
+
+
+namespace Xtensive.Orm.Tests.Issues.IssueJira0802_PostgreOrderByWithConditionalIssueModel
+{
+  [HierarchyRoot]
+  public class InventoryAction : MesObject
+  {
+    [Field]
+    public Product Product { get; set; }
+
+    [Field]
+    public LogisticFlow LogisticFlow { get; set; }
+
+    [Field(Length = 50)]
+    public string NullableField { get; set; }
+
+    public InventoryAction(Session session, int id)
+      : base(session, id)
+    {
+    }
+  }
+
+  [HierarchyRoot]
+  public class LogisticFlow : MesObject
+  {
+    public LogisticFlow(Session session, int id)
+      : base(session, id)
+    {
+    }
+  }
+
+  [HierarchyRoot]
+  public class Product : MesObject
+  {
+    [Field]
+    public string MeasureType { get; set; }
+
+    public Product(Session session, int id)
+      : base(session, id)
+    {
+    }
+  }
+
+  [HierarchyRoot]
+  public class PickingProductRequirement : MesObject
+  {
+    [Field]
+    [Association(OnOwnerRemove = OnRemoveAction.Clear, OnTargetRemove = OnRemoveAction.Deny)]
+    public Product Product { get; private set; }
+
+    [Field]
+    public DimensionalField Quantity { get; set; }
+
+    [Field]
+    public InventoryAction InventoryAction { get; set; }
+
+    public PickingProductRequirement(Session session, int id)
+      : base(session, id)
+    {
+    }
+  }
+
+  public class DimensionalField : Structure
+  {
+    [Field]
+    public decimal NormalizedValue { get; private set; }
+
+    public DimensionalField(Session session, decimal nValue)
+      : base(session)
+    {
+      NormalizedValue = nValue;
+    }
+  }
+
+  public abstract class MesObject : Entity
+  {
+    [Field, Key]
+    public int ID { get; private set; }
+
+    protected MesObject(Session session, int id)
+      : base(session, id)
+    {
+    }
+
+    protected MesObject(Session session)
+      : base(session)
+    {
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Storage/PartialIndexTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/PartialIndexTest.cs
@@ -14,6 +14,7 @@ using Xtensive.Orm.Tests;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Providers;
 using Xtensive.Orm.Tests.Storage.PartialIndexTestModel;
+using NUnit.Framework.Interfaces;
 
 namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
 {
@@ -70,9 +71,9 @@ namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
   }
 
   [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
-  public class FilterOnReferenceField : TestBase
+  public class FilterOnReferenceField1 : TestBase
   {
-    public static Expression<Func<FilterOnReferenceField, bool>> Index() =>
+    public static Expression<Func<FilterOnReferenceField1, bool>> Index() =>
       test => test.Target != null;
 
     [Field]
@@ -80,13 +81,85 @@ namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
   }
 
   [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
-  public class FilterOnComplexReferenceField : TestBase
+  public class FilterOnReferenceField2 : TestBase
   {
-    public static Expression<Func<FilterOnComplexReferenceField, bool>> Index() =>
+    public static Expression<Func<FilterOnReferenceField2, bool>> Index() =>
+      test => test.Target == null;
+
+    [Field]
+    public TargetEntity Target { get; set; }
+  }
+
+  [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
+  public class FilterOnReferenceField3 : TestBase
+  {
+    public static Expression<Func<FilterOnReferenceField3, bool>> Index() =>
+      test => test.Target == test.Alien;
+
+    [Field]
+    public TargetEntity Target { get; set; }
+
+    [Field]
+    public TargetEntity Alien { get; set; }
+  }
+
+  [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
+  public class FilterOnReferenceField4 : TestBase
+  {
+    public static Expression<Func<FilterOnReferenceField4, bool>> Index() =>
+      test => test.Target != test.Alien;
+
+    [Field]
+    public TargetEntity Target { get; set; }
+
+    [Field]
+    public TargetEntity Alien { get; set; }
+  }
+
+  [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
+  public class FilterOnComplexReferenceField1 : TestBase
+  {
+    public static Expression<Func<FilterOnComplexReferenceField1, bool>> Index() =>
       test => test.Target != null;
 
     [Field]
     public ComplexTargetEntity Target { get; set; }
+  }
+
+  [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
+  public class FilterOnComplexReferenceField2 : TestBase
+  {
+    public static Expression<Func<FilterOnComplexReferenceField2, bool>> Index() =>
+      test => test.Target == null;
+
+    [Field]
+    public ComplexTargetEntity Target { get; set; }
+  }
+
+  [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
+  public class FilterOnComplexReferenceField3 : TestBase
+  {
+    public static Expression<Func<FilterOnComplexReferenceField3, bool>> Index() =>
+      test => test.Target == test.Alien;
+
+    [Field]
+    public ComplexTargetEntity Target { get; set; }
+
+    [Field]
+    public ComplexTargetEntity Alien { get; set; }
+  }
+
+  [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
+  public class FilterOnComplexReferenceField4 : TestBase
+  {
+    public static Expression<Func<FilterOnComplexReferenceField4, bool>> Index() =>
+      test => test.Target != test.Alien;
+
+    [Field]
+    public ComplexTargetEntity Target { get; set; }
+
+    [Field]
+    public ComplexTargetEntity Alien { get; set; }
   }
 
   [HierarchyRoot, Index(nameof(Target), Filter = nameof(Index))]
@@ -168,7 +241,7 @@ namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
   public class ConditionalExpressionSuport : TestBase
   {
     public static Expression<Func<ConditionalExpressionSuport, bool>> Index =>
-      test => test.Id == ((test.TestField == null) ? 100 : 200) ? test.TestField.Contains("hello") : false;
+      test => test.Id == 100 ? test.TestField.Contains("hello") : false;
 
     [Field]
     public string TestField { get; set; }
@@ -530,10 +603,28 @@ namespace Xtensive.Orm.Tests.Storage
     public void SimpleFilterWithPropertyTest() => AssertBuildSuccess(typeof(SimpleFilterWithProperty));
 
     [Test]
-    public void FilterOnReferenceFieldTest() => AssertBuildSuccess(typeof(FilterOnReferenceField));
+    public void FilterOnReferenceFieldTest1() => AssertBuildSuccess(typeof(FilterOnReferenceField1));
 
     [Test]
-    public void FilterOnComplexReferenceFieldTest() => AssertBuildSuccess(typeof(FilterOnComplexReferenceField));
+    public void FilterOnReferenceFieldTest2() => AssertBuildSuccess(typeof(FilterOnReferenceField2));
+
+    [Test]
+    public void FilterOnReferenceFieldTest3() => AssertBuildFailure(typeof(FilterOnReferenceField3));
+
+    [Test]
+    public void FilterOnReferenceFieldTest4() => AssertBuildFailure(typeof(FilterOnReferenceField4));
+
+    [Test]
+    public void FilterOnComplexReferenceFieldTest1() => AssertBuildSuccess(typeof(FilterOnComplexReferenceField1));
+
+    [Test]
+    public void FilterOnComplexReferenceFieldTest2() => AssertBuildSuccess(typeof(FilterOnComplexReferenceField2));
+
+    [Test]
+    public void FilterOnComplexReferenceFieldTest3() => AssertBuildFailure(typeof(FilterOnComplexReferenceField3));
+
+    [Test]
+    public void FilterOnComplexReferenceFieldTest4() => AssertBuildFailure(typeof(FilterOnComplexReferenceField4));
 
     [Test]
     public void FilterOnReferenceFieldIdTest() => AssertBuildSuccess(typeof(FilterOnReferenceIdField));
@@ -553,7 +644,7 @@ namespace Xtensive.Orm.Tests.Storage
     [Test]
     public void ContainsOperatorSupportTest() => AssertBuildSuccess(typeof(ContainsOperatorSupport));
 
-    [Test]
+    [Test, RequirePostgreSql]
     public void ConditionalOperationSupportTest() => AssertBuildSuccess(typeof(ConditionalExpressionSuport));
 
     [Test]
@@ -577,12 +668,34 @@ namespace Xtensive.Orm.Tests.Storage
     [Test]
     public void EnumFieldFilterTest() => AssertBuildSuccess(typeof(EnumFieldFilter));
 
-    [Test]
-    public void ValidateTest()
+    [Test, RequirePostgreSql]
+    public void ValidateTestForPgSql()
     {
       var types = typeof(TestBase).Assembly
         .GetTypes()
-        .Where(type => type.Namespace == typeof(TestBase).Namespace && type != typeof(InheritanceClassTable))
+        .Where(type => type.Namespace == typeof(TestBase).Namespace
+          && type != typeof(InheritanceClassTable)
+          && type != typeof(FilterOnReferenceField3)
+          && type != typeof(FilterOnReferenceField4)
+          && type != typeof(FilterOnComplexReferenceField3)
+          && type != typeof(FilterOnComplexReferenceField4))
+        .ToList();
+      BuildDomain(types, DomainUpgradeMode.Recreate);
+      BuildDomain(types, DomainUpgradeMode.Validate);
+    }
+
+    [Test, RequireSqlServer]
+    public void ValidateTestForSqlServer()
+    {
+      var types = typeof(TestBase).Assembly
+        .GetTypes()
+        .Where(type => type.Namespace == typeof(TestBase).Namespace
+          && type != typeof(InheritanceClassTable)
+          && type != typeof(ConditionalExpressionSuport)
+          && type != typeof(FilterOnReferenceField3)
+          && type != typeof(FilterOnReferenceField4)
+          && type != typeof(FilterOnComplexReferenceField3)
+          && type != typeof(FilterOnComplexReferenceField4))
         .ToList();
       BuildDomain(types, DomainUpgradeMode.Recreate);
       BuildDomain(types, DomainUpgradeMode.Validate);

--- a/Orm/Xtensive.Orm.Tests/Storage/PartialIndexTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/PartialIndexTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2021 Xtensive LLC.
+// Copyright (C) 2011-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -159,6 +159,16 @@ namespace Xtensive.Orm.Tests.Storage.PartialIndexTestModel
   {
     public static Expression<Func<ContainsOperatorSupport, bool>> Index =>
       test => new[] { "1", "2", "3" }.Contains(test.TestField);
+
+    [Field]
+    public string TestField { get; set; }
+  }
+
+  [HierarchyRoot, Index(nameof(TestField), Filter = nameof(Index))]
+  public class ConditionalExpressionSuport : TestBase
+  {
+    public static Expression<Func<ConditionalExpressionSuport, bool>> Index =>
+      test => test.Id == ((test.TestField == null) ? 100 : 200) ? test.TestField.Contains("hello") : false;
 
     [Field]
     public string TestField { get; set; }
@@ -542,6 +552,9 @@ namespace Xtensive.Orm.Tests.Storage
 
     [Test]
     public void ContainsOperatorSupportTest() => AssertBuildSuccess(typeof(ContainsOperatorSupport));
+
+    [Test]
+    public void ConditionalOperationSupportTest() => AssertBuildSuccess(typeof(ConditionalExpressionSuport));
 
     [Test]
     public void DoubleIndexWithNameTest() => AssertBuildSuccess(typeof(DoubleIndexWithName));

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -88,6 +88,8 @@ namespace Xtensive.Orm.Building.Builders
         return BuildEntityCheck(field, b.NodeType);
       if (entityAccessMap.TryGetValue(right, out field) && IsNull(left))
         return BuildEntityCheck(field, b.NodeType);
+      if (entityAccessMap.TryGetValue(left, out var _) && entityAccessMap.TryGetValue(right, out var _))
+        throw UnableToTranslate(b, Strings.ComparisonOfTwoEntityFieldsIsNotSupported);
 
       return base.VisitBinary(b);
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
@@ -15,7 +15,7 @@ using Xtensive.Sql.Dml;
 
 namespace Xtensive.Orm.Providers
 {
-  partial class ExpressionProcessor
+  internal partial class ExpressionProcessor
   {
     private readonly static Type ObjectType = typeof(object);
     private readonly static Type BooleanType = typeof(bool);
@@ -157,7 +157,7 @@ namespace Xtensive.Orm.Providers
 
     private SqlExpression TryTranslateEqualitySpecialCases(SqlExpression left, SqlExpression right)
     {
-      if (right.NodeType==SqlNodeType.Null || emptyStringIsNull && IsEmptyStringLiteral(right))
+      if (right.NodeType==SqlNodeType.Null || EmptyStringIsNull && IsEmptyStringLiteral(right))
         return SqlDml.IsNull(left);
 
       object id = null;
@@ -173,7 +173,7 @@ namespace Xtensive.Orm.Providers
 
     private SqlExpression TryTranslateInequalitySpecialCases(SqlExpression left, SqlExpression right)
     {
-      if (right.NodeType==SqlNodeType.Null || emptyStringIsNull && IsEmptyStringLiteral(right))
+      if (right.NodeType==SqlNodeType.Null || EmptyStringIsNull && IsEmptyStringLiteral(right))
         return SqlDml.IsNotNull(left);
       
       object id = null;

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -344,7 +344,7 @@ namespace Xtensive.Orm.Providers
       else {
         @case[check] = ifTrue;
         @case.Else = ifFalse;
-        return c;
+        return @case;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -352,8 +352,10 @@ namespace Xtensive.Orm.Providers
         ? booleanExpressionConverter.BooleanToInt(check)
         : check;
       var varCheck = boolCheck as SqlVariant;
-      if (!PreferCaseOverVariant && !varCheck.IsNullReference())
+
+      if (!PreferCaseOverVariant && !varCheck.IsNullReference()) {
         return SqlDml.Variant(varCheck.Id, ifFalse, ifTrue);
+      }
       var @case = SqlDml.Case();
       if (fixExpressions && IsBooleanExpression(expression)) {
         @case[check] = booleanExpressionConverter.BooleanToInt(ifTrue);
@@ -482,8 +484,11 @@ namespace Xtensive.Orm.Providers
 
     // Constructors
 
-    public ExpressionProcessor(
-      LambdaExpression lambda, HandlerAccessor handlers, SqlCompiler compiler, in bool preferCaseOverVariant, params IReadOnlyList<SqlExpression>[] sourceColumns)
+    public ExpressionProcessor(LambdaExpression lambda,
+      HandlerAccessor handlers,
+      SqlCompiler compiler,
+      in bool preferCaseOverVariant,
+      params IReadOnlyList<SqlExpression>[] sourceColumns)
     {
       ArgumentValidator.EnsureArgumentNotNull(lambda, "lambda");
       ArgumentValidator.EnsureArgumentNotNull(handlers, "handlers");

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -323,28 +323,27 @@ namespace Xtensive.Orm.Providers
       var check = Visit(expression.Test);
       var ifTrue = Visit(expression.IfTrue);
       var ifFalse = Visit(expression.IfFalse);
-      SqlContainer container = ifTrue as SqlContainer;
-      if (container!=null)
-        ifTrue = TryUnwrapEnum(container);
-      container = ifFalse as SqlContainer;
-      if (container!=null)
-        ifFalse = TryUnwrapEnum(container);
+
+      if (ifTrue is SqlContainer ifTrueContainer)
+        ifTrue = TryUnwrapEnum(ifTrueContainer);
+      if (ifFalse is SqlContainer ifFalseContainer)
+        ifFalse = TryUnwrapEnum(ifFalseContainer);
+
       var boolCheck = fixBooleanExpressions
         ? booleanExpressionConverter.BooleanToInt(check)
         : check;
-      var varCheck = boolCheck as SqlVariant;
-      if (!varCheck.IsNullReference())
-        return SqlDml.Variant(varCheck.Id, ifFalse, ifTrue);
+      //var varCheck = boolCheck as SqlVariant;
+      //if (!varCheck.IsNullReference())
+      //  return SqlDml.Variant(varCheck.Id, ifFalse, ifTrue);
+      var @case = SqlDml.Case();
       if (fixBooleanExpressions && IsBooleanExpression(expression)) {
-        var c = SqlDml.Case();
-        c[check] = booleanExpressionConverter.BooleanToInt(ifTrue);
-        c.Else = booleanExpressionConverter.BooleanToInt(ifFalse);
-        return booleanExpressionConverter.IntToBoolean(c);
+        @case[check] = booleanExpressionConverter.BooleanToInt(ifTrue);
+        @case.Else = booleanExpressionConverter.BooleanToInt(ifFalse);
+        return booleanExpressionConverter.IntToBoolean(@case);
       }
       else {
-        var c = SqlDml.Case();
-        c[check] = ifTrue;
-        c.Else = ifFalse;
+        @case[check] = ifTrue;
+        @case.Else = ifFalse;
         return c;
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/PartialIndexFilterCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/PartialIndexFilterCompiler.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Providers
         .Cast<SqlExpression>()
         .ToList();
 
-      var processor = new ExpressionProcessor(index.Filter.Expression, handlers, null, columns);
+      var processor = new ExpressionProcessor(filter.Expression, handlers, null, true, columns);
       var fragment = SqlDml.Fragment(processor.Translate());
       var result = handlers.StorageDriver.Compile(fragment).GetCommandText();
       return result;

--- a/Orm/Xtensive.Orm/Orm/Providers/PartialIndexFilterCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/PartialIndexFilterCompiler.cs
@@ -1,11 +1,12 @@
-﻿// Copyright (C) 2013 Xtensive LLC
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2013-2024 Xtensive LLC
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2013.07.18
 
 using System.Linq;
 using Xtensive.Orm.Model;
+using Xtensive.Core;
 using Xtensive.Sql;
 using Xtensive.Sql.Dml;
 using Xtensive.Sql.Model;
@@ -16,13 +17,16 @@ namespace Xtensive.Orm.Providers
   {
     public string Compile(HandlerAccessor handlers, IndexInfo index)
     {
-      var table = SqlDml.TableRef(CreateStubTable(index.ReflectedType.MappingName, index.Filter.Fields.Count));
+      var filter = index.Filter;
+      var fieldsCount = filter.Fields.Count;
+
+      var table = SqlDml.TableRef(CreateStubTable(index.ReflectedType.MappingName, fieldsCount));
       // Translation of ColumnRefs without alias seems broken, use original name as alias.
-      var columns = index.Filter.Fields
+      var columns = filter.Fields
         .Select(field => field.Column.Name)
         .Select((name, i) => SqlDml.ColumnRef(table.Columns[i], name))
         .Cast<SqlExpression>()
-        .ToList();
+        .ToList(fieldsCount);
 
       var processor = new ExpressionProcessor(filter.Expression, handlers, null, true, columns);
       var fragment = SqlDml.Fragment(processor.Translate());

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Providers
     protected Pair<SqlExpression, IEnumerable<QueryParameterBinding>> ProcessExpression(LambdaExpression le,
       params IReadOnlyList<SqlExpression>[] sourceColumns)
     {
-      var processor = new ExpressionProcessor(le, Handlers, this, sourceColumns);
+      var processor = new ExpressionProcessor(le, Handlers, this, (Owner ?? RootProvider).Type == ProviderType.Sort, sourceColumns);
       var result = new Pair<SqlExpression, IEnumerable<QueryParameterBinding>>(
         processor.Translate(), processor.GetBindings());
       return result;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
@@ -60,10 +60,10 @@ namespace Xtensive.Orm.Providers
 
     protected virtual string ProcessAliasedName(string name) => name;
 
-    protected Pair<SqlExpression, IEnumerable<QueryParameterBinding>> ProcessExpression(LambdaExpression le,
+    protected Pair<SqlExpression, IEnumerable<QueryParameterBinding>> ProcessExpression(LambdaExpression le, in bool preferCaseOverVariant,
       params IReadOnlyList<SqlExpression>[] sourceColumns)
     {
-      var processor = new ExpressionProcessor(le, Handlers, this, (Owner ?? RootProvider).Type == ProviderType.Sort, sourceColumns);
+      var processor = new ExpressionProcessor(le, Handlers, this, preferCaseOverVariant, sourceColumns);
       var result = new Pair<SqlExpression, IEnumerable<QueryParameterBinding>>(
         processor.Translate(), processor.GetBindings());
       return result;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -111,7 +111,7 @@ namespace Xtensive.Orm.Providers
       var sourceColumns = ExtractColumnExpressions(sqlSelect);
       var allBindings = EnumerableUtils<QueryParameterBinding>.Empty;
       foreach (var column in provider.CalculatedColumns) {
-        var result = ProcessExpression(column.Expression, sourceColumns);
+        var result = ProcessExpression(column.Expression, true, sourceColumns);
         var predicate = result.First;
         var bindings = result.Second;
         if (column.Type.StripNullable()==typeof (bool))
@@ -150,7 +150,7 @@ namespace Xtensive.Orm.Providers
       var query = ExtractSqlSelect(provider, source);
 
       var sourceColumns = ExtractColumnExpressions(query);
-      var result = ProcessExpression(provider.Predicate, sourceColumns);
+      var result = ProcessExpression(provider.Predicate, true, sourceColumns);
       var predicate = result.First;
       var bindings = result.Second;
 
@@ -254,7 +254,7 @@ namespace Xtensive.Orm.Providers
 
       var joinType = provider.JoinType==JoinType.LeftOuter ? SqlJoinType.LeftOuterJoin : SqlJoinType.InnerJoin;
 
-      var result = ProcessExpression(provider.Predicate, leftExpressions, rightExpressions);
+      var result = ProcessExpression(provider.Predicate, false, leftExpressions, rightExpressions);
       var joinExpression = result.First;
       var bindings = result.Second;
 

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -260,6 +260,15 @@ namespace Xtensive {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Comparison of two entity fields is not supported..
+        /// </summary>
+        internal static string ComparisonOfTwoEntityFieldsIsNotSupported {
+            get {
+                return ResourceManager.GetString("ComparisonOfTwoEntityFieldsIsNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ComparisonRule({0}, {1}).
         /// </summary>
         internal static string ComparisonRuleFormat {

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -3473,4 +3473,7 @@ Error: {1}</value>
   <data name="ExXExpressionsWithConstantValuesOfYTypeNotSupported" xml:space="preserve">
     <value>{0} expressions with constant values of {1} type are not supported.</value>
   </data>
+  <data name="ComparisonOfTwoEntityFieldsIsNotSupported" xml:space="preserve">
+    <value>Comparison of two entity fields is not supported.</value>
+  </data>
 </root>


### PR DESCRIPTION
Some conditional expressions are not translated into SqlCase, but to SqlVariant, at the same time other providers use SqlCase successfully.

This led to wrong result SQL query text in many parts, like ORDER BY, GROUP BY. This happened because instead of entire expression postprocessor as expected chose either of two branches of SqlVariant. For example, for query like
```
session.Query.All<SomeTable>().OrderBy(e=> e.MultiplyCoefficient * (e.SomeEntityRef == localEntityRef ? 2 : 1));
```
it led to something static value of 2 instead of expression which should be applied to every row in results, similar to this

```
SELECT *
FROM "SomeTable" "a"
ORDER BY "a"."MultiplyCoefficient" * 2;
```
when correct SQL text should be similar to this

```
SELECT *
FROM "SomeTable" "a"
ORDER BY "a"."MultiplyCoefficient" * (CASE WHEN  "a"."SomeEntityRef.Id" = @p0_1 THEN 2 ELSE 1 END);
```