### PR TITLE
Make EntitySet<T> implement IAsyncEnumerable<T> so that we can use ToListAsync() on EntitySet<T>

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/EntitySetTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/EntitySetTest.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Xtensive.Orm.Tests;
 using Xtensive.Orm.Linq;
@@ -119,6 +120,14 @@ namespace Xtensive.Orm.Tests.Linq
         join e in Session.Query.All<Employee>() on i.DesignatedEmployee equals e
         select e;
       Assert.AreEqual(customer.Invoices.Count, result.ToList().Count);
+    }
+    
+    [Test]
+    public async Task ToListAsyncTest()
+    {
+      var customer = GetCustomer();
+      var invoices = await customer.Invoices.ToListAsync();
+      Assert.AreEqual(customer.Invoices.Count, invoices.Count);
     }
 
     private Customer GetCustomer()


### PR DESCRIPTION
#394 

In previous version of DataObjects, we could use AsAsync() on both IQueryable<T> and EntitySet<T>.
Now that AsAsync() has been removed, we expect ToListAsync() to work for both IQueryable<T> and EntitySet<T> types, but there is a runtime error since EntitySet<T> does not implement IAsyncEnumerable<T>.