### PR TITLE
NodeCollection.Add method imrovement

### DIFF
--- a/ChangeLog/6.0.13_dev.txt
+++ b/ChangeLog/6.0.13_dev.txt
@@ -4,4 +4,5 @@
 [main] Join/LeftJoin is denied to have the same expression instance for both inner/outer selector
 [main] Addressed issue when wrong type of join was chosen when .First/FirstOrDefalult() method was used as subquery
 [main] Added dedicated exception when RenameFieldHint.TargetType exists in current model but absent in storage model
+[main] Xtensive.Sql.Model.NodeCollection<T>.Add() throws understandable exception in case of duplicate name of item
 [postgresql] Fixed issue of incorrect translation of contitional expressions including comparison with nullable fields

--- a/Orm/Xtensive.Orm/Sql/Model/NodeCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/NodeCollection.cs
@@ -30,12 +30,23 @@ namespace Xtensive.Sql.Model
     /// <returns><see langword="True"/> if this instance is read-only; otherwise, <see langword="false"/>.</returns>
     public override bool IsReadOnly { get { return IsLocked || base.IsReadOnly; } }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Adds item to collection.
+    /// </summary>
+    /// <param name="item">Item to add</param>
+    /// <exception cref="ArgumentException">The item with same name already exists in the collection</exception>
     public override void Add(TNode item)
     {
       base.Add(item);
-      if (!string.IsNullOrEmpty(item.GetNameInternal()))
-        nameIndex.Add(item.GetNameInternal(), item);
+      var name = item.GetNameInternal();
+      if (!string.IsNullOrEmpty(name)) {
+        try {
+          nameIndex.Add(name, item);
+        }
+        catch(ArgumentException) {
+          throw new ArgumentException(string.Format(Strings.ExItemWithNameXAlreadyExists, name));
+        }
+      }
     }
 
     public override bool Remove(TNode item)


### PR DESCRIPTION
Throws dedicated exception with information about duplicate, instead of general Dictionary counterpart.

Though try...catch is ugly here it is has almost no impact on valid scenarios, it is better that .ContainsKey on every operation for sure.