### PR TITLE
No warning that netcoreapp3.0 is no longer supported

### DIFF
--- a/Weaver/Xtensive.Orm.Weaver/Xtensive.Orm.Weaver.csproj
+++ b/Weaver/Xtensive.Orm.Weaver/Xtensive.Orm.Weaver.csproj
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>$(OrmKeyFile)</AssemblyOriginatorKeyFile>
     <OutputPath>$(BaseOutputPath)tools\weaver\</OutputPath>
     <RollForward>Major</RollForward>
+    <NoWarn>NETSDK1138</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.0" />


### PR DESCRIPTION
We know this, can't change it for 6.0 and warning is annoying.