### PR TITLE
Fix failing reprocessing tests on certain providers.

### DIFF
--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/DeadlockReprocessing.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/DeadlockReprocessing.cs
@@ -10,77 +10,77 @@ using System.Transactions;
 using NUnit.Framework;
 using TestCommon.Model;
 using Xtensive.Orm.Reprocessing.Tests.ReprocessingContext;
+using Xtensive.Orm.Tests;
 
 namespace Xtensive.Orm.Reprocessing.Tests
 {
-  [TestFixture, Timeout(DefaultTestTimeout * 4)]
+  [TestFixture]
   public class DeadlockReprocessing : ReprocessingBaseTest
   {
+    protected override void CheckRequirements()
+    {
+      base.CheckRequirements();
+      Require.ProviderIsNot(StorageProvider.Firebird, "Throws timeout operation instead of deadlock, which is not reprocessible.");
+    }
+
     [Test, Timeout(DefaultTestTimeout)]
     public void SimpleDeadlockTest()
     {
-      Console.WriteLine("Test started");
-
-      var context = new Context(Domain);
-      context.Run(IsolationLevel.Serializable, null, context.Deadlock);
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(2));
+      using (var context = new Context(Domain)) {
+        context.Run(IsolationLevel.Serializable, null, context.Deadlock);
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(2));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSerializableDeadlockTest()
     {
-      Console.WriteLine("Test started");
-
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.Serializable,
-        null,
-        (b, level, open) => context.Parent(b, level, open, ExecuteActionStrategy.HandleReprocessableException, context.Deadlock));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(4));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.Serializable,
+          null,
+          (b, level, open) => context.Parent(b, level, open, ExecuteActionStrategy.HandleReprocessableException, context.Deadlock));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(4));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSnapshotDeadlockTest()
     {
-      Console.WriteLine("Test started");
-
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.Snapshot,
-        null,
-        (b, level, open) => context.Parent(b, level, open, ExecuteActionStrategy.HandleReprocessableException, context.Deadlock));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(4));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.Snapshot,
+          null,
+          (b, level, open) => context.Parent(b, level, open, ExecuteActionStrategy.HandleReprocessableException, context.Deadlock));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(4));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedNestedSerializableSerializableTest()
     {
-      Console.WriteLine("Test started");
-
       //nested nested serializable deadlock
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.Serializable,
-        null,
-        (b, level, open) =>
-          context.Parent(
-            b,
-            level,
-            open,
-            ExecuteActionStrategy.HandleReprocessableException,
-            (b1, level1, open1) =>
-              context.Parent(b1, level1, open1, ExecuteActionStrategy.HandleReprocessableException, context.Deadlock)));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(6));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.Serializable,
+          null,
+          (b, level, open) =>
+            context.Parent(
+              b,
+              level,
+              open,
+              ExecuteActionStrategy.HandleReprocessableException,
+              (b1, level1, open1) =>
+                context.Parent(b1, level1, open1, ExecuteActionStrategy.HandleReprocessableException, context.Deadlock)));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(6));
+      }
     }
 
-    private int Bar2Count()
-    {
-      return Domain.Execute(session => session.Query.All<Bar2>().Count());
-    }
+    private int Bar2Count() => Domain.Execute(session => session.Query.All<Bar2>().Count());
   }
 }
 

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/UniqueConstraintViolationReprocessing.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/UniqueConstraintViolationReprocessing.cs
@@ -25,12 +25,11 @@ namespace Xtensive.Orm.Reprocessing.Tests
     [Test, Timeout(DefaultTestTimeout)]
     public void SimpleUniqueTest()
     {
-      Console.WriteLine("Test started");
-
-      var context = new Context(Domain);
-      context.Run(null, null, context.UniqueConstraintViolation);
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(2));
+      using (var context = new Context(Domain)) {
+        context.Run(null, null, context.UniqueConstraintViolation);
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(2));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
@@ -74,189 +73,180 @@ namespace Xtensive.Orm.Reprocessing.Tests
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSerializablePrimaryKeyConstraintTest()
     {
-      Console.WriteLine("Test started");
-
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.Serializable,
-        null,
-        (b, level, open) =>
-          context.Parent(
-            b, level, open, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolationPrimaryKey));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(4));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.Serializable,
+          null,
+          (b, level, open) =>
+            context.Parent(
+              b, level, open, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolationPrimaryKey));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(4));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSnapshotPrimaryKeyConstraintTest()
     {
-      Console.WriteLine("Test started");
-
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.Snapshot,
-        null,
-        (b, level, open) =>
-          context.Parent(
-            b, level, open, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolationPrimaryKey));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(4));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.Snapshot,
+          null,
+          (b, level, open) =>
+            context.Parent(
+              b, level, open, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolationPrimaryKey));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(4));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSerializableUniqueIndexTest()
     {
-      Console.WriteLine("Test started");
-
-      var context = new Context(Domain);
-      context.Run(
-      IsolationLevel.Serializable,
-          null,
-          (b, level, open) =>
-            context.Parent(
-              b, level, null, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolation));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(4));
+      using (var context = new Context(Domain)) {
+        context.Run(
+        IsolationLevel.Serializable,
+            null,
+            (b, level, open) =>
+              context.Parent(
+                b, level, null, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolation));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(4));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSnapshotUniqueIndexTest()
     {
-      Console.WriteLine("Test started");
-
-      var context = new Context(Domain);
-      context.Run(
-      IsolationLevel.Snapshot,
-          null,
-          (b, level, open) =>
-            context.Parent(
-              b, level, null, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolation));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(4));
+      using (var context = new Context(Domain)) {
+        context.Run(
+        IsolationLevel.Snapshot,
+            null,
+            (b, level, open) =>
+              context.Parent(
+                b, level, null, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolation));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(4));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSerializableExternalWithoutTxUniqueIndexTest()
     {
-      Console.WriteLine("Test started");
-
       //ExternalWithoutTransaction nested serializable UniqueConstraint
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.Serializable,
-        null,
-        (b, level, open) =>
-          context.External(
-            b,
-            null,
-            open,
-            (s, b1, level1, open1) =>
-              context.Parent(
-                s,
-                b1,
-                IsolationLevel.Serializable,
-                open1,
-                ExecuteActionStrategy.HandleUniqueConstraintViolation,
-                context.UniqueConstraintViolation)));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(4));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.Serializable,
+          null,
+          (b, level, open) =>
+            context.External(
+              b,
+              null,
+              open,
+              (s, b1, level1, open1) =>
+                context.Parent(
+                  s,
+                  b1,
+                  IsolationLevel.Serializable,
+                  open1,
+                  ExecuteActionStrategy.HandleUniqueConstraintViolation,
+                  context.UniqueConstraintViolation)));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(4));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSnapshotExternalWithoutTxUniqueIndexTest()
     {
-      Console.WriteLine("Test started");
-
       //ExternalWithoutTransaction nested snapshot UniqueConstraint
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.Snapshot,
-        null,
-        (b, level, open) =>
-          context.External(
-            b,
-            null,
-            open,
-            (s, b1, level1, open1) =>
-              context.Parent(
-                s,
-                b1,
-                IsolationLevel.Snapshot,
-                open1,
-                ExecuteActionStrategy.HandleUniqueConstraintViolation,
-                context.UniqueConstraintViolation)));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(4));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.Snapshot,
+          null,
+          (b, level, open) =>
+            context.External(
+              b,
+              null,
+              open,
+              (s, b1, level1, open1) =>
+                context.Parent(
+                  s,
+                  b1,
+                  IsolationLevel.Snapshot,
+                  open1,
+                  ExecuteActionStrategy.HandleUniqueConstraintViolation,
+                  context.UniqueConstraintViolation)));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(4));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSerializableExternalWithTxUniqueIndexTest()
     {
-      Console.WriteLine("Test started");
-
       //ExternalWithTransaction nested serializable UniqueConstraint
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.Serializable,
-        null,
-        (b, level, open) =>
-          context.External(
-            b,
-            level,
-            open,
-            (s, b1, level1, open1) =>
-              context.Parent(
-                s,
-                b1,
-                level1,
-                open1,
-                ExecuteActionStrategy.HandleUniqueConstraintViolation,
-                context.UniqueConstraintViolation)));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(6));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.Serializable,
+          null,
+          (b, level, open) =>
+            context.External(
+              b,
+              level,
+              open,
+              (s, b1, level1, open1) =>
+                context.Parent(
+                  s,
+                  b1,
+                  level1,
+                  open1,
+                  ExecuteActionStrategy.HandleUniqueConstraintViolation,
+                  context.UniqueConstraintViolation)));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(6));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedSnapshotExternalWithTxUniqueIndexTest()
     {
-      Console.WriteLine("Test started");
-
       //ExternalWithTransaction nested snapshot UniqueConstraint
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.Snapshot,
-        null,
-        (b, level, open) =>
-          context.External(
-            b,
-            level,
-            open,
-            (s, b1, level1, open1) =>
-              context.Parent(
-                s,
-                b1,
-                level1,
-                open1,
-                ExecuteActionStrategy.HandleUniqueConstraintViolation,
-                context.UniqueConstraintViolation)));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(6));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.Snapshot,
+          null,
+          (b, level, open) =>
+            context.External(
+              b,
+              level,
+              open,
+              (s, b1, level1, open1) =>
+                context.Parent(
+                  s,
+                  b1,
+                  level1,
+                  open1,
+                  ExecuteActionStrategy.HandleUniqueConstraintViolation,
+                  context.UniqueConstraintViolation)));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(6));
+      }
     }
 
     [Test, Timeout(DefaultTestTimeout)]
     public void NestedUniqueIndexWithAutoTransaction()
     {
-      Console.WriteLine("Test started");
-
       //nested UniqueConstraint with auto transaction
-      var context = new Context(Domain);
-      context.Run(
-        IsolationLevel.ReadUncommitted,
-        TransactionOpenMode.Auto,
-        (b, l, o) =>
-          context.Parent(b, l, o, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolation));
-      Assert.That(context.Count, Is.EqualTo(3));
-      Assert.That(Bar2Count(), Is.EqualTo(4));
+      using (var context = new Context(Domain)) {
+        context.Run(
+          IsolationLevel.ReadUncommitted,
+          TransactionOpenMode.Auto,
+          (b, l, o) =>
+            context.Parent(b, l, o, ExecuteActionStrategy.HandleUniqueConstraintViolation, context.UniqueConstraintViolation));
+        Assert.That(context.Count, Is.EqualTo(3));
+        Assert.That(Bar2Count(), Is.EqualTo(4));
+      }
     }
 
     private int Bar2Count()


### PR DESCRIPTION
- deadlock tests were ignored for Firebird, in the actual test FB throws error code recognized as OperationTimeoutException, which is not processable at the moment. This led to infinite execution. Timeouts, introduced earlier, though partially help, but better to not allow them to be reached.
- Reprocessing.Tests.Context is now disposable. Since AutoResetEvents are disposable they dispose before setting to null or in Context.Dispose method.