### PR TITLE
Ability to load configurations from IConfigurationSection/IConfigurationRoot

### DIFF
--- a/ChangeLog/7.1.2_dev.txt
+++ b/ChangeLog/7.1.2_dev.txt
@@ -1,1 +1,9 @@
 [main] Addressed issue when cycles in Entity dependency graph were not detected
+[main] Intoduced DomainConfuguration.ExtensionConfigurations as unified configuration storage for extensions' configurations
+[main] DomainConfiguration.Load() method now has overloads which gets abstractions from Microsoft.Extensions.Configuration API
+[localization] LocalizationConfiguration.Load() method now has overloads which gets abstractions from Microsoft.Extensions.Configuration API
+[localization] ConfigureLocalizationExtension() extensions for DomainConfiguration are added, check ReadMe/documentation for examples of usage
+[reprocessing] ReprocessingConfiguration.Load() method now has overloads which gets abstractions from Microsoft.Extensions.Configuration API
+[reprocessing] ConfigureReprocessingExtension() extensions for DomainConfiguration are added, check ReadMe/documentation for examples of usage
+[security] SecurityConfiguration.Load() method now has overloads which gets abstractions from Microsoft.Extensions.Configuration API
+[security] ConfigureSecurityExtension() extensions for DomainConfiguration are added, check ReadMe/documentation for examples of usage

--- a/Extensions/TestCommon/ModernConfigurationTestBase.cs
+++ b/Extensions/TestCommon/ModernConfigurationTestBase.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace TestCommon
+{
+  public abstract class ModernConfigurationTestBase
+  {
+    protected enum ConfigTypes
+    {
+      Json,
+      Xml,
+    }
+
+    protected IConfiguration configuration;
+
+    protected abstract ConfigTypes ConfigFormat { get; }
+
+    protected abstract void AddConfigurationFile(IConfigurationBuilder configurationBuilder);
+
+    [OneTimeSetUp]
+    public virtual void BeforeAllTestsSetUp()
+    {
+      var configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.SetBasePath(Directory.GetCurrentDirectory());
+      AddConfigurationFile(configurationBuilder);
+      configuration = (ConfigurationRoot) configurationBuilder.Build();
+    }
+
+    protected void IgnoreIfXml()
+    {
+      if (ConfigFormat == ConfigTypes.Xml)
+        throw new IgnoreException("Not valid for Xml format");
+    }
+    protected void IgnoreIfJson()
+    {
+      if (ConfigFormat == ConfigTypes.Json)
+        throw new IgnoreException("Not valid for JSON format");
+    }
+
+    protected IConfigurationSection GetAndCheckConfigurationSection(string sectionName)
+    {
+      var section = configuration.GetSection(sectionName);
+      Assert.That(section, Is.Not.Null);
+      return section;
+    }
+  }
+}

--- a/Extensions/TestCommon/ModernConfigurationTestBase.cs
+++ b/Extensions/TestCommon/ModernConfigurationTestBase.cs
@@ -17,7 +17,7 @@ namespace TestCommon
       Xml,
     }
 
-    protected IConfiguration configuration;
+    protected IConfigurationRoot configurationRoot;
 
     protected abstract ConfigTypes ConfigFormat { get; }
 
@@ -29,7 +29,7 @@ namespace TestCommon
       var configurationBuilder = new ConfigurationBuilder();
       configurationBuilder.SetBasePath(Directory.GetCurrentDirectory());
       AddConfigurationFile(configurationBuilder);
-      configuration = (ConfigurationRoot) configurationBuilder.Build();
+      configurationRoot = (ConfigurationRoot) configurationBuilder.Build();
     }
 
     protected void IgnoreIfXml()
@@ -45,7 +45,7 @@ namespace TestCommon
 
     protected IConfigurationSection GetAndCheckConfigurationSection(string sectionName)
     {
-      var section = configuration.GetSection(sectionName);
+      var section = configurationRoot.GetSection(sectionName);
       Assert.That(section, Is.Not.Null);
       return section;
     }

--- a/Extensions/TestCommon/ModernConfigurationTestBase.cs
+++ b/Extensions/TestCommon/ModernConfigurationTestBase.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 
 namespace TestCommon
 {
-  public abstract class ModernConfigurationTestBase
+  public abstract class MicrosoftConfigurationTestBase
   {
     protected enum ConfigTypes
     {

--- a/Extensions/TestCommon/TestCommon.csproj
+++ b/Extensions/TestCommon/TestCommon.csproj
@@ -10,9 +10,15 @@
   <Import Project="$(SolutionDir)MSBuild\DataObjects.Net.InternalBuild.targets" />
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/Extensions/TestCommon/TestCommon.csproj
+++ b/Extensions/TestCommon/TestCommon.csproj
@@ -8,22 +8,13 @@
     <AssemblyOriginatorKeyFile>$(ExtensionsKeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="$(SolutionDir)MSBuild\DataObjects.Net.InternalBuild.targets" />
-  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.BulkOperations/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.BulkOperations/NugetContent/ReadMe.md
@@ -8,7 +8,7 @@ to server-side UPDATE or DELETE commands.
 
 Prerequisites
 -------------
-DataObjects.Net 7.0.x (http://dataobjects.net)
+DataObjects.Net 7.1.x (http://dataobjects.net)
 
 
 Examples of usage

--- a/Extensions/Xtensive.Orm.Localization.Tests/LocalizationSettings.config
+++ b/Extensions/Xtensive.Orm.Localization.Tests/LocalizationSettings.config
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <!-- No elements, all names should be default-->
+  <Xtensive.Orm.Localization.Xml.Empty>
+  </Xtensive.Orm.Localization.Xml.Empty>
+
+  <!--Names are empty, all names should be default-->
+  <Xtensive.Orm.Localization.Xml.NameEmpty>
+    <DefaultCulture></DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.NameEmpty>
+
+  <Xtensive.Orm.Localization.Xml.NameDefined>
+    <DefaultCulture>es-ES</DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.NameDefined>
+
+  <Xtensive.Orm.Localization.Xml.FaultyValue>
+    <DefaultCulture>ololo</DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.FaultyValue>
+
+  <!-- Different namings schemes of elements -->
+  <!-- LC - lower case -->
+  <!-- UC - upper case -->
+  <!-- CC - camel case -->
+  <!-- PC - pascal case-->
+  <Xtensive.Orm.Localization.Xml.Naming.LC>
+    <defaultculture>es-ES</defaultculture>
+  </Xtensive.Orm.Localization.Xml.Naming.LC>
+
+  <Xtensive.Orm.Localization.Xml.Naming.UC>
+    <DEFAULTCULTURE>es-ES</DEFAULTCULTURE>
+  </Xtensive.Orm.Localization.Xml.Naming.UC>
+
+  <Xtensive.Orm.Localization.Xml.Naming.CC>
+    <defaultCulture>es-ES</defaultCulture>
+  </Xtensive.Orm.Localization.Xml.Naming.CC>
+
+  <Xtensive.Orm.Localization.Xml.Naming.PC>
+    <DefaultCulture>es-ES</DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.Naming.PC>
+
+  <!-- Cases of mistyping of element names -->
+  <!-- LC - lower case -->
+  <!-- UC - upper case -->
+  <!-- CC - camel case -->
+  <!-- PC - pascal case-->
+  <Xtensive.Orm.Localization.Xml.Mistype.LC>
+    <defailtculture>es-ES</defailtculture>
+  </Xtensive.Orm.Localization.Xml.Mistype.LC>
+
+  <Xtensive.Orm.Localization.Xml.Mistype.UC>
+    <DEFAILTCULTURE>es-ES</DEFAILTCULTURE>
+  </Xtensive.Orm.Localization.Xml.Mistype.UC>
+
+  <Xtensive.Orm.Localization.Xml.Mistype.CC>
+    <defailtCulture>es-ES</defailtCulture>
+  </Xtensive.Orm.Localization.Xml.Mistype.CC>
+
+  <Xtensive.Orm.Localization.Xml.Mistype.PC>
+    <DefailtCulture>es-ES</DefailtCulture>
+  </Xtensive.Orm.Localization.Xml.Mistype.PC>
+
+  <!-- Cases of configuration when service name is represented by Name child node -->
+  <Xtensive.Orm.Localization.Xml.NameNode.NameEmpty>
+    <DefaultCulture>
+      <Name></Name>
+    </DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.NameNode.NameEmpty>
+
+  <Xtensive.Orm.Localization.Xml.NameNode.Espaniol>
+    <DefaultCulture>
+      <Name>es-ES</Name>
+    </DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.NameNode.Espaniol>
+
+  <Xtensive.Orm.Localization.Xml.NameNode.FaultyValue>
+    <DefaultCulture>
+      <Name>ololo</Name>
+    </DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.NameNode.FaultyValue>
+
+  <Xtensive.Orm.Localization.Xml.NameNode.Naming.LC>
+    <DefaultCulture>
+      <name>es-ES</name>
+    </DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.NameNode.Naming.LC>
+
+  <Xtensive.Orm.Localization.Xml.NameNode.Naming.UC>
+    <DefaultCulture>
+      <NAME>es-ES</NAME>
+    </DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.NameNode.Naming.UC>
+
+  <Xtensive.Orm.Localization.Xml.NameNode.Naming.CC>
+    <DefaultCulture>
+      <naMe>es-ES</naMe>
+    </DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.NameNode.Naming.CC>
+
+  <Xtensive.Orm.Localization.Xml.NameNode.Naming.PC>
+    <DefaultCulture>
+      <NaMe>es-ES</NaMe>
+    </DefaultCulture>
+  </Xtensive.Orm.Localization.Xml.NameNode.Naming.PC>
+  
+  
+  <!-- combinations of Xml-specifit cases, mostly old-fashion attributes -->
+  <Xtensive.Orm.Localization.NameAttribute.NameEmpty>
+    <defaultCulture name="" />
+  </Xtensive.Orm.Localization.NameAttribute.NameEmpty>
+
+  <Xtensive.Orm.Localization.NameAttribute.None>
+    <defaultCulture />
+  </Xtensive.Orm.Localization.NameAttribute.None>
+
+  <Xtensive.Orm.Localization.NameAttribute.Defined>
+    <defaultCulture name="es-ES" />
+  </Xtensive.Orm.Localization.NameAttribute.Defined>
+
+  <Xtensive.Orm.Localization.NameAttribute.FaultyValue>
+    <defaultCulture name="ololo" />
+  </Xtensive.Orm.Localization.NameAttribute.FaultyValue>
+
+  <Xtensive.Orm.Localization.NameAttribute.LC>
+    <defaultculture name="es-ES" />
+  </Xtensive.Orm.Localization.NameAttribute.LC>
+
+  <Xtensive.Orm.Localization.NameAttribute.UC>
+    <DEFAULTCULTURE name="es-ES" />
+  </Xtensive.Orm.Localization.NameAttribute.UC>
+
+  <Xtensive.Orm.Localization.NameAttribute.PC>
+    <DefaultCulture name="es-ES" />
+  </Xtensive.Orm.Localization.NameAttribute.PC>
+
+</configuration>

--- a/Extensions/Xtensive.Orm.Localization.Tests/MicrosoftConfigurationTests.cs
+++ b/Extensions/Xtensive.Orm.Localization.Tests/MicrosoftConfigurationTests.cs
@@ -10,7 +10,7 @@ using Xtensive.Orm.Localization.Configuration;
 
 namespace Xtensive.Orm.Localization.Tests.Configuration
 {
-  public sealed class JsonConfigurationTest : ModernConfigurationTest
+  public sealed class JsonConfigurationTest : MicrosoftConfigurationTest
   {
     protected override ConfigTypes ConfigFormat => ConfigTypes.Json;
 
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Localization.Tests.Configuration
     }
   }
 
-  public sealed class XmlConfigurationTest : ModernConfigurationTest
+  public sealed class XmlConfigurationTest : MicrosoftConfigurationTest
   {
     protected override ConfigTypes ConfigFormat => ConfigTypes.Xml;
 
@@ -98,7 +98,7 @@ namespace Xtensive.Orm.Localization.Tests.Configuration
   }
 
   [TestFixture]
-  public abstract class ModernConfigurationTest : TestCommon.ModernConfigurationTestBase
+  public abstract class MicrosoftConfigurationTest : TestCommon.MicrosoftConfigurationTestBase
   {
     protected readonly CultureInfo defaultCulture = new CultureInfo("en-US");
     protected readonly CultureInfo expectedCulture = new CultureInfo("es-ES");

--- a/Extensions/Xtensive.Orm.Localization.Tests/ModernConfigurationTests.cs
+++ b/Extensions/Xtensive.Orm.Localization.Tests/ModernConfigurationTests.cs
@@ -1,0 +1,312 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Globalization;
+using System.Threading;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Xtensive.Orm.Localization.Configuration;
+
+namespace Xtensive.Orm.Localization.Tests.Configuration
+{
+  public sealed class JsonConfigurationTest : ModernConfigurationTest
+  {
+    protected override ConfigTypes ConfigFormat => ConfigTypes.Json;
+
+    protected override void AddConfigurationFile(IConfigurationBuilder configurationBuilder)
+    {
+      _ = configurationBuilder.AddJsonFile("localizationsettings.json");
+    }
+  }
+
+  public sealed class XmlConfigurationTest : ModernConfigurationTest
+  {
+    protected override ConfigTypes ConfigFormat => ConfigTypes.Xml;
+
+    protected override void AddConfigurationFile(IConfigurationBuilder configurationBuilder)
+    {
+      _ = configurationBuilder.AddXmlFile("LocalizationSettings.config");
+    }
+
+    [Test]
+    public void NameAttributeEmptyNameTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.NameEmpty");
+      var locConfig = LocalizationConfiguration.Load(section);
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+    [Test]
+    public void NameAttributeAbsentTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.None");
+      var locConfig = LocalizationConfiguration.Load(section);
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+
+    [Test]
+    public void NameAttributeDefinedTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.Defined");
+      var locConfig = LocalizationConfiguration.Load(section);
+      Assert.That(locConfig, Is.Not.Null);
+      Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
+    }
+
+    [Test]
+    public void NameAttributeFaultyValueTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.FaultyValue");
+      var locConfig = LocalizationConfiguration.Load(section);
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+    [Test]
+    public void NameAttributeLowCase()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.LC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      Assert.That(locConfig, Is.Not.Null);
+      Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
+    }
+
+    [Test]
+    public void NameAttributeUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.UC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      Assert.That(locConfig, Is.Not.Null);
+      Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
+    }
+
+    [Test]
+    public void NameAttributePascalCase()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.PC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      Assert.That(locConfig, Is.Not.Null);
+      Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
+    }
+  }
+
+  [TestFixture]
+  public abstract class ModernConfigurationTest : TestCommon.ModernConfigurationTestBase
+  {
+    protected readonly CultureInfo defaultCulture = new CultureInfo("en-US");
+    protected readonly CultureInfo expectedCulture = new CultureInfo("es-ES");
+
+    private CultureInfo resetCulture;
+
+    public override void BeforeAllTestsSetUp()
+    {
+      base.BeforeAllTestsSetUp();
+      
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+      resetCulture = Thread.CurrentThread.CurrentCulture;
+      Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+      Thread.CurrentThread.CurrentCulture = resetCulture;
+    }
+
+    [Test]
+    public void EmptySectionCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Empty");
+      var locConfig = LocalizationConfiguration.Load(section);
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+    [Test]
+    public void EmptyName()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameEmpty");
+      var locConfig = LocalizationConfiguration.Load(section);
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+    [Test]
+    public void NameDefined()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameDefined");
+      var locConfig = LocalizationConfiguration.Load(section);
+      Assert.That(locConfig, Is.Not.Null);
+      Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
+    }
+
+    [Test]
+    public void FaultyValue()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.FaultyValue");
+      var locConfig = LocalizationConfiguration.Load(section);
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+
+    #region Naming
+    [Test]
+    public void NamingInLowCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.LC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateNamingConfigurationResults(locConfig);
+    }
+
+    [Test]
+    public void NamingInUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.UC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateNamingConfigurationResults(locConfig);
+    }
+
+    [Test]
+    public void NamingInCamelCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.CC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateNamingConfigurationResults(locConfig);
+    }
+
+    [Test]
+    public void NamingInPascalCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.PC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateNamingConfigurationResults(locConfig);
+    }
+
+    private void ValidateNamingConfigurationResults(LocalizationConfiguration locConfig)
+    {
+      Assert.That(locConfig, Is.Not.Null);
+      Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
+    }
+    #endregion
+
+    #region mistype cases
+    [Test]
+    public void MistypeInLowCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.LC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(locConfig);
+    }
+
+    [Test]
+    public void MistypeInUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.UC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(locConfig);
+    }
+
+    [Test]
+    public void MistypeInCamelCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.CC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(locConfig);
+    }
+
+    [Test]
+    public void MistypeInPascalCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.PC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(locConfig);
+    }
+
+    private void ValidateMistypeConfigurationResults(LocalizationConfiguration locConfig)
+    {
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+    #endregion
+
+    #region Name as node
+
+    [Test]
+    public void NoNameNodes()
+    {
+      IgnoreIfXml();
+
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Empty");
+      var locConfig = LocalizationConfiguration.Load(section);
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+    [Test]
+    public void NameNodeIsEmpty()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.NameEmpty");
+      var locConfig = LocalizationConfiguration.Load(section);
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+    [Test]
+    public void DefinedNameNode()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Espaniol");
+      var locConfig = LocalizationConfiguration.Load(section);
+      Assert.That(locConfig, Is.Not.Null);
+      Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
+    }
+
+    [Test]
+    public void FaultyNameNodeValue()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.FaultyValue");
+      var locConfig = LocalizationConfiguration.Load(section);
+      CheckConfigurationIsDefault(locConfig);
+    }
+
+    [Test]
+    public void NameNodeInLowCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.LC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateNamingConfigurationResults(locConfig);
+    }
+
+    [Test]
+    public void NameNodeInUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.UC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateNamingConfigurationResults(locConfig);
+    }
+
+    [Test]
+    public void NameNodeInCamelCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.CC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateNamingConfigurationResults(locConfig);
+    }
+
+    [Test]
+    public void NameNodeInPascalCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.PC");
+      var locConfig = LocalizationConfiguration.Load(section);
+      ValidateNamingConfigurationResults(locConfig);
+    }
+
+    #endregion
+
+    protected void CheckConfigurationIsDefault(LocalizationConfiguration locConfig)
+    {
+      Assert.That(locConfig, Is.Not.Null);
+      Assert.That(locConfig.DefaultCulture, Is.EqualTo(defaultCulture));
+    }
+  }
+}

--- a/Extensions/Xtensive.Orm.Localization.Tests/ModernConfigurationTests.cs
+++ b/Extensions/Xtensive.Orm.Localization.Tests/ModernConfigurationTests.cs
@@ -30,62 +30,68 @@ namespace Xtensive.Orm.Localization.Tests.Configuration
     }
 
     [Test]
-    public void NameAttributeEmptyNameTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeEmptyNameTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.NameEmpty");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration("Xtensive.Orm.Localization.NameAttribute.NameEmpty", useRoot);
       CheckConfigurationIsDefault(locConfig);
     }
 
     [Test]
-    public void NameAttributeAbsentTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeAbsentTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.None");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration("Xtensive.Orm.Localization.NameAttribute.None", useRoot);
       CheckConfigurationIsDefault(locConfig);
     }
 
-
     [Test]
-    public void NameAttributeDefinedTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeDefinedTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.Defined");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration("Xtensive.Orm.Localization.NameAttribute.Defined", useRoot);
       Assert.That(locConfig, Is.Not.Null);
       Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
     }
 
     [Test]
-    public void NameAttributeFaultyValueTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeFaultyValueTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.FaultyValue");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration("Xtensive.Orm.Localization.NameAttribute.FaultyValue", useRoot);
       CheckConfigurationIsDefault(locConfig);
     }
 
     [Test]
-    public void NameAttributeLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeLowCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.LC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration("Xtensive.Orm.Localization.NameAttribute.LC", useRoot);
       Assert.That(locConfig, Is.Not.Null);
       Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
     }
 
     [Test]
-    public void NameAttributeUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeUpperCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.UC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration("Xtensive.Orm.Localization.NameAttribute.UC", useRoot);
       Assert.That(locConfig, Is.Not.Null);
       Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
     }
 
     [Test]
-    public void NameAttributePascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributePascalCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Localization.NameAttribute.PC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration("Xtensive.Orm.Localization.NameAttribute.PC", useRoot);
       Assert.That(locConfig, Is.Not.Null);
       Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
     }
@@ -105,6 +111,13 @@ namespace Xtensive.Orm.Localization.Tests.Configuration
       
     }
 
+    protected LocalizationConfiguration LoadConfiguration(string sectionName, bool useRoot)
+    {
+      return useRoot
+        ? LocalizationConfiguration.Load(configurationRoot, sectionName)
+        : LocalizationConfiguration.Load(configurationRoot.GetSection(sectionName));
+    }
+
     [SetUp]
     public void SetUp()
     {
@@ -119,69 +132,77 @@ namespace Xtensive.Orm.Localization.Tests.Configuration
     }
 
     [Test]
-    public void EmptySectionCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptySectionCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Empty");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.Empty", useRoot);
       CheckConfigurationIsDefault(locConfig);
     }
 
     [Test]
-    public void EmptyName()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptyName(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameEmpty");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameEmpty", useRoot);
       CheckConfigurationIsDefault(locConfig);
     }
 
     [Test]
-    public void NameDefined()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameDefined(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameDefined");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameDefined", useRoot);
       Assert.That(locConfig, Is.Not.Null);
       Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
     }
 
     [Test]
-    public void FaultyValue()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void FaultyValue(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.FaultyValue");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.FaultyValue", useRoot);
       CheckConfigurationIsDefault(locConfig);
     }
 
-
     #region Naming
+
     [Test]
-    public void NamingInLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInLowCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.LC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.LC", useRoot);
       ValidateNamingConfigurationResults(locConfig);
     }
 
     [Test]
-    public void NamingInUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInUpperCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.UC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.UC", useRoot);
       ValidateNamingConfigurationResults(locConfig);
     }
 
     [Test]
-    public void NamingInCamelCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInCamelCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.CC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.CC", useRoot);
       ValidateNamingConfigurationResults(locConfig);
     }
 
     [Test]
-    public void NamingInPascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInPascalCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.PC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.Naming.PC", useRoot);
       ValidateNamingConfigurationResults(locConfig);
     }
 
@@ -190,38 +211,44 @@ namespace Xtensive.Orm.Localization.Tests.Configuration
       Assert.That(locConfig, Is.Not.Null);
       Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
     }
+
     #endregion
 
     #region mistype cases
+
     [Test]
-    public void MistypeInLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInLowCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.LC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.LC", useRoot);
       ValidateMistypeConfigurationResults(locConfig);
     }
 
     [Test]
-    public void MistypeInUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInUpperCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.UC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.UC", useRoot);
       ValidateMistypeConfigurationResults(locConfig);
     }
 
     [Test]
-    public void MistypeInCamelCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInCamelCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.CC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.CC", useRoot);
       ValidateMistypeConfigurationResults(locConfig);
     }
 
     [Test]
-    public void MistypeInPascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInPascalCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.PC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.Mistype.PC", useRoot);
       ValidateMistypeConfigurationResults(locConfig);
     }
 
@@ -235,69 +262,77 @@ namespace Xtensive.Orm.Localization.Tests.Configuration
     #region Name as node
 
     [Test]
-    public void NoNameNodes()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NoNameNodes(bool useRoot)
     {
       IgnoreIfXml();
 
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Empty");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Empty", useRoot);
       CheckConfigurationIsDefault(locConfig);
     }
 
     [Test]
-    public void NameNodeIsEmpty()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodeIsEmpty(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.NameEmpty");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.NameEmpty", useRoot);
       CheckConfigurationIsDefault(locConfig);
     }
 
     [Test]
-    public void DefinedNameNode()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DefinedNameNode(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Espaniol");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Espaniol", useRoot);
       Assert.That(locConfig, Is.Not.Null);
       Assert.That(locConfig.DefaultCulture, Is.EqualTo(expectedCulture));
     }
 
     [Test]
-    public void FaultyNameNodeValue()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void FaultyNameNodeValue(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.FaultyValue");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.FaultyValue", useRoot);
       CheckConfigurationIsDefault(locConfig);
     }
 
     [Test]
-    public void NameNodeInLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodeInLowCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.LC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.LC", useRoot);
       ValidateNamingConfigurationResults(locConfig);
     }
 
     [Test]
-    public void NameNodeInUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodeInUpperCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.UC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.UC", useRoot);
       ValidateNamingConfigurationResults(locConfig);
     }
 
     [Test]
-    public void NameNodeInCamelCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodeInCamelCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.CC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.CC", useRoot);
       ValidateNamingConfigurationResults(locConfig);
     }
 
     [Test]
-    public void NameNodeInPascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodeInPascalCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.PC");
-      var locConfig = LocalizationConfiguration.Load(section);
+      var locConfig = LoadConfiguration($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.PC", useRoot);
       ValidateNamingConfigurationResults(locConfig);
     }
 

--- a/Extensions/Xtensive.Orm.Localization.Tests/Xtensive.Orm.Localization.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Localization.Tests/Xtensive.Orm.Localization.Tests.csproj
@@ -8,16 +8,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Localization.Tests/Xtensive.Orm.Localization.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Localization.Tests/Xtensive.Orm.Localization.Tests.csproj
@@ -10,11 +10,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Extensions/Xtensive.Orm.Localization.Tests/Xtensive.Orm.Localization.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Localization.Tests/Xtensive.Orm.Localization.Tests.csproj
@@ -9,6 +9,16 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />
     <ProjectReference Include="..\TestCommon\TestCommon.csproj" />
@@ -20,4 +30,16 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="localizationsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="LocalizationSettings.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="localizationsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ProjectExtensions><VisualStudio><UserProperties localizationsettings_1json__JsonSchema="https://json.schemastore.org/appsettings.json" /></VisualStudio></ProjectExtensions>
 </Project>

--- a/Extensions/Xtensive.Orm.Localization.Tests/localizationsettings.json
+++ b/Extensions/Xtensive.Orm.Localization.Tests/localizationsettings.json
@@ -1,0 +1,80 @@
+{
+  "Xtensive.Orm.Localization.Json.Empty": {
+
+  },
+
+  "Xtensive.Orm.Localization.Json.NameEmpty": {
+    "DefaultCulture": ""
+  },
+
+  "Xtensive.Orm.Localization.Json.NameDefined": {
+    "DefaultCulture": "es-ES"
+  },
+
+  "Xtensive.Orm.Localization.Json.FaultyValue": {
+    "DefaultCulture": "ololo"
+  },
+
+  "Xtensive.Orm.Localization.Json.Naming.LC": {
+    "defaultculture": "es-ES"
+  },
+  "Xtensive.Orm.Localization.Json.Naming.UC": {
+    "DEFAULTCULTURE": "es-ES"
+  },
+  "Xtensive.Orm.Localization.Json.Naming.CC": {
+    "defaultCulture": "es-ES"
+  },
+  "Xtensive.Orm.Localization.Json.Naming.PC": {
+    "DefaultCulture": "es-ES"
+  },
+
+  "Xtensive.Orm.Localization.Json.Mistype.LC": {
+    "defailtculture": "es-ES"
+  },
+  "Xtensive.Orm.Localization.Json.Mistype.UC": {
+    "DEFAILTCULTURE": "es-ES"
+  },
+  "Xtensive.Orm.Localization.Json.Mistype.CC": {
+    "defailtCulture": "es-ES"
+  },
+  "Xtensive.Orm.Localization.Json.Mistype.PC": {
+    "DefailtCulture": "es-ES"
+  },
+
+
+  "Xtensive.Orm.Localization.Json.NameNode.Empty": {
+    "DefaultCulture": {
+    }
+  },
+
+  "Xtensive.Orm.Localization.Json.NameNode.NameEmpty": {
+    "DefaultCulture": {
+      "Name": ""
+    }
+  },
+
+  "Xtensive.Orm.Localization.Json.NameNode.Espaniol": {
+    "DefaultCulture": {
+      "Name": "es-ES"
+    }
+  },
+
+  "Xtensive.Orm.Localization.Json.NameNode.FaultyValue": {
+    "DefaultCulture": {
+      "Name": "ololo"
+    }
+  },
+
+  "Xtensive.Orm.Localization.Json.NameNode.Naming.LC": {
+    "DefaultCulture": { "name": "es-ES" }
+  },
+  "Xtensive.Orm.Localization.Json.NameNode.Naming.UC": {
+    "DefaultCulture": { "NAME": "es-ES" }
+  },
+  "Xtensive.Orm.Localization.Json.NameNode.Naming.CC": {
+    "DefaultCulture": { "naMe": "es-ES" }
+  },
+  "Xtensive.Orm.Localization.Json.NameNode.Naming.PC": {
+    "DefaultCulture": { "NaMe": "es-ES" }
+  }
+}

--- a/Extensions/Xtensive.Orm.Localization/Configuration/Elements/ConfigurationSection.cs
+++ b/Extensions/Xtensive.Orm.Localization/Configuration/Elements/ConfigurationSection.cs
@@ -18,6 +18,7 @@ namespace Xtensive.Orm.Localization.Configuration
     /// Gets default section name for security configuration.
     /// Value is "Xtensive.Orm.Localization".
     /// </summary>
+    [Obsolete("Use Localization.DefaultSectionName instead.")]
     public static readonly string DefaultSectionName = "Xtensive.Orm.Localization";
 
     private const string DefaultCultureElementName = "defaultCulture";

--- a/Extensions/Xtensive.Orm.Localization/Configuration/LocalizationConfiguration.cs
+++ b/Extensions/Xtensive.Orm.Localization/Configuration/LocalizationConfiguration.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2011-2024 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2012.07.06
 
@@ -132,7 +132,7 @@ namespace Xtensive.Orm.Localization.Configuration
     }
 
     /// <summary>
-    /// Loads <see cref="LocalizationConfiguration"/> from given configuration section of <paramref name="configurationRoot"/>.
+    /// Loads <see cref="LocalizationConfiguration"/> from given configuration section of <paramref name="configuration"/>.
     /// If section name is not provided <see cref="LocalizationConfiguration.DefaultSectionName"/> is used.
     /// </summary>
     /// <param name="configuration"><see cref="IConfiguration"/> of sections.</param>
@@ -142,17 +142,16 @@ namespace Xtensive.Orm.Localization.Configuration
     {
       ArgumentValidator.EnsureArgumentNotNull(configuration, nameof(configuration));
 
-      if (configuration is IConfigurationRoot configurationRoot)
+      if (configuration is IConfigurationRoot configurationRoot) {
         return new LocalizationConfigurationReader().Read(configurationRoot, sectionName ?? DefaultSectionName);
+      }
       else if (configuration is IConfigurationSection configurationSection) {
-        if (sectionName.IsNullOrEmpty())
-          return new LocalizationConfigurationReader().Read(configurationSection);
-        else {
-          return new LocalizationConfigurationReader().Read(configurationSection.GetSection(sectionName));
-        }
+        return sectionName.IsNullOrEmpty()
+          ? new LocalizationConfigurationReader().Read(configurationSection)
+          : new LocalizationConfigurationReader().Read(configurationSection.GetSection(sectionName));
       }
 
-      throw new NotSupportedException("Type of configuration is not supported");
+      throw new NotSupportedException("Type of configuration is not supported.");
     }
 
     /// <summary>

--- a/Extensions/Xtensive.Orm.Localization/Configuration/LocalizationConfiguration.cs
+++ b/Extensions/Xtensive.Orm.Localization/Configuration/LocalizationConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011 Xtensive LLC.
+// Copyright (C) 2011-2024 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Dmitri Maximov
@@ -7,7 +7,10 @@
 using System;
 using System.Configuration;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
+using Microsoft.Extensions.Configuration;
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Localization.Configuration
 {
@@ -17,11 +20,19 @@ namespace Xtensive.Orm.Localization.Configuration
   [Serializable]
   public class LocalizationConfiguration
   {
+    private class LocalizationOptions
+    {
+      public string DefaultCulture { get; set; } = null;
+    }
+
     /// <summary>
     /// Default SectionName value:
     /// "<see langword="Xtensive.Orm.Localization" />".
     /// </summary>
     public const string DefaultSectionName = "Xtensive.Orm.Localization";
+
+    private const string DefaultCultureElementName = "DefaultCulture";
+    private const string CultureNameAttributeName = "name";
 
     /// <summary>
     /// Gets or sets the default culture.
@@ -88,8 +99,8 @@ namespace Xtensive.Orm.Localization.Configuration
       var result = new LocalizationConfiguration();
       result.DefaultCulture = Thread.CurrentThread.CurrentCulture;
 
-      string cultureName = configurationSection==null
-        ? string.Empty 
+      string cultureName = configurationSection == null
+        ? string.Empty
         : configurationSection.DefaultCulture.Name;
       if (string.IsNullOrEmpty(cultureName))
         return result;
@@ -98,10 +109,95 @@ namespace Xtensive.Orm.Localization.Configuration
         var culture = new CultureInfo(cultureName);
         result.DefaultCulture = culture;
       }
-      catch (CultureNotFoundException)
-      {
+      catch (CultureNotFoundException) {
       }
       return result;
+    }
+
+    public static LocalizationConfiguration Load(IConfigurationSection configurationSection)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(configurationSection, nameof(configurationSection));
+
+      if (TryReadAsOptions(configurationSection, out var localizationConfiguration))
+        return localizationConfiguration;
+
+      // if failed then try to handle unusual formats or xml with name attribute
+      return TryReadUnusualOrOldFormats(configurationSection, out var fallbackConfiguration)
+        ? fallbackConfiguration
+        : new LocalizationConfiguration {
+            DefaultCulture = Thread.CurrentThread.CurrentCulture
+          };
+    }
+
+    private static bool TryReadAsOptions(IConfigurationSection rootSection, out LocalizationConfiguration localizationConfiguration)
+    {
+      LocalizationOptions localizationOptions;
+      try {
+        localizationOptions = rootSection.Get<LocalizationOptions>();
+      }
+      catch {
+        localizationConfiguration = null;
+        return false;
+      }
+
+      if (localizationOptions != null) {
+        if (!string.IsNullOrEmpty(localizationOptions.DefaultCulture)) {
+          try {
+            var culture = new CultureInfo(localizationOptions.DefaultCulture);
+            localizationConfiguration = new LocalizationConfiguration() { DefaultCulture = culture };
+            return true;
+          }
+          catch (CultureNotFoundException) {
+          }
+        }
+      }
+      localizationConfiguration = null;
+      return false;
+    }
+
+    /// <summary>
+    /// Tries to read configuration of old format that supported by
+    /// old <see cref="System.Configuration.ConfigurationManager"/>
+    /// or configuration where name of service is element, not attribute.
+    /// </summary>
+    /// <param name="rootSection">A configuration section that contains data to read.</param>
+    /// <param name="localizationConfiguration">Read configuration or null if reading was not successful.</param>
+    /// <returns><see landword="true"/> if reading is successful, otherwise <see landword="true"/>.</returns>
+    private static bool TryReadUnusualOrOldFormats(IConfigurationSection rootSection,
+      out LocalizationConfiguration localizationConfiguration)
+    {
+      var defaultCultureSection = rootSection.GetSection(DefaultCultureElementName);
+
+      if (defaultCultureSection == null) {
+        localizationConfiguration = null;
+        return false;
+      }
+
+      var cultureName = defaultCultureSection.GetSection(CultureNameAttributeName)?.Value;
+      if (cultureName == null) {
+        var children = defaultCultureSection.GetChildren().ToList();
+        if (children.Count > 0) {
+          cultureName = children[0].GetSection(CultureNameAttributeName).Value;
+        }
+      }
+
+      if (cultureName != null && ! string.IsNullOrEmpty(cultureName)) {
+        try {
+          var culture = new CultureInfo(cultureName);
+          localizationConfiguration = new LocalizationConfiguration() {
+            DefaultCulture = culture
+          };
+          return true;
+        }
+        catch (CultureNotFoundException) {
+          localizationConfiguration = new LocalizationConfiguration() {
+            DefaultCulture = Thread.CurrentThread.CurrentCulture
+          };
+          return true;
+        }
+      }
+      localizationConfiguration = null;
+      return false;
     }
   }
 }

--- a/Extensions/Xtensive.Orm.Localization/Configuration/LocalizationConfigurationReader.cs
+++ b/Extensions/Xtensive.Orm.Localization/Configuration/LocalizationConfigurationReader.cs
@@ -1,0 +1,66 @@
+// Copyright (C) 2011-2024 Xtensive LLC.
+// All rights reserved.
+// For conditions of distribution and use, see license.
+// Created by: Dmitri Maximov
+// Created:    2012.07.06
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Configuration;
+using Xtensive.Core;
+using Xtensive.Orm.Configuration;
+
+namespace Xtensive.Orm.Localization.Configuration
+{
+  internal sealed class LocalizationConfigurationReader : IConfigurationSectionReader<LocalizationConfiguration>
+  {
+    public LocalizationConfiguration Read(IConfigurationSection configurationSection) => ReadInternal(configurationSection);
+
+    public LocalizationConfiguration Read(IConfigurationSection configurationSection, string nameOfConfiguration) =>
+      throw new NotSupportedException();
+
+    public LocalizationConfiguration Read(IConfigurationRoot configurationRoot) =>
+      Read(configurationRoot, LocalizationConfiguration.DefaultSectionName);
+
+    public LocalizationConfiguration Read(IConfigurationRoot configurationRoot, string sectionName)
+    {
+      var section = configurationRoot.GetSection(sectionName);
+      return ReadInternal(section);
+    }
+
+    public LocalizationConfiguration Read(IConfigurationRoot configurationRoot, string sectionName, string nameOfConfiguration) =>
+      throw new NotSupportedException();
+
+    private const string DefaultCultureElementName = "DefaultCulture";
+    private const string CultureNameAttributeName = "name";
+
+    private LocalizationConfiguration ReadInternal(IConfigurationSection configurationSection)
+    {
+      var defaultCultureSection = configurationSection.GetSection(DefaultCultureElementName);
+      if (defaultCultureSection == null)
+        return new LocalizationConfiguration() { DefaultCulture = Thread.CurrentThread.CurrentCulture };
+
+      var cultureName = defaultCultureSection.Value;
+      if (cultureName == null) {
+        cultureName = defaultCultureSection.GetSection(CultureNameAttributeName)?.Value;
+        if (cultureName == null) {
+          var children = defaultCultureSection.GetChildren().ToList();
+          if (children.Count > 0) {
+            cultureName = children[0].GetSection(CultureNameAttributeName).Value;
+          }
+        }
+      }
+
+      if (cultureName.IsNullOrEmpty())
+        return new LocalizationConfiguration() { DefaultCulture = Thread.CurrentThread.CurrentCulture };
+      try {
+        return new LocalizationConfiguration() { DefaultCulture = new CultureInfo(cultureName) };
+      }
+      catch (CultureNotFoundException) {
+        return new LocalizationConfiguration() { DefaultCulture = Thread.CurrentThread.CurrentCulture };
+      }
+    }
+  }
+}

--- a/Extensions/Xtensive.Orm.Localization/DomainConfugurationExtensions.cs
+++ b/Extensions/Xtensive.Orm.Localization/DomainConfugurationExtensions.cs
@@ -1,0 +1,130 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Localization.Configuration;
+
+namespace Xtensive.Orm.Localization
+{
+  /// <summary>
+  /// Contains extensions for DomainConfiguration that help to configure the extension.
+  /// </summary>
+  public static class DomainConfugurationLocalizationExtensions
+  {
+    /// <summary>
+    /// Loads configuration by calling <see cref="LocalizationConfiguration.Load()"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration)
+      => ConfigureLocalizationExtension(domainConfiguration, LocalizationConfiguration.Load());
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="LocalizationConfiguration.Load(string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationSectionName">Section name.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration,
+       string configurationSectionName) =>
+      ConfigureLocalizationExtension(domainConfiguration, LocalizationConfiguration.Load(configurationSectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="LocalizationConfiguration.Load(System.Configuration.Configuration)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuration to load from.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration,
+        System.Configuration.Configuration configuration) =>
+      ConfigureLocalizationExtension(domainConfiguration, LocalizationConfiguration.Load(configuration));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="LocalizationConfiguration.Load(System.Configuration.Configuration)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuration to load from.</param>
+    /// <param name="sectionName">Section in <paramref name="configuration"/></param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration,
+        System.Configuration.Configuration configuration, string sectionName) =>
+      ConfigureLocalizationExtension(domainConfiguration, LocalizationConfiguration.Load(configuration, sectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="LocalizationConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuration to load from.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration,
+        IConfiguration configuration) =>
+      ConfigureLocalizationExtension(domainConfiguration, LocalizationConfiguration.Load(configuration));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="LocalizationConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuration to load from.</param>
+    /// <param name="sectionName">Section in <paramref name="configuration"/></param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration,
+        IConfiguration configuration, string sectionName = null) =>
+      ConfigureLocalizationExtension(domainConfiguration, LocalizationConfiguration.Load(configuration, sectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="LocalizationConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationRoot">Configuration to load from.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration,
+      IConfigurationRoot configurationRoot) =>
+      ConfigureLocalizationExtension(domainConfiguration, LocalizationConfiguration.Load(configurationRoot));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="LocalizationConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationRoot">Configuration to load from.</param>
+    /// <param name="sectionName">Section in <paramref name="configurationRoot"/></param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration,
+        IConfigurationRoot configurationRoot, string sectionName) =>
+      ConfigureLocalizationExtension(domainConfiguration, LocalizationConfiguration.Load(configurationRoot, sectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="LocalizationConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationSection">Configuration section to load from.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration,
+        IConfigurationSection configurationSection) =>
+      ConfigureLocalizationExtension(domainConfiguration, LocalizationConfiguration.Load(configurationSection));
+
+    /// <summary>
+    /// Configures the extension with given localization configuration instance.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="localizationConfiguration">Localization configuration instance.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureLocalizationExtension(this DomainConfiguration domainConfiguration,
+      LocalizationConfiguration localizationConfiguration)
+    {
+      domainConfiguration.ExtensionConfigurations.Set(localizationConfiguration);
+      domainConfiguration.Types.Register(typeof(DomainConfugurationLocalizationExtensions).Assembly);
+      return domainConfiguration;
+    }
+  }
+}

--- a/Extensions/Xtensive.Orm.Localization/Internals/TypeLocalizationMap.cs
+++ b/Extensions/Xtensive.Orm.Localization/Internals/TypeLocalizationMap.cs
@@ -10,6 +10,7 @@ using Xtensive.Orm.Localization.Configuration;
 using Xtensive.Orm.Model;
 using Xtensive.Orm;
 using Xtensive.Reflection;
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Localization
 {
@@ -21,13 +22,19 @@ namespace Xtensive.Orm.Localization
 
     public static void Initialize(Domain domain)
     {
-      if (domain == null)
-        throw new ArgumentNullException("domain");
-      if (domain.Extensions.Get<TypeLocalizationMap>() != null)
+      ArgumentValidator.EnsureArgumentNotNull(domain, nameof(domain));
+
+      var existing = domain.Extensions.Get<TypeLocalizationMap>();
+      if (existing != null) {
         return;
+      }
+
+      var configFromNewSource = domain.Configuration.ExtensionConfigurations.Get<LocalizationConfiguration>();
 
       var map = new TypeLocalizationMap() {
-        Configuration = LocalizationConfiguration.Load()
+        Configuration = (configFromNewSource != null)
+          ? configFromNewSource
+          : LocalizationConfiguration.Load()// config from old source.
       };
       foreach (var localizableTypeInfo in domain.Model.Types.Entities) {
         var type = localizableTypeInfo.UnderlyingType;

--- a/Extensions/Xtensive.Orm.Localization/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Localization/NugetContent/ReadMe.md
@@ -8,7 +8,7 @@ This implies that localizable resources are a part of domain model so they are s
 
 Prerequisites
 -------------
-DataObjects.Net 7.0.x or later (http://dataobjects.net)
+DataObjects.Net 7.1.x or later (http://dataobjects.net)
 
 Implementation
 --------------
@@ -49,6 +49,7 @@ Define corresponding localizations, e.g.:
       : base(session, culture, target) {}
   }
 ```
+
 
 Examples of usage
 -----------------
@@ -106,4 +107,264 @@ Examples of usage
     where p.Title=="Bienvenido"
     select p;
   Assert.AreEqual(1, query.Count());
+```
+
+
+Examples of how to configure extension
+--------------------------------------
+
+Following examples show different ways to configure extension in configuration files of various types.
+
+**Example #1** Confugure in App.config/Web.config
+
+```xml
+<configuration>
+  <configSections>
+    <section name="Xtensive.Orm" type="Xtensive.Orm.Configuration.Elements.ConfigurationSection, Xtensive.Orm"/>
+    <section name="Xtensive.Orm.Localization" type="Xtensive.Orm.Localization.Configuration.ConfigurationSection, Xtensive.Orm.Localization"/>
+  </configSections>
+  <Xtensive.Orm>
+    <!-- domain(s) configured -->
+  </Xtensive.Orm>
+  <Xtensive.Orm.Localization>
+    <defaultCulture name="es-ES"/>
+  </Xtensive.Orm.Localization>
+</configuration>
+```
+
+Such configuration is only compatible with System.Configuration.ConfigurationManager.
+If project still supports such configurations then Localization configuration will be read automatically when it needed to be read.
+Sometimes a work-around is needed to read such configuration, for more read Example #2 and Example #3
+
+
+**Example #2** Reading old-style configuration of an assembly in NET 5 and newer.
+
+Due to new architecture without AppDomain (which among the other things was in charge of gathering configuration files of loaded assemblies
+as it would be one configuration file) System.Configuration.ConfigurationManager now reads only configuration file of actual executable, loaded 
+assemblies' configuration files stay unreachable by default, though there is need to read some data from them.
+A great example is test projects which are usually get loaded by test runner executable, and the only configuration accessible in this case
+is test runner one.
+
+Extra step is required to read configuration files in such cases. Thankfully ConfigurationManager has methods to get access to assemblies' configurations.
+
+To get access to an assembly configuration file it should be opened explicitly by
+
+```csharp
+  var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
+```
+
+The instance returned from ```OpenExeConfiguration``` provides access to sections of the assembly configuration. DataObjects.Net configurations
+(```DomainConfiguration```, ```LocalizationConfiguration```, etc.) have ```Load()``` methods that can recieve this instance.
+```LocalizationConfiguration``` can be read like so
+
+```csharp
+  var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
+  var localizationConfig = LocalizationConfiguration.Load(configuration);
+
+  // loaded configuration should be manually placed to
+  domainConfiguration.ExtensionConfigurations.Set(localizationConfig);
+```
+
+The ```domainConfiguration.ExtensionConfigurations``` is a new unified place from which an extension will try to get its configuration
+instead of calling default parameterless ```Load()``` method, which has not a lot of sense now, though the method is kept as a second source
+for backwards compatibility.
+
+For more convenience, DomainConfiguration extensions are provided, which make code more neat and clear.
+For instance,
+
+```csharp
+  var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
+
+  var domainConfiguration = DomainConfiguration.Load(configuration);
+
+  // the extension hides getting configuration with LocalizationConfiguration.Load(configuration)
+  // and also putting it to ExtensionConfigurations collection.
+  domainConfiguration.ConfigureLocalizationExtension(configuration);
+```
+
+Custom section names are also supported if for some reason default section name is not used.
+
+
+**Example #3** Reading old-style configuration of an assembly in a project that uses appsettings.json file.
+
+If for some reason there is need to keep the old-style configuration then there is a work-around as well.
+Static configuration manager provides method ```OpenMappedExeConfiguration()``` which allows to get 
+any *.config file as ```System.Configuration.Configuration``` instance. For example
+
+```csharp
+  ExeConfigurationFileMap configFileMap = new ExeConfigurationFileMap();
+  configFileMap.ExeConfigFilename = "Orm.config"; //or other file name, the file should exist bin folder
+  var configuration = System.Configuration.ConfigurationManager.OpenMappedExeConfiguration(configFileMap, ConfigurationUserLevel.None);
+```
+
+After that, as in previous example, the instance can be passed to ```Load``` method of ```LocalizationConfiguration``` to read extension configuration
+and later put it to ```DomainConfiguration.ExtensionConfigurations```.
+After ```System.Configuration.Configuration``` instance is provided it is possible to pass it into Load method of different DataObjects.Net configurations,
+including ```LocalizationConfiguration```. Then put localization configuration to ```DomainConfiguration.ExtensionConfigurations``` collection.
+
+```csharp
+  var localizationConfiguration = LocalizationConfiguration.Load(configuration);
+
+  domainConfiguration.ExtensionConfigurations.Set(localizationConfiguration);
+```
+
+or to extension method
+
+```csharp
+  domainConfiguration.ConfigureLocalizationExtension(configuration);
+```
+
+
+**Example #4** Configure using Microsoft.Extensions.Configuration API.
+
+This API allows to have configurations in various forms including JSON and XML formats.
+Loading of such files may differ depending on .NET version, check Microsoft manuals for instructions.
+
+Allowed Json and Xml configuration definition look like below
+
+```xml
+<configuration>
+  <Xtensive.Orm.Localization>
+    <DefaultCulture>es-ES</DefaultCulture>
+  </Xtensive.Orm.Localization>
+</configuration>
+```
+
+```json
+{
+  "Xtensive.Orm.Localization": {
+    "DefaultCulture": "es-ES"
+  }
+}
+```
+
+The API has certain issues with Xml elements with attributes so it is recommended to use
+more up-to-date attributeless nodes.
+For JSON it is pretty clear.
+
+```LocalizationConfiguration.Load``` method can accept different types of abstractions from the
+API, including 
+- ```Microsoft.Extensions.Configuration.IConfiguration```,
+- ```Microsoft.Extensions.Configuration.IConfigurationRoot```
+- ```Microsoft.Extensions.Configuration.IConfigurationSection```.
+
+Loading of configuration may look like
+
+```csharp
+  
+  var app = builder.Build();
+
+  // tries to load from default section "Xtensive.Orm.Localization"
+  var localizationConfig = LocalizationConfiguration.Load(app.Configuration);
+
+  domainConfiguration.ExtensionConfigurations.Set(localizationConfig);
+```
+
+or, with use of extension
+
+
+```csharp
+  
+  var app = builder.Build();
+
+  // tries to load from default section "Xtensive.Orm.Localization"
+  // and additionally adds Xtensive.Orm.Localization assembly to domain types.
+
+  domainConfiguration.ConfigureLocalizationExtension(app.Configuration);
+```
+
+
+
+**Example #5** Configure using Microsoft.Extensions.Configuration API from section with non-default name.
+
+For configurations like
+
+```xml
+  <configuration>
+    <Orm.Localization>
+      <DefaultCulture>es-ES</DefaultCulture>
+    </Orm.Localization>
+  </configuration>
+```
+
+```json
+{
+  "Orm.Localization": {
+    "DefaultCulture": "es-ES"
+  }
+}
+```
+
+Loading of configuration may look like
+
+```csharp
+  
+  var app = builder.Build();
+
+  var localizationConfig = LocalizationConfiguration.Load(app.Configuration, "Orm.Localization");
+
+  domainConfiguration.ExtensionConfigurations.Set(localizationConfig);
+```
+
+or with use of extension
+
+```csharp
+  
+  var app = builder.Build();
+
+  domainConfiguration.ConfigureLocalizationExtension(app.Configuration, "Orm.Localization");
+```
+
+
+**Example #6** Configure using Microsoft.Extensions.Configuration API from sub-section deeper in section tree.
+
+If for some reason extension configuration should be moved deeper in section tree like something below
+
+```xml
+<configuration>
+  <Orm.Extensions>
+    <Xtensive.Orm.Localization>
+      <DefaultCulture>es-ES</DefaultCulture>
+    </Xtensive.Orm.Localization>
+  </Orm.Extensions>
+</configuration>
+```
+
+or in JSON
+
+```json
+{
+  "Orm.Extensions": {
+    "Xtensive.Orm.Localization": {
+      "DefaultCulture": "es-ES"
+    }
+  }
+}
+```
+
+Then section must be provided manually, code may look like
+
+```csharp
+  
+  var app = builder.Build();
+
+  var configurationRoot = app.Configuration;
+  var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");
+  var localizationSection = extensionsGroupSection.GetSection("Xtensive.Orm.Localization");
+  var localizationConfig = LocalizationConfiguration.Load(localizationSection);
+
+  domainConfiguration.ExtensionConfigurations.Set(localizationConfig);
+```
+
+or with use of extension method
+
+```csharp
+  
+  var app = builder.Build();
+
+  var configurationRoot = app.Configuration;
+  var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");
+  var localizationSection = extensionsGroupSection.GetSection("Xtensive.Orm.Localization");
+
+  domainConfiguration.ConfigureLocalizationExtension(localizationSection);
 ```

--- a/Extensions/Xtensive.Orm.Localization/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Localization/NugetContent/ReadMe.md
@@ -115,7 +115,7 @@ Examples of how to configure extension
 
 Following examples show different ways to configure extension in configuration files of various types.
 
-**Example #1** Confugure in App.config/Web.config
+**Example #1** Confugure default culture in App.config/Web.config
 
 ```xml
 <configuration>
@@ -132,20 +132,20 @@ Following examples show different ways to configure extension in configuration f
 </configuration>
 ```
 
-Such configuration is only compatible with System.Configuration.ConfigurationManager.
-If project still supports such configurations then Localization configuration will be read automatically when it needed to be read.
+Such configuration is usually read with ```System.Configuration.ConfigurationManager```.
+If project still supports such configurations then Localization configuration will be read automatically when it needs to be read.
 Sometimes a work-around is needed to read such configuration, for more read Example #2 and Example #3
 
 
 **Example #2** Reading old-style configuration of an assembly in NET 5 and newer.
 
 Due to new architecture without AppDomain (which among the other things was in charge of gathering configuration files of loaded assemblies
-as it would be one configuration file) System.Configuration.ConfigurationManager now reads only configuration file of actual executable, loaded 
+as it would be one configuration file) ```System.Configuration.ConfigurationManager``` now reads only configuration file of actual executable, loaded 
 assemblies' configuration files stay unreachable by default, though there is need to read some data from them.
 A great example is test projects which are usually get loaded by test runner executable, and the only configuration accessible in this case
 is test runner one.
 
-Extra step is required to read configuration files in such cases. Thankfully ConfigurationManager has methods to get access to assemblies' configurations.
+Extra step is required to read configuration files in such cases. Thankfully, ```ConfigurationManager``` has methods to get access to assemblies' configuration files.
 
 To get access to an assembly configuration file it should be opened explicitly by
 
@@ -165,17 +165,15 @@ The instance returned from ```OpenExeConfiguration``` provides access to section
   domainConfiguration.ExtensionConfigurations.Set(localizationConfig);
 ```
 
-The ```domainConfiguration.ExtensionConfigurations``` is a new unified place from which an extension will try to get its configuration
+The ```domainConfiguration.ExtensionConfigurations``` is a new unified place from which the extension will try to get its configuration
 instead of calling default parameterless ```Load()``` method, which has not a lot of sense now, though the method is kept as a second source
 for backwards compatibility.
 
-For more convenience, DomainConfiguration extensions are provided, which make code more neat and clear.
+For more convenience, ```DomainConfiguration``` extensions are provided, which make code neater.
 For instance,
 
 ```csharp
   var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
-
-  var domainConfiguration = DomainConfiguration.Load(configuration);
 
   // the extension hides getting configuration with LocalizationConfiguration.Load(configuration)
   // and also putting it to ExtensionConfigurations collection.
@@ -189,7 +187,7 @@ Custom section names are also supported if for some reason default section name 
 
 If for some reason there is need to keep the old-style configuration then there is a work-around as well.
 Static configuration manager provides method ```OpenMappedExeConfiguration()``` which allows to get 
-any *.config file as ```System.Configuration.Configuration``` instance. For example
+any *.config file as ```System.Configuration.Configuration``` instance. For example,
 
 ```csharp
   ExeConfigurationFileMap configFileMap = new ExeConfigurationFileMap();
@@ -198,9 +196,7 @@ any *.config file as ```System.Configuration.Configuration``` instance. For exam
 ```
 
 After that, as in previous example, the instance can be passed to ```Load``` method of ```LocalizationConfiguration``` to read extension configuration
-and later put it to ```DomainConfiguration.ExtensionConfigurations```.
-After ```System.Configuration.Configuration``` instance is provided it is possible to pass it into Load method of different DataObjects.Net configurations,
-including ```LocalizationConfiguration```. Then put localization configuration to ```DomainConfiguration.ExtensionConfigurations``` collection.
+and later put it to ```DomainConfiguration.ExtensionConfigurations```
 
 ```csharp
   var localizationConfiguration = LocalizationConfiguration.Load(configuration);
@@ -208,7 +204,7 @@ including ```LocalizationConfiguration```. Then put localization configuration t
   domainConfiguration.ExtensionConfigurations.Set(localizationConfiguration);
 ```
 
-or to extension method
+Extension usage will look like
 
 ```csharp
   domainConfiguration.ConfigureLocalizationExtension(configuration);
@@ -220,7 +216,7 @@ or to extension method
 This API allows to have configurations in various forms including JSON and XML formats.
 Loading of such files may differ depending on .NET version, check Microsoft manuals for instructions.
 
-Allowed Json and Xml configuration definition look like below
+Allowed JSON and XML configuration definition look like below
 
 ```xml
 <configuration>
@@ -238,14 +234,13 @@ Allowed Json and Xml configuration definition look like below
 }
 ```
 
-The API has certain issues with Xml elements with attributes so it is recommended to use
+The API has certain issues with XML elements with attributes so it is recommended to use
 more up-to-date attributeless nodes.
-For JSON it is pretty clear.
+For JSON it is pretty clear, almost averyone knows its format.
 
-```LocalizationConfiguration.Load``` method can accept different types of abstractions from the
-API, including 
-- ```Microsoft.Extensions.Configuration.IConfiguration```,
-- ```Microsoft.Extensions.Configuration.IConfigurationRoot```
+```LocalizationConfiguration.Load``` method can accept different types of abstractions from the API, including
+- ```Microsoft.Extensions.Configuration.IConfiguration```;
+- ```Microsoft.Extensions.Configuration.IConfigurationRoot```;
 - ```Microsoft.Extensions.Configuration.IConfigurationSection```.
 
 Loading of configuration may look like
@@ -254,18 +249,22 @@ Loading of configuration may look like
   
   var app = builder.Build();
 
+  //...
+
   // tries to load from default section "Xtensive.Orm.Localization"
   var localizationConfig = LocalizationConfiguration.Load(app.Configuration);
 
   domainConfiguration.ExtensionConfigurations.Set(localizationConfig);
 ```
 
-or, with use of extension
+or, with use of extension, like
 
 
 ```csharp
   
   var app = builder.Build();
+
+  //...
 
   // tries to load from default section "Xtensive.Orm.Localization"
   // and additionally adds Xtensive.Orm.Localization assembly to domain types.
@@ -301,17 +300,17 @@ Loading of configuration may look like
   
   var app = builder.Build();
 
+  //...
+
   var localizationConfig = LocalizationConfiguration.Load(app.Configuration, "Orm.Localization");
 
   domainConfiguration.ExtensionConfigurations.Set(localizationConfig);
 ```
 
-or with use of extension
+or, with use of extension, like
 
 ```csharp
-  
   var app = builder.Build();
-
   domainConfiguration.ConfigureLocalizationExtension(app.Configuration, "Orm.Localization");
 ```
 
@@ -348,6 +347,8 @@ Then section must be provided manually, code may look like
   
   var app = builder.Build();
 
+  //...
+
   var configurationRoot = app.Configuration;
   var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");
   var localizationSection = extensionsGroupSection.GetSection("Xtensive.Orm.Localization");
@@ -356,11 +357,13 @@ Then section must be provided manually, code may look like
   domainConfiguration.ExtensionConfigurations.Set(localizationConfig);
 ```
 
-or with use of extension method
+or, with use of extension method, like
 
 ```csharp
   
   var app = builder.Build();
+
+  //...
 
   var configurationRoot = app.Configuration;
   var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");

--- a/Extensions/Xtensive.Orm.Localization/Xtensive.Orm.Localization.csproj
+++ b/Extensions/Xtensive.Orm.Localization/Xtensive.Orm.Localization.csproj
@@ -27,4 +27,17 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Extensions/Xtensive.Orm.Localization/Xtensive.Orm.Localization.csproj
+++ b/Extensions/Xtensive.Orm.Localization/Xtensive.Orm.Localization.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />

--- a/Extensions/Xtensive.Orm.Localization/Xtensive.Orm.Localization.csproj
+++ b/Extensions/Xtensive.Orm.Localization/Xtensive.Orm.Localization.csproj
@@ -31,11 +31,11 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>

--- a/Extensions/Xtensive.Orm.Logging.NLog/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Logging.NLog/NugetContent/ReadMe.md
@@ -1,4 +1,4 @@
-﻿Xtensive.Orm.Logging.NLog
+Xtensive.Orm.Logging.NLog
 =========================
 
 Summary
@@ -8,7 +8,7 @@ The extension provides integration points between DataObjects.Net internal loggi
 Prerequisites
 -------------
 
-DataObjects.Net 7.0.x (http://dataobjects.net)
+DataObjects.Net 7.1.x (http://dataobjects.net)
 NLog 4.5 or later (http://nlog-project.org)
 
 Implementation

--- a/Extensions/Xtensive.Orm.Logging.log4net/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Logging.log4net/NugetContent/ReadMe.md
@@ -1,4 +1,4 @@
-﻿Xtensive.Orm.Logging.log4net
+Xtensive.Orm.Logging.log4net
 ============================
 
 Summary
@@ -7,7 +7,7 @@ The extension provides integration points between DataObjects.Net internal loggi
 
 Prerequisites
 -------------
-DataObjects.Net 7.0.x (http://dataobjects.net)
+DataObjects.Net 7.1.x (http://dataobjects.net)
 log4net 2.0.10 or later (http://logging.apache.org/log4net/)
 
 Implementation

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/App.config
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <configSections>
     <section name="Xtensive.Orm" type="Xtensive.Orm.Configuration.Elements.ConfigurationSection, Xtensive.Orm" />

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/ReprocessingSettings.config
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/ReprocessingSettings.config
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <!-- No elements, all names should be default-->
+  <Xtensive.Orm.Reprocessing.Xml.Empty>
+  </Xtensive.Orm.Reprocessing.Xml.Empty>
+
+  <!--Names are empty, all names should be default-->
+  <Xtensive.Orm.Reprocessing.Xml.AllEmpty>
+    <DefaultTransactionOpenMode></DefaultTransactionOpenMode>
+    <DefaultExecuteStrategy></DefaultExecuteStrategy>
+  </Xtensive.Orm.Reprocessing.Xml.AllEmpty>
+
+  <Xtensive.Orm.Reprocessing.Xml.OnlyTM.Empty>
+    <DefaultTransactionOpenMode></DefaultTransactionOpenMode>
+  </Xtensive.Orm.Reprocessing.Xml.OnlyTM.Empty>
+  <Xtensive.Orm.Reprocessing.Xml.OnlyTM.Auto>
+    <DefaultTransactionOpenMode>Auto</DefaultTransactionOpenMode>
+  </Xtensive.Orm.Reprocessing.Xml.OnlyTM.Auto>
+  <Xtensive.Orm.Reprocessing.Xml.OnlyTM.New>
+    <DefaultTransactionOpenMode>New</DefaultTransactionOpenMode>
+  </Xtensive.Orm.Reprocessing.Xml.OnlyTM.New>
+  <Xtensive.Orm.Reprocessing.Xml.OnlyTM.Default>
+    <DefaultTransactionOpenMode>Default</DefaultTransactionOpenMode>
+  </Xtensive.Orm.Reprocessing.Xml.OnlyTM.Default>
+
+  <Xtensive.Orm.Reprocessing.Xml.OnlyStrategy.Empty>
+    <DefaultExecuteStrategy></DefaultExecuteStrategy>
+  </Xtensive.Orm.Reprocessing.Xml.OnlyStrategy.Empty>
+
+  <Xtensive.Orm.Reprocessing.Xml.OnlyStrategy.HandleReprocessible>
+    <DefaultExecuteStrategy>Xtensive.Orm.Reprocessing.HandleReprocessableExceptionStrategy, Xtensive.Orm.Reprocessing</DefaultExecuteStrategy>
+  </Xtensive.Orm.Reprocessing.Xml.OnlyStrategy.HandleReprocessible>
+
+  <Xtensive.Orm.Reprocessing.Xml.OnlyStrategy.HandleUnique>
+    <DefaultExecuteStrategy>Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing</DefaultExecuteStrategy>
+  </Xtensive.Orm.Reprocessing.Xml.OnlyStrategy.HandleUnique>
+
+  <Xtensive.Orm.Reprocessing.Xml.OnlyStrategy.NonExistent>
+    <DefaultExecuteStrategy>Xtensive.Orm.Reprocessing.DummyStrategy, Xtensive.Orm.Reprocessing</DefaultExecuteStrategy>
+  </Xtensive.Orm.Reprocessing.Xml.OnlyStrategy.NonExistent>
+  
+
+  <!-- Different namings schemes of elements -->
+  <!-- LC - lower case -->
+  <!-- UC - upper case -->
+  <!-- CC - camel case -->
+  <!-- PC - pascal case-->
+  <Xtensive.Orm.Reprocessing.Xml.Naming.LC>
+    <defaulttransactionopenmode>Auto</defaulttransactionopenmode>
+    <defaultexecutestrategy>Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing</defaultexecutestrategy>
+  </Xtensive.Orm.Reprocessing.Xml.Naming.LC>
+
+  <Xtensive.Orm.Reprocessing.Xml.Naming.UC>
+    <DEFAULTTRANSACTIONOPENMODE>Auto</DEFAULTTRANSACTIONOPENMODE>
+    <DEFAULTEXECUTESTRATEGY>Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing</DEFAULTEXECUTESTRATEGY>
+  </Xtensive.Orm.Reprocessing.Xml.Naming.UC>
+
+  <Xtensive.Orm.Reprocessing.Xml.Naming.CC>
+    <defaultTransactionOpenMode>Auto</defaultTransactionOpenMode>
+    <defaultExecuteStrategy>Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing</defaultExecuteStrategy>
+  </Xtensive.Orm.Reprocessing.Xml.Naming.CC>
+
+  <Xtensive.Orm.Reprocessing.Xml.Naming.PC>
+    <DefaultTransactionOpenMode>Auto</DefaultTransactionOpenMode>
+    <DefaultExecuteStrategy>Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing</DefaultExecuteStrategy>
+  </Xtensive.Orm.Reprocessing.Xml.Naming.PC>
+
+  <!-- Cases of mistyping of element names -->
+  <!-- LC - lower case -->
+  <!-- UC - upper case -->
+  <!-- CC - camel case -->
+  <!-- PC - pascal case-->
+  <Xtensive.Orm.Reprocessing.Xml.Mistype.LC>
+    <defaultttransactionopenmode>Auto</defaultttransactionopenmode>
+    <defaulttexecutestrategy>Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing</defaulttexecutestrategy>
+  </Xtensive.Orm.Reprocessing.Xml.Mistype.LC>
+
+  <Xtensive.Orm.Reprocessing.Xml.Mistype.UC>
+    <DEFAULTTTRANSACTIONOPENMODE>Auto</DEFAULTTTRANSACTIONOPENMODE>
+    <DEFAULTTEXECUTESTRATEGY>Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing</DEFAULTTEXECUTESTRATEGY>
+  </Xtensive.Orm.Reprocessing.Xml.Mistype.UC>
+
+  <Xtensive.Orm.Reprocessing.Xml.Mistype.CC>
+    <defaultTtransactionOpenMode>Auto</defaultTtransactionOpenMode>
+    <defaulttExecuteStrategy>Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing</defaulttExecuteStrategy>
+  </Xtensive.Orm.Reprocessing.Xml.Mistype.CC>
+
+  <Xtensive.Orm.Reprocessing.Xml.Mistype.PC>
+    <DefaultTtransactionOpenMode>Auto</DefaultTtransactionOpenMode>
+    <DefaulttExecuteStrategy>Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing</DefaulttExecuteStrategy>
+  </Xtensive.Orm.Reprocessing.Xml.Mistype.PC>
+
+
+
+  <!-- combinations of Xml-specifit cases, mostly old-fashion attributes -->
+  <Xtensive.Orm.Reprocessing.Xml.EmptyNodes>
+    <DefaultTtransactionOpenMode/>
+    <DefaulttExecuteStrategy />
+  </Xtensive.Orm.Reprocessing.Xml.EmptyNodes>
+
+  <Xtensive.Orm.Reprocessing.Attributes.EmptyValues
+    defaultTransactionOpenMode=""
+    defaultExecuteStrategy="" />
+
+  <Xtensive.Orm.Reprocessing.Attributes.EmptyTMOnly
+    defaultTransactionOpenMode="" />
+
+  <Xtensive.Orm.Reprocessing.Attributes.EmptyStrategyOnly
+    defaultExecuteStrategy="" />
+
+  <Xtensive.Orm.Reprocessing.Attributes.All
+    defaultTransactionOpenMode="Auto"
+    defaultExecuteStrategy="Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing" />
+
+  <Xtensive.Orm.Reprocessing.Attributes.OnlyTM
+    defaultTransactionOpenMode="Auto" />
+
+  <Xtensive.Orm.Reprocessing.Attributes.OnlyStrategy
+    defaultExecuteStrategy="Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing" />
+
+  <!-- not compatible with ConfigurationManager style structute -->
+  <Xtensive.Orm.Reprocessing.Attributes.LC
+    defaulttransactionopenmode="Auto"
+    defaultExecuteStrategy="Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing" />
+
+  <!-- not compatible with ConfigurationManager style structute -->
+  <Xtensive.Orm.Reprocessing.Attributes.UC
+    DEFAULTTRANSACTIONOPENMODE="Auto"
+    DEFAULTEXECUTESTRATEGY="Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing" />
+
+  <!-- not compatible with ConfigurationManager style structute -->
+  <Xtensive.Orm.Reprocessing.Attributes.PC
+    DefaultTransactionOpenMode="Auto"
+    DefaultExecuteStrategy="Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing" />
+  
+</configuration>

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/MicrosoftConfugurationTests.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/MicrosoftConfugurationTests.cs
@@ -9,7 +9,7 @@ using Xtensive.Orm.Reprocessing.Configuration;
 
 namespace Xtensive.Orm.Reprocessing.Tests.Configuration
 {
-  public sealed class JsonConfigurationTest : ModernConfigurationTest
+  public sealed class JsonConfigurationTest : MicrosoftConfigurationTest
   {
     protected override ConfigTypes ConfigFormat => ConfigTypes.Json;
 
@@ -19,7 +19,7 @@ namespace Xtensive.Orm.Reprocessing.Tests.Configuration
     }
   }
 
-  public sealed class XmlConfigurationTest : ModernConfigurationTest
+  public sealed class XmlConfigurationTest : MicrosoftConfigurationTest
   {
     protected override ConfigTypes ConfigFormat => ConfigTypes.Xml;
 
@@ -131,7 +131,7 @@ namespace Xtensive.Orm.Reprocessing.Tests.Configuration
     }
   }
 
-  public abstract class ModernConfigurationTest : TestCommon.ModernConfigurationTestBase
+  public abstract class MicrosoftConfigurationTest : TestCommon.MicrosoftConfigurationTestBase
   {
     protected ReprocessingConfiguration LoadConfiguration(string sectionName, bool useRoot)
     {

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/ModernConfugurationTests.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/ModernConfugurationTests.cs
@@ -29,92 +29,102 @@ namespace Xtensive.Orm.Reprocessing.Tests.Configuration
     }
 
     [Test]
-    public void EmptyNodesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptyNodesTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Xml.EmptyNodes");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Xml.EmptyNodes", useRoot);
       CheckConfigIsDefault(repConfig);
     }
 
     [Test]
-    public void EmptyValuesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptyValuesTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.EmptyValues");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Attributes.EmptyValues", useRoot);
       CheckConfigIsDefault(repConfig);
     }
 
     [Test]
-    public void EmptyTransactionModeOnlyTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptyTransactionModeOnlyTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.EmptyTMOnly");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Attributes.EmptyTMOnly", useRoot);
       CheckConfigIsDefault(repConfig);
     }
 
     [Test]
-    public void EmptyStrategyOnlyTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptyStrategyOnlyTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.EmptyStrategyOnly");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Attributes.EmptyStrategyOnly", useRoot);
       CheckConfigIsDefault(repConfig);
     }
 
     [Test]
-    public void AllAttributesHasValuesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void AllAttributesHasValuesTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.All");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Attributes.All", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
     }
 
     [Test]
-    public void OnlyTMAttributeHasValueTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyTMAttributeHasValueTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.OnlyTM");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Attributes.OnlyTM", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
     }
 
     [Test]
-    public void OnlyStrategyAttributeHasValueTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyStrategyAttributeHasValueTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.OnlyStrategy");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Attributes.OnlyStrategy", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
     }
 
     [Test]
-    public void AttributesInLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void AttributesInLowCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.LC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Attributes.LC", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
     }
 
     [Test]
-    public void AttributesInUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void AttributesInUpperCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.UC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Attributes.UC", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
     }
 
     [Test]
-    public void AttributesInPascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void AttributesInPascalCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.PC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration("Xtensive.Orm.Reprocessing.Attributes.PC", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
@@ -123,65 +133,80 @@ namespace Xtensive.Orm.Reprocessing.Tests.Configuration
 
   public abstract class ModernConfigurationTest : TestCommon.ModernConfigurationTestBase
   {
-    [Test]
-    public void EmptySectionCase()
+    protected ReprocessingConfiguration LoadConfiguration(string sectionName, bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Empty");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      return useRoot
+        ? ReprocessingConfiguration.Load(configurationRoot, sectionName)
+        : ReprocessingConfiguration.Load(configurationRoot.GetSection(sectionName));
+    }
+
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptySectionCase(bool useRoot)
+    {
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Empty", useRoot);
       CheckConfigIsDefault(repConfig);
     }
 
     [Test]
-    public void EmptyNames()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptyNames(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.AllEmpty");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.AllEmpty", useRoot);
       CheckConfigIsDefault(repConfig);
     }
 
     [Test]
-    public void OnlyTransactionOpenModeAndEmpty()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyTransactionOpenModeAndEmpty(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.Empty");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.Empty", useRoot);
       CheckConfigIsDefault(repConfig);
     }
 
     [Test]
-    public void OnlyTransactionOpenModeAuto()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyTransactionOpenModeAuto(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.Auto");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.Auto", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
     }
 
     [Test]
-    public void OnlyTransactionOpenModeNew()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyTransactionOpenModeNew(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.New");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.New", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
     }
 
     [Test]
-    public void OnlyTransactionOpenModeDefault()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyTransactionOpenModeDefault(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.Default");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.Default", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Default));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
     }
 
     [Test]
-    public void OnlyStrategyAndEmpty()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyStrategyAndEmpty(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.Empty");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.Empty", useRoot);
       CheckConfigIsDefault(repConfig);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
@@ -189,63 +214,72 @@ namespace Xtensive.Orm.Reprocessing.Tests.Configuration
     }
 
     [Test]
-    public void OnlyStrategyHandleReprocessible()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyStrategyHandleReprocessible(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.HandleReprocessible");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.HandleReprocessible", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
     }
 
     [Test]
-    public void OnlyStrategyHandleUnique()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyStrategyHandleUnique(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.HandleUnique");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.HandleUnique", useRoot);
       Assert.That(repConfig, Is.Not.Null);
       Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
       Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
     }
 
     [Test]
-    public void OnlyStrategyNonExistent()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyStrategyNonExistent(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.NonExistent");
-      _ = Assert.Throws<InvalidOperationException>(() => ReprocessingConfiguration.Load(section));
+      _ = Assert.Throws<InvalidOperationException>(
+        () => LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.NonExistent", useRoot));
     }
 
 
     #region Naming
+
     [Test]
-    public void NamingInLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInLowCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.LC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.LC", useRoot);
       ValidateNamingConfigurationResults(repConfig);
     }
 
     [Test]
-    public void NamingInUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInUpperCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.UC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.UC", useRoot);
       ValidateNamingConfigurationResults(repConfig);
     }
 
     [Test]
-    public void NamingInCamelCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInCamelCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.CC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.CC", useRoot);
       ValidateNamingConfigurationResults(repConfig);
     }
 
     [Test]
-    public void NamingInPascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInPascalCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.PC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.PC", useRoot);
       ValidateNamingConfigurationResults(repConfig);
     }
 
@@ -258,35 +292,40 @@ namespace Xtensive.Orm.Reprocessing.Tests.Configuration
     #endregion
 
     #region mistype cases
+
     [Test]
-    public void MistypeInLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInLowCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.LC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.LC", useRoot);
       ValidateMistypeConfigurationResults(repConfig);
     }
 
     [Test]
-    public void MistypeInUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInUpperCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.UC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.UC", useRoot);
       ValidateMistypeConfigurationResults(repConfig);
     }
 
     [Test]
-    public void MistypeInCamelCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInCamelCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.CC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.CC", useRoot);
       ValidateMistypeConfigurationResults(repConfig);
     }
 
     [Test]
-    public void MistypeInPascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInPascalCase(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.PC");
-      var repConfig = ReprocessingConfiguration.Load(section);
+      var repConfig = LoadConfiguration($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.PC", useRoot);
       ValidateMistypeConfigurationResults(repConfig);
     }
 

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/ModernConfugurationTests.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Tests/ModernConfugurationTests.cs
@@ -1,0 +1,307 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Xtensive.Orm.Reprocessing.Configuration;
+
+namespace Xtensive.Orm.Reprocessing.Tests.Configuration
+{
+  public sealed class JsonConfigurationTest : ModernConfigurationTest
+  {
+    protected override ConfigTypes ConfigFormat => ConfigTypes.Json;
+
+    protected override void AddConfigurationFile(IConfigurationBuilder configurationBuilder)
+    {
+      _ = configurationBuilder.AddJsonFile("reprocessingsettings.json");
+    }
+  }
+
+  public sealed class XmlConfigurationTest : ModernConfigurationTest
+  {
+    protected override ConfigTypes ConfigFormat => ConfigTypes.Xml;
+
+    protected override void AddConfigurationFile(IConfigurationBuilder configurationBuilder)
+    {
+      _ = configurationBuilder.AddXmlFile("ReprocessingSettings.config");
+    }
+
+    [Test]
+    public void EmptyNodesTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Xml.EmptyNodes");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      CheckConfigIsDefault(repConfig);
+    }
+
+    [Test]
+    public void EmptyValuesTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.EmptyValues");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      CheckConfigIsDefault(repConfig);
+    }
+
+    [Test]
+    public void EmptyTransactionModeOnlyTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.EmptyTMOnly");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      CheckConfigIsDefault(repConfig);
+    }
+
+    [Test]
+    public void EmptyStrategyOnlyTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.EmptyStrategyOnly");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      CheckConfigIsDefault(repConfig);
+    }
+
+    [Test]
+    public void AllAttributesHasValuesTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.All");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
+    }
+
+    [Test]
+    public void OnlyTMAttributeHasValueTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.OnlyTM");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
+    }
+
+    [Test]
+    public void OnlyStrategyAttributeHasValueTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.OnlyStrategy");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
+    }
+
+    [Test]
+    public void AttributesInLowCase()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.LC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
+    }
+
+    [Test]
+    public void AttributesInUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.UC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
+    }
+
+    [Test]
+    public void AttributesInPascalCase()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Reprocessing.Attributes.PC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
+    }
+  }
+
+  public abstract class ModernConfigurationTest : TestCommon.ModernConfigurationTestBase
+  {
+    [Test]
+    public void EmptySectionCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Empty");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      CheckConfigIsDefault(repConfig);
+    }
+
+    [Test]
+    public void EmptyNames()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.AllEmpty");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      CheckConfigIsDefault(repConfig);
+    }
+
+    [Test]
+    public void OnlyTransactionOpenModeAndEmpty()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.Empty");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      CheckConfigIsDefault(repConfig);
+    }
+
+    [Test]
+    public void OnlyTransactionOpenModeAuto()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.Auto");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
+    }
+
+    [Test]
+    public void OnlyTransactionOpenModeNew()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.New");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
+    }
+
+    [Test]
+    public void OnlyTransactionOpenModeDefault()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyTM.Default");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Default));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
+    }
+
+    [Test]
+    public void OnlyStrategyAndEmpty()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.Empty");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      CheckConfigIsDefault(repConfig);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
+    }
+
+    [Test]
+    public void OnlyStrategyHandleReprocessible()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.HandleReprocessible");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
+    }
+
+    [Test]
+    public void OnlyStrategyHandleUnique()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.HandleUnique");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
+    }
+
+    [Test]
+    public void OnlyStrategyNonExistent()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.OnlyStrategy.NonExistent");
+      _ = Assert.Throws<InvalidOperationException>(() => ReprocessingConfiguration.Load(section));
+    }
+
+
+    #region Naming
+    [Test]
+    public void NamingInLowCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.LC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      ValidateNamingConfigurationResults(repConfig);
+    }
+
+    [Test]
+    public void NamingInUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.UC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      ValidateNamingConfigurationResults(repConfig);
+    }
+
+    [Test]
+    public void NamingInCamelCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.CC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      ValidateNamingConfigurationResults(repConfig);
+    }
+
+    [Test]
+    public void NamingInPascalCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Naming.PC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      ValidateNamingConfigurationResults(repConfig);
+    }
+
+    private static void ValidateNamingConfigurationResults(ReprocessingConfiguration repConfig)
+    {
+      Assert.That(repConfig, Is.Not.Null);
+      Assert.That(repConfig.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.Auto));
+      Assert.That(repConfig.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleUniqueConstraintViolationStrategy)));
+    }
+    #endregion
+
+    #region mistype cases
+    [Test]
+    public void MistypeInLowCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.LC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(repConfig);
+    }
+
+    [Test]
+    public void MistypeInUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.UC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(repConfig);
+    }
+
+    [Test]
+    public void MistypeInCamelCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.CC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(repConfig);
+    }
+
+    [Test]
+    public void MistypeInPascalCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Reprocessing.{ConfigFormat}.Mistype.PC");
+      var repConfig = ReprocessingConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(repConfig);
+    }
+
+    private static void ValidateMistypeConfigurationResults(ReprocessingConfiguration repConfig)
+    {
+      CheckConfigIsDefault(repConfig);
+    }
+
+    #endregion
+
+    protected static void CheckConfigIsDefault(ReprocessingConfiguration configuration)
+    {
+      Assert.That(configuration, Is.Not.Null);
+      Assert.That(configuration.DefaultTransactionOpenMode, Is.EqualTo(TransactionOpenMode.New));
+      Assert.That(configuration.DefaultExecuteStrategy, Is.EqualTo(typeof(HandleReprocessableExceptionStrategy)));
+    }
+  }
+}

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Xtensive.Orm.Reprocessing.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Xtensive.Orm.Reprocessing.Tests.csproj
@@ -8,16 +8,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Xtensive.Orm.Reprocessing.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Xtensive.Orm.Reprocessing.Tests.csproj
@@ -9,6 +9,16 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />
     <ProjectReference Include="..\TestCommon\TestCommon.csproj" />
@@ -19,5 +29,13 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="ReprocessingSettings.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="reprocessingsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/Xtensive.Orm.Reprocessing.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/Xtensive.Orm.Reprocessing.Tests.csproj
@@ -10,11 +10,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Extensions/Xtensive.Orm.Reprocessing.Tests/reprocessingsettings.json
+++ b/Extensions/Xtensive.Orm.Reprocessing.Tests/reprocessingsettings.json
@@ -1,0 +1,72 @@
+{
+  "Xtensive.Orm.Reprocessing.Json.Empty": {
+
+  },
+
+  "Xtensive.Orm.Reprocessing.Json.AllEmpty": {
+    "DefaultTransactionOpenMode": "",
+    "DefaultExecuteStrategy": ""
+  },
+
+
+  "Xtensive.Orm.Reprocessing.Json.OnlyTM.Empty": {
+    "DefaultTransactionOpenMode": ""
+  },
+  "Xtensive.Orm.Reprocessing.Json.OnlyTM.Auto": {
+    "DefaultTransactionOpenMode": "Auto"
+  },
+  "Xtensive.Orm.Reprocessing.Json.OnlyTM.New": {
+    "DefaultTransactionOpenMode": "New"
+  },
+  "Xtensive.Orm.Reprocessing.Json.OnlyTM.Default": {
+    "DefaultTransactionOpenMode": "Default"
+  },
+
+  "Xtensive.Orm.Reprocessing.Json.OnlyStrategy.Empty": {
+    "DefaultExecuteStrategy": ""
+  },
+  "Xtensive.Orm.Reprocessing.Json.OnlyStrategy.HandleReprocessible": {
+    "DefaultExecuteStrategy": "Xtensive.Orm.Reprocessing.HandleReprocessableExceptionStrategy, Xtensive.Orm.Reprocessing"
+  },
+  "Xtensive.Orm.Reprocessing.Json.OnlyStrategy.HandleUnique": {
+    "DefaultExecuteStrategy": "Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing"
+  },
+  "Xtensive.Orm.Reprocessing.Json.OnlyStrategy.NonExistent": {
+    "DefaultExecuteStrategy": "Xtensive.Orm.Reprocessing.DummyStrategy, Xtensive.Orm.Reprocessing"
+  },
+
+
+  "Xtensive.Orm.Reprocessing.Json.Naming.LC": {
+    "defaulttransactionopenmode": "Auto",
+    "defaultexecutestrategy": "Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing"
+  },
+  "Xtensive.Orm.Reprocessing.Json.Naming.UC": {
+    "DEFAULTTRANSACTIONOPENMODE": "Auto",
+    "DEFAULTEXECUTESTRATEGY": "Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing"
+  },
+  "Xtensive.Orm.Reprocessing.Json.Naming.CC": {
+    "defaultTransactionOpenMode": "Auto",
+    "defaultExecuteStrategy": "Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing"
+  },
+  "Xtensive.Orm.Reprocessing.Json.Naming.PC": {
+    "DefaultTransactionOpenMode": "Auto",
+    "DefaultExecuteStrategy": "Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing"
+  },
+
+  "Xtensive.Orm.Reprocessing.Json.Mistype.LC": {
+    "defaultttransactionopenmode": "Auto",
+    "defaulttexecutestrategy": "Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing"
+  },
+  "Xtensive.Orm.Reprocessing.Json.Mistype.UC": {
+    "DEFAULTTTRANSACTIONOPENMODE": "Auto",
+    "DEFAULTTEXECUTESTRATEGY": "Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing"
+  },
+  "Xtensive.Orm.Reprocessing.Json.Mistype.CC": {
+    "defaultTtransactionOpenMode": "Auto",
+    "defaulttExecuteStrategy": "Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing"
+  },
+  "Xtensive.Orm.Reprocessing.Json.Mistype.PC": {
+    "DefaultTtransactionOpenMode": "Auto",
+    "DefaulttExecuteStrategy": "Xtensive.Orm.Reprocessing.HandleUniqueConstraintViolationStrategy, Xtensive.Orm.Reprocessing"
+  }
+}

--- a/Extensions/Xtensive.Orm.Reprocessing/Configuration/ConfigurationSection.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/Configuration/ConfigurationSection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Configuration;
 
@@ -11,8 +11,9 @@ namespace Xtensive.Orm.Reprocessing.Configuration
   {
     /// <summary>
     /// Gets default section name for reprocessing configuration.
-    /// Value is "Xtensive.Reprocessing".
+    /// Value is "Xtensive.Orm.Reprocessing".
     /// </summary>
+    [Obsolete("Use ReprocessingConfiguration.DefaultSectionName instead")]
     public static readonly string DefaultSectionName = "Xtensive.Orm.Reprocessing";
 
     /// <summary>

--- a/Extensions/Xtensive.Orm.Reprocessing/Configuration/ReprocessingConfiguration.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/Configuration/ReprocessingConfiguration.cs
@@ -12,6 +12,12 @@ namespace Xtensive.Orm.Reprocessing.Configuration
   public class ReprocessingConfiguration : ConfigurationBase
   {
     /// <summary>
+    /// Gets default section name for reprocessing configuration.
+    /// Value is "Xtensive.Orm.Reprocessing".
+    /// </summary>
+    public static readonly string DefaultSectionName = "Xtensive.Orm.Reprocessing";
+
+    /// <summary>
     /// Gets default value of the <see cref="DefaultTransactionOpenMode"/> property.
     /// </summary>
     public static readonly TransactionOpenMode DefaultDefaultTransactionOpenMode = TransactionOpenMode.New;
@@ -68,7 +74,7 @@ namespace Xtensive.Orm.Reprocessing.Configuration
     /// <returns>The reprocessing configuration.</returns>
     public static ReprocessingConfiguration Load()
     {
-      return Load(ConfigurationSection.DefaultSectionName);
+      return Load(DefaultSectionName);
     }
 
     /// <summary>
@@ -89,7 +95,7 @@ namespace Xtensive.Orm.Reprocessing.Configuration
     /// <returns>The reprocessing configuration.</returns>
     public static ReprocessingConfiguration Load(System.Configuration.Configuration configuration)
     {
-      return Load(configuration, ConfigurationSection.DefaultSectionName);
+      return Load(configuration, DefaultSectionName);
     }
 
     /// <summary>
@@ -125,13 +131,13 @@ namespace Xtensive.Orm.Reprocessing.Configuration
       ArgumentValidator.EnsureArgumentNotNull(configuration, nameof(configuration));
 
       if (configuration is IConfigurationRoot configurationRoot) {
-        return new ReprocessingConfigurationReader().Read(configurationRoot, sectionName ?? ConfigurationSection.DefaultSectionName);
+        return new ReprocessingConfigurationReader().Read(configurationRoot, sectionName ?? DefaultSectionName);
       }
       else if (configuration is IConfigurationSection configurationSection) {
         return new ReprocessingConfigurationReader().Read(configurationSection);
       }
 
-      throw new NotSupportedException("Type of configuration is not supported");
+      throw new NotSupportedException("Type of configuration is not supported.");
     }
 
 
@@ -145,7 +151,7 @@ namespace Xtensive.Orm.Reprocessing.Configuration
     {
       ArgumentValidator.EnsureArgumentNotNull(configurationRoot, nameof(configurationRoot));
 
-      return new ReprocessingConfigurationReader().Read(configurationRoot, sectionName ?? ConfigurationSection.DefaultSectionName);
+      return new ReprocessingConfigurationReader().Read(configurationRoot, sectionName ?? DefaultSectionName);
     }
 
     /// <summary>
@@ -159,8 +165,6 @@ namespace Xtensive.Orm.Reprocessing.Configuration
 
       return new ReprocessingConfigurationReader().Read(configurationSection);
     }
-
-    
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReprocessingConfiguration"/> class.

--- a/Extensions/Xtensive.Orm.Reprocessing/Configuration/ReprocessingConfigurationReader.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/Configuration/ReprocessingConfigurationReader.cs
@@ -1,4 +1,8 @@
-﻿using System;
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
 using Microsoft.Extensions.Configuration;
 using Xtensive.Orm.Configuration;
 
@@ -20,7 +24,7 @@ namespace Xtensive.Orm.Reprocessing.Configuration
       throw new NotSupportedException();
 
     public ReprocessingConfiguration Read(IConfigurationRoot configurationRoot) =>
-      Read(configurationRoot, ConfigurationSection.DefaultSectionName);
+      Read(configurationRoot, ReprocessingConfiguration.DefaultSectionName);
 
     public ReprocessingConfiguration Read(IConfigurationRoot configurationRoot, string sectionName)
     {

--- a/Extensions/Xtensive.Orm.Reprocessing/Configuration/ReprocessingConfigurationReader.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/Configuration/ReprocessingConfigurationReader.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.Extensions.Configuration;
+using Xtensive.Orm.Configuration;
+
+namespace Xtensive.Orm.Reprocessing.Configuration
+{
+  internal sealed class ReprocessingConfigurationReader : IConfigurationSectionReader<ReprocessingConfiguration>
+  {
+    // intermediate class for reading section
+    private class ReprocessingOptions
+    {
+      public TransactionOpenMode DefaultTransactionOpenMode { get; set; }
+
+      public string DefaultExecuteStrategy { get; set; }
+    }
+
+    public ReprocessingConfiguration Read(IConfigurationSection configurationSection) => ReadInternal(configurationSection);
+
+    public ReprocessingConfiguration Read(IConfigurationSection configurationSection, string nameOfConfiguration) =>
+      throw new NotSupportedException();
+
+    public ReprocessingConfiguration Read(IConfigurationRoot configurationRoot) =>
+      Read(configurationRoot, ConfigurationSection.DefaultSectionName);
+
+    public ReprocessingConfiguration Read(IConfigurationRoot configurationRoot, string sectionName)
+    {
+      var section = configurationRoot.GetSection(sectionName);
+      return ReadInternal(section);
+    }
+
+    public ReprocessingConfiguration Read(IConfigurationRoot configurationRoot, string sectionName, string nameOfConfiguration) =>
+      throw new NotSupportedException();
+
+    private ReprocessingConfiguration ReadInternal(IConfigurationSection section)
+    {
+      var reprocessingOptions = section.Get<ReprocessingOptions>();
+
+      if (reprocessingOptions == default) {
+        return new ReprocessingConfiguration();
+      }
+
+      if (reprocessingOptions.DefaultTransactionOpenMode == default
+        && reprocessingOptions.DefaultExecuteStrategy == default) {
+        // that means instance is default. probably invalid
+        return new ReprocessingConfiguration();
+      }
+
+      var result = new ReprocessingConfiguration();
+      if (reprocessingOptions.DefaultTransactionOpenMode != default) {
+        result.DefaultTransactionOpenMode = reprocessingOptions.DefaultTransactionOpenMode;
+      }
+      if (!string.IsNullOrEmpty(reprocessingOptions.DefaultExecuteStrategy)) {
+        var type = Type.GetType(reprocessingOptions.DefaultExecuteStrategy, false);
+        if (type == null)
+          throw new InvalidOperationException($"Can't resolve type '{reprocessingOptions.DefaultExecuteStrategy}'. Note that DefaultExecuteStrategy value should be in form of Assembly Qualified Name");
+        result.DefaultExecuteStrategy = type;
+      }
+      return result;
+    }
+  }
+}

--- a/Extensions/Xtensive.Orm.Reprocessing/Configuration/ReprocessingConfigurationReader.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/Configuration/ReprocessingConfigurationReader.cs
@@ -9,7 +9,7 @@ namespace Xtensive.Orm.Reprocessing.Configuration
     // intermediate class for reading section
     private class ReprocessingOptions
     {
-      public TransactionOpenMode DefaultTransactionOpenMode { get; set; }
+      public TransactionOpenMode? DefaultTransactionOpenMode { get; set; }
 
       public string DefaultExecuteStrategy { get; set; }
     }
@@ -47,7 +47,7 @@ namespace Xtensive.Orm.Reprocessing.Configuration
 
       var result = new ReprocessingConfiguration();
       if (reprocessingOptions.DefaultTransactionOpenMode != default) {
-        result.DefaultTransactionOpenMode = reprocessingOptions.DefaultTransactionOpenMode;
+        result.DefaultTransactionOpenMode = reprocessingOptions.DefaultTransactionOpenMode.Value;
       }
       if (!string.IsNullOrEmpty(reprocessingOptions.DefaultExecuteStrategy)) {
         var type = Type.GetType(reprocessingOptions.DefaultExecuteStrategy, false);

--- a/Extensions/Xtensive.Orm.Reprocessing/DomainConfigurationExtensions.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/DomainConfigurationExtensions.cs
@@ -1,3 +1,7 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
 using Microsoft.Extensions.Configuration;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Reprocessing.Configuration;

--- a/Extensions/Xtensive.Orm.Reprocessing/DomainConfigurationExtensions.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/DomainConfigurationExtensions.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.Configuration;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Reprocessing.Configuration;
+
+namespace Xtensive.Orm.Reprocessing
+{
+  /// <summary>
+  /// Contains extensions for DomainConfiguration that help to configure the extension.
+  /// </summary>
+  public static class DomainConfigurationReprocessingExtensions
+  {
+    /// <summary>
+    /// Loads configuration by calling <see cref="ReprocessingConfiguration.Load()"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureReprocessingExtension(this DomainConfiguration domainConfiguration) =>
+      ConfigureReprocessingExtension(domainConfiguration, ReprocessingConfiguration.Load());
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="ReprocessingConfiguration.Load(string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationSectionName">Section name.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureReprocessingExtension(this DomainConfiguration domainConfiguration,
+       string configurationSectionName) =>
+      ConfigureReprocessingExtension(domainConfiguration, ReprocessingConfiguration.Load(configurationSectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="ReprocessingConfiguration.Load(System.Configuration.Configuration)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuration to load from.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureReprocessingExtension(this DomainConfiguration domainConfiguration,
+        System.Configuration.Configuration configuration) =>
+      ConfigureReprocessingExtension(domainConfiguration, ReprocessingConfiguration.Load(configuration));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="ReprocessingConfiguration.Load(System.Configuration.Configuration)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuration to load from.</param>
+    /// <param name="sectionName">Section in <paramref name="configuration"/></param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureReprocessingExtension(this DomainConfiguration domainConfiguration,
+        System.Configuration.Configuration configuration, string sectionName) =>
+      ConfigureReprocessingExtension(domainConfiguration, ReprocessingConfiguration.Load(configuration, sectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="ReprocessingConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuration to load from.</param>
+    /// <param name="sectionName">Section in <paramref name="configuration"/></param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureReprocessingExtension(this DomainConfiguration domainConfiguration,
+        IConfiguration configuration, string sectionName = null) =>
+      ConfigureReprocessingExtension(domainConfiguration, ReprocessingConfiguration.Load(configuration, sectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="ReprocessingConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationRoot">Configuration to load from.</param>
+    /// <param name="sectionName">Section in <paramref name="configurationRoot"/></param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureReprocessingExtension(this DomainConfiguration domainConfiguration,
+        IConfigurationRoot configurationRoot, string sectionName = null) =>
+      ConfigureReprocessingExtension(domainConfiguration, ReprocessingConfiguration.Load(configurationRoot, sectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="ReprocessingConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationSection">Configuration section to load from.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureReprocessingExtension(this DomainConfiguration domainConfiguration,
+        IConfigurationSection configurationSection) =>
+      ConfigureReprocessingExtension(domainConfiguration, ReprocessingConfiguration.Load(configurationSection));
+
+    /// <summary>
+    /// Configures the extension with given reprocessing configuration instance.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="reprocessingConfiguration">Security configuration instance.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureReprocessingExtension(this DomainConfiguration domainConfiguration,
+      ReprocessingConfiguration reprocessingConfiguration)
+    {
+      domainConfiguration.ExtensionConfigurations.Set(reprocessingConfiguration);
+      domainConfiguration.Types.Register(typeof(DomainConfigurationReprocessingExtensions).Assembly);
+      return domainConfiguration;
+    }
+  }
+}

--- a/Extensions/Xtensive.Orm.Reprocessing/DomainExtensions.cs
+++ b/Extensions/Xtensive.Orm.Reprocessing/DomainExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Transactions;
+using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Reprocessing.Configuration;
 
 namespace Xtensive.Orm.Reprocessing
@@ -190,7 +191,8 @@ namespace Xtensive.Orm.Reprocessing
       IExecuteActionStrategy strategy,
       Func<Session, T> func)
     {
-      var config = domain.GetReprocessingConfiguration();
+      var config = domain.Configuration.ExtensionConfigurations.Get<ReprocessingConfiguration>()
+        ?? domain.GetReprocessingConfiguration();
       if (strategy == null) {
         strategy = ExecuteActionStrategy.GetSingleton(config.DefaultExecuteStrategy);
       }
@@ -208,7 +210,8 @@ namespace Xtensive.Orm.Reprocessing
       IExecuteActionStrategy strategy,
       Func<Session, T> func)
     {
-      var config = domain.GetReprocessingConfiguration();
+      var config = domain.Configuration.ExtensionConfigurations.Get<ReprocessingConfiguration>()
+        ?? domain.GetReprocessingConfiguration();
       if (strategy == null) {
         strategy = ExecuteActionStrategy.GetSingleton(config.DefaultExecuteStrategy);
       }

--- a/Extensions/Xtensive.Orm.Reprocessing/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Reprocessing/NugetContent/ReadMe.md
@@ -8,7 +8,7 @@ should represent a separate block of logic, usually a delegate of a method and b
 
 Prerequisites
 -------------
-DataObjects.Net 7.0.x (http://dataobjects.net)
+DataObjects.Net 7.1.x (http://dataobjects.net)
 
 Examples of usage
 -----------------
@@ -40,10 +40,16 @@ To indicate that a particular strategy should be used, use the following syntax:
     });
 ```
 
-**Expample #3**. Confugure reprocessing in configuration file. To omit setting up the strategy each time consider configuring it in 
-application configuration file, e.g.:
+
+Examples of how to configure extension
+--------------------------------------
+
+Following examples show different ways to configure extension in configuration files of various types.
+
+**Example #1** Confugure in App.config/Web.config
 
 ```xml
+<configuration>
   <configSections>
     <!-- ... -->
     <section name="Xtensive.Orm.Reprocessing" 
@@ -54,7 +60,249 @@ application configuration file, e.g.:
     defaultTransactionOpenMode="New" 
     defaultExecuteStrategy="Xtensive.Orm.Reprocessing.HandleReprocessableExceptionStrategy, Xtensive.Orm.Reprocessing">
   </Xtensive.Orm.Reprocessing>
+</configuration>
 ```
 
-Having that done, in scenarios with no strategy specified, the extension will automatically use 
-the strategy from the configuration.
+Such configuration is only compatible with System.Configuration.ConfigurationManager.
+If project still supports such configurations then Reprocessing configuration will be read automatically when it needed to be read.
+Sometimes a work-around is needed to read such configuration, for more read Example #2 and Example #3
+
+
+**Example #2** Reading old-style configuration of an assembly in NET 5 and newer.
+
+Due to new architecture without AppDomain (which among the other things was in charge of gathering configuration files of loaded assemblies
+as it would be one configuration file) System.Configuration.ConfigurationManager now reads only configuration file of actual executable, loaded 
+assemblies' configuration files stay unreachable by default, though there is need to read some data from them.
+A great example is test projects which are usually get loaded by test runner executable, and the only configuration accessible in this case
+is test runner one.
+
+Extra step is required to read configuration files in such cases. Thankfully ConfigurationManager has methods to get access to assemblies' configurations.
+
+To get access to an assembly configuration file it should be opened explicitly by
+
+```csharp
+  var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
+```
+
+The instance returned from ```OpenExeConfiguration``` provides access to sections of the assembly configuration. DataObjects.Net configurations
+(```DomainConfiguration```, ```ReprocessingConfiguration```, etc.) have ```Load()``` methods that can recieve this instance.
+```ReprocessingConfiguration``` can be read like so
+
+```csharp
+  var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
+  var reprocessingConfig = ReprocessingConfiguration.Load(configuration);
+
+  // loaded configuration should be manually placed to
+  domainConfiguration.ExtensionConfigurations.Set(reprocessingConfig);
+```
+
+The ```domainConfiguration.ExtensionConfigurations``` is a new unified place from which an extension will try to get its configuration
+instead of calling default parameterless ```Load()``` method, which has not a lot of sense now, though the method is kept as a second source
+for backwards compatibility.
+
+For more convenience, DomainConfiguration extensions are provided, which make code more neat and clear.
+For instance,
+
+```csharp
+  var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
+
+  var domainConfiguration = DomainConfiguration.Load(configuration);
+
+  // the extension hides getting configuration with ReprocessingConfiguration.Load(configuration)
+  // and also putting it to ExtensionConfigurations collection.
+  domainConfiguration.ConfigureReprocessingExtension(configuration);
+```
+
+Custom section names are also supported if for some reason default section name is not used.
+
+
+**Example #3** Reading old-style configuration of an assembly in a project that uses appsettings.json file.
+
+If for some reason there is need to keep the old-style configuration then there is a work-around as well.
+Static configuration manager provides method ```OpenMappedExeConfiguration()``` which allows to get 
+any *.config file as ```System.Configuration.Configuration``` instance. For example
+
+```csharp
+  ExeConfigurationFileMap configFileMap = new ExeConfigurationFileMap();
+  configFileMap.ExeConfigFilename = "Orm.config"; //or other file name, the file should exist bin folder
+  var configuration = System.Configuration.ConfigurationManager.OpenMappedExeConfiguration(configFileMap, ConfigurationUserLevel.None);
+```
+
+After that, as in previous example, the instance can be passed to ```Load``` method of ```ReprocessingConfiguration``` to read extension configuration
+and later put it to ```DomainConfiguration.ExtensionConfigurations```.
+After ```System.Configuration.Configuration``` instance is provided it is possible to pass it into Load method of different DataObjects.Net configurations,
+including ```ReprocessingConfiguration```. Then put reprocessing configuration to ```DomainConfiguration.ExtensionConfigurations``` collection.
+
+```csharp
+  var reprocessingConfiguration = ReprocessingConfiguration.Load(configuration);
+
+  domainConfiguration.ExtensionConfigurations.Set(reprocessingConfiguration);
+```
+
+or to extension method
+
+```csharp
+  domainConfiguration.ConfigureReprocessingExtension(configuration);
+```
+
+
+**Example #4** Configure using Microsoft.Extensions.Configuration API.
+
+This API allows to have configurations in various forms including JSON and XML formats.
+Loading of such files may differ depending on .NET version, check Microsoft manuals for instructions.
+
+Allowed Json and Xml configuration definition look like below
+
+```xml
+<configuration>
+  <Xtensive.Orm.Reprocessing>
+    <DefaultTransactionOpenMode>New</DefaultTransactionOpenMode>
+    <DefaultExecuteStrategy>Xtensive.Orm.Reprocessing.HandleReprocessableExceptionStrategy, Xtensive.Orm.Reprocessing</DefaultExecuteStrategy>
+  </Xtensive.Orm.Reprocessing>
+</configuration>
+```
+
+```json
+{
+  "Xtensive.Orm.Reprocessing": {
+    "DefaultTransactionOpenMode" : "New",
+    "DefaultExecuteStrategy" : "Xtensive.Orm.Reprocessing.HandleReprocessableExceptionStrategy, Xtensive.Orm.Reprocessing"
+  }
+}
+```
+
+The API has certain issues with Xml elements with attributes so it is recommended to use
+more up-to-date attributeless nodes.
+For JSON it is pretty clear.
+
+```ReprocessingConfiguration.Load``` method can accept different types of abstractions from the
+API, including 
+- ```Microsoft.Extensions.Configuration.IConfiguration```,
+- ```Microsoft.Extensions.Configuration.IConfigurationRoot```
+- ```Microsoft.Extensions.Configuration.IConfigurationSection```.
+
+Loading of configuration may look like
+
+```csharp
+  
+  var app = builder.Build();
+
+  // tries to load from default section "Xtensive.Orm.Reprocessing"
+  var reprocessingConfig = ReprocessingConfiguration.Load(app.Configuration);
+
+  domainConfiguration.ExtensionConfigurations.Set(reprocessingConfig);
+```
+
+or, with use of extension
+
+
+```csharp
+  
+  var app = builder.Build();
+
+  // tries to load from default section "Xtensive.Orm.Reprocessing"
+  // and put it into domainConfiguration.ExtensionConfigurations
+
+  domainConfiguration.ConfigureReprocessingExtension(app.Configuration);
+```
+
+
+
+**Example #5** Configure using Microsoft.Extensions.Configuration API from section with non-default name.
+
+For configurations like
+
+```xml
+<configuration>
+  <Orm.Reprocessing>
+    <DefaultTransactionOpenMode>New</DefaultTransactionOpenMode>
+    <DefaultExecuteStrategy>Xtensive.Orm.Reprocessing.HandleReprocessableExceptionStrategy, Xtensive.Orm.Reprocessing</DefaultExecuteStrategy>
+  </Orm.Reprocessing>
+</configuration>
+```
+
+```json
+{
+  "Orm.Reprocessing": {
+    "DefaultTransactionOpenMode" : "New",
+    "DefaultExecuteStrategy" : "Xtensive.Orm.Reprocessing.HandleReprocessableExceptionStrategy, Xtensive.Orm.Reprocessing"
+  }
+}
+```
+
+Loading of configuration may look like
+
+```csharp
+  
+  var app = builder.Build();
+
+  var reprocessingConfig = ReprocessingConfiguration.Load(app.Configuration, "Orm.Reprocessing");
+
+  domainConfiguration.ExtensionConfigurations.Set(reprocessingConfig);
+```
+
+or with use of extension
+
+```csharp
+  
+  var app = builder.Build();
+
+  domainConfiguration.ConfigureReprocessingExtension(app.Configuration, "Orm.Reprocessing");
+```
+
+
+**Example #6** Configure using Microsoft.Extensions.Configuration API from sub-section deeper in section tree.
+
+If for some reason extension configuration should be moved deeper in section tree like something below
+
+```xml
+<configuration>
+  <Orm.Extensions>
+    <Xtensive.Orm.Reprocessing>
+      <DefaultTransactionOpenMode>New</DefaultTransactionOpenMode>
+      <DefaultExecuteStrategy>Xtensive.Orm.Reprocessing.HandleReprocessableExceptionStrategy, Xtensive.Orm.Reprocessing</DefaultExecuteStrategy>
+    </Xtensive.Orm.Reprocessing>
+  </Orm.Extensions>
+</configuration>
+```
+
+or in JSON
+
+```json
+{
+  "Orm.Extensions": {
+    "Xtensive.Orm.Reprocessing": {
+      "DefaultTransactionOpenMode" : "New",
+      "DefaultExecuteStrategy" : "Xtensive.Orm.Reprocessing.HandleReprocessableExceptionStrategy, Xtensive.Orm.Reprocessing"
+    }
+  }
+}
+```
+
+Then section must be provided manually, code may look like
+
+```csharp
+  
+  var app = builder.Build();
+
+  var configurationRoot = app.Configuration;
+  var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");
+  var reprocessingSection = extensionsGroupSection.GetSection("Xtensive.Orm.Reprocessing");
+
+  var reprocessingConfig = ReprocessingConfiguration.Load(reprocessingSection);
+
+  domainConfiguration.ExtensionConfigurations.Set(reprocessingConfig);
+```
+
+or with use of extension method
+
+```csharp
+  
+  var app = builder.Build();
+
+  var configurationRoot = app.Configuration;
+  var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");
+  var reprocessingSection = extensionsGroupSection.GetSection("Xtensive.Orm.Reprocessing");
+
+  domainConfiguration.ConfigureReprocessingExtension(reprocessingSection);
+```

--- a/Extensions/Xtensive.Orm.Reprocessing/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Reprocessing/NugetContent/ReadMe.md
@@ -63,20 +63,20 @@ Following examples show different ways to configure extension in configuration f
 </configuration>
 ```
 
-Such configuration is only compatible with System.Configuration.ConfigurationManager.
-If project still supports such configurations then Reprocessing configuration will be read automatically when it needed to be read.
+Such configuration is usually read with ```System.Configuration.ConfigurationManager```.
+If project still supports such configurations then Reprocessing configuration will be read automatically when it needs to be read.
 Sometimes a work-around is needed to read such configuration, for more read Example #2 and Example #3
 
 
 **Example #2** Reading old-style configuration of an assembly in NET 5 and newer.
 
 Due to new architecture without AppDomain (which among the other things was in charge of gathering configuration files of loaded assemblies
-as it would be one configuration file) System.Configuration.ConfigurationManager now reads only configuration file of actual executable, loaded 
+as it would be one configuration file) ```System.Configuration.ConfigurationManager``` now reads only configuration file of actual executable, loaded 
 assemblies' configuration files stay unreachable by default, though there is need to read some data from them.
 A great example is test projects which are usually get loaded by test runner executable, and the only configuration accessible in this case
 is test runner one.
 
-Extra step is required to read configuration files in such cases. Thankfully ConfigurationManager has methods to get access to assemblies' configurations.
+Extra step is required to read configuration files in such cases. Thankfully, ```ConfigurationManager``` has methods to get access to assemblies' configuration files.
 
 To get access to an assembly configuration file it should be opened explicitly by
 
@@ -96,17 +96,15 @@ The instance returned from ```OpenExeConfiguration``` provides access to section
   domainConfiguration.ExtensionConfigurations.Set(reprocessingConfig);
 ```
 
-The ```domainConfiguration.ExtensionConfigurations``` is a new unified place from which an extension will try to get its configuration
+The ```domainConfiguration.ExtensionConfigurations``` is a new unified place from which the extension will try to get its configuration
 instead of calling default parameterless ```Load()``` method, which has not a lot of sense now, though the method is kept as a second source
 for backwards compatibility.
 
-For more convenience, DomainConfiguration extensions are provided, which make code more neat and clear.
+For more convenience, ```DomainConfiguration``` extensions are provided, which make code more neater.
 For instance,
 
 ```csharp
   var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
-
-  var domainConfiguration = DomainConfiguration.Load(configuration);
 
   // the extension hides getting configuration with ReprocessingConfiguration.Load(configuration)
   // and also putting it to ExtensionConfigurations collection.
@@ -120,7 +118,7 @@ Custom section names are also supported if for some reason default section name 
 
 If for some reason there is need to keep the old-style configuration then there is a work-around as well.
 Static configuration manager provides method ```OpenMappedExeConfiguration()``` which allows to get 
-any *.config file as ```System.Configuration.Configuration``` instance. For example
+any *.config file as ```System.Configuration.Configuration``` instance. For example,
 
 ```csharp
   ExeConfigurationFileMap configFileMap = new ExeConfigurationFileMap();
@@ -129,9 +127,7 @@ any *.config file as ```System.Configuration.Configuration``` instance. For exam
 ```
 
 After that, as in previous example, the instance can be passed to ```Load``` method of ```ReprocessingConfiguration``` to read extension configuration
-and later put it to ```DomainConfiguration.ExtensionConfigurations```.
-After ```System.Configuration.Configuration``` instance is provided it is possible to pass it into Load method of different DataObjects.Net configurations,
-including ```ReprocessingConfiguration```. Then put reprocessing configuration to ```DomainConfiguration.ExtensionConfigurations``` collection.
+and later put it to ```DomainConfiguration.ExtensionConfigurations```
 
 ```csharp
   var reprocessingConfiguration = ReprocessingConfiguration.Load(configuration);
@@ -139,7 +135,7 @@ including ```ReprocessingConfiguration```. Then put reprocessing configuration t
   domainConfiguration.ExtensionConfigurations.Set(reprocessingConfiguration);
 ```
 
-or to extension method
+Extension usage will look like
 
 ```csharp
   domainConfiguration.ConfigureReprocessingExtension(configuration);
@@ -151,7 +147,7 @@ or to extension method
 This API allows to have configurations in various forms including JSON and XML formats.
 Loading of such files may differ depending on .NET version, check Microsoft manuals for instructions.
 
-Allowed Json and Xml configuration definition look like below
+Allowed JSON and XML configuration definition look like below
 
 ```xml
 <configuration>
@@ -173,12 +169,11 @@ Allowed Json and Xml configuration definition look like below
 
 The API has certain issues with Xml elements with attributes so it is recommended to use
 more up-to-date attributeless nodes.
-For JSON it is pretty clear.
+For JSON it is pretty clear,  almost averyone knows its format.
 
-```ReprocessingConfiguration.Load``` method can accept different types of abstractions from the
-API, including 
-- ```Microsoft.Extensions.Configuration.IConfiguration```,
-- ```Microsoft.Extensions.Configuration.IConfigurationRoot```
+```ReprocessingConfiguration.Load``` method can accept different types of abstractions from the API, including 
+- ```Microsoft.Extensions.Configuration.IConfiguration```;
+- ```Microsoft.Extensions.Configuration.IConfigurationRoot```;
 - ```Microsoft.Extensions.Configuration.IConfigurationSection```.
 
 Loading of configuration may look like
@@ -187,18 +182,22 @@ Loading of configuration may look like
   
   var app = builder.Build();
 
+  //...
+
   // tries to load from default section "Xtensive.Orm.Reprocessing"
   var reprocessingConfig = ReprocessingConfiguration.Load(app.Configuration);
 
   domainConfiguration.ExtensionConfigurations.Set(reprocessingConfig);
 ```
 
-or, with use of extension
+or, with use of extension, like
 
 
 ```csharp
   
   var app = builder.Build();
+
+  //...
 
   // tries to load from default section "Xtensive.Orm.Reprocessing"
   // and put it into domainConfiguration.ExtensionConfigurations
@@ -236,16 +235,20 @@ Loading of configuration may look like
   
   var app = builder.Build();
 
+  //...
+
   var reprocessingConfig = ReprocessingConfiguration.Load(app.Configuration, "Orm.Reprocessing");
 
   domainConfiguration.ExtensionConfigurations.Set(reprocessingConfig);
 ```
 
-or with use of extension
+or, with use of extension, like
 
 ```csharp
   
   var app = builder.Build();
+
+  //...
 
   domainConfiguration.ConfigureReprocessingExtension(app.Configuration, "Orm.Reprocessing");
 ```
@@ -285,6 +288,8 @@ Then section must be provided manually, code may look like
   
   var app = builder.Build();
 
+  //...
+
   var configurationRoot = app.Configuration;
   var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");
   var reprocessingSection = extensionsGroupSection.GetSection("Xtensive.Orm.Reprocessing");
@@ -294,11 +299,13 @@ Then section must be provided manually, code may look like
   domainConfiguration.ExtensionConfigurations.Set(reprocessingConfig);
 ```
 
-or with use of extension method
+or, with use of extension method, like
 
 ```csharp
   
   var app = builder.Build();
+
+  //...
 
   var configurationRoot = app.Configuration;
   var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");

--- a/Extensions/Xtensive.Orm.Reprocessing/Xtensive.Orm.Reprocessing.csproj
+++ b/Extensions/Xtensive.Orm.Reprocessing/Xtensive.Orm.Reprocessing.csproj
@@ -17,9 +17,13 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Label="Nuget content">
     <Content Include="$(ProjectDir)NuGetContent\**">

--- a/Extensions/Xtensive.Orm.Reprocessing/Xtensive.Orm.Reprocessing.csproj
+++ b/Extensions/Xtensive.Orm.Reprocessing/Xtensive.Orm.Reprocessing.csproj
@@ -17,11 +17,11 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>

--- a/Extensions/Xtensive.Orm.Reprocessing/Xtensive.Orm.Reprocessing.csproj
+++ b/Extensions/Xtensive.Orm.Reprocessing/Xtensive.Orm.Reprocessing.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />

--- a/Extensions/Xtensive.Orm.Security.Tests/App.config
+++ b/Extensions/Xtensive.Orm.Security.Tests/App.config
@@ -1,9 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <configSections>
     <section name="Xtensive.Orm" type="Xtensive.Orm.Configuration.Elements.ConfigurationSection, Xtensive.Orm" />
     <section name="Xtensive.Orm.Security.WithName" type="Xtensive.Orm.Security.Configuration.ConfigurationSection, Xtensive.Orm.Security" />
     <section name="Xtensive.Orm.Security.WithoutName" type="Xtensive.Orm.Security.Configuration.ConfigurationSection, Xtensive.Orm.Security" />
+    <section name="Xtensive.Orm.Security.AllDeclared" type="Xtensive.Orm.Security.Configuration.ConfigurationSection, Xtensive.Orm.Security" />
     <section name="Xtensive.Orm.Security.Empty" type="Xtensive.Orm.Security.Configuration.ConfigurationSection, Xtensive.Orm.Security" />
     <section name="Xtensive.Orm.Security" type="Xtensive.Orm.Security.Configuration.ConfigurationSection, Xtensive.Orm.Security" />
   </configSections>
@@ -16,7 +17,13 @@
   </Xtensive.Orm.Security.WithoutName>
   <Xtensive.Orm.Security.Empty>
   </Xtensive.Orm.Security.Empty>
+  <Xtensive.Orm.Security.AllDeclared>
+    <hashingService name="sha1" />
+    <authenticationService name="notdefault" />
+  </Xtensive.Orm.Security.AllDeclared>
   <Xtensive.Orm.Security>
     <hashingService name="sha1"/>
   </Xtensive.Orm.Security>
+  
+  
 </configuration>

--- a/Extensions/Xtensive.Orm.Security.Tests/SecuritySettings.config
+++ b/Extensions/Xtensive.Orm.Security.Tests/SecuritySettings.config
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <!-- No elements, all names should be default-->
+  <Xtensive.Orm.Security.Xml.Empty>
+  </Xtensive.Orm.Security.Xml.Empty>
+
+  <!--Names are empty, all names should be default-->
+  <Xtensive.Orm.Security.Xml.AllEmpty>
+    <HashingService></HashingService>
+    <AuthenticationService></AuthenticationService>
+  </Xtensive.Orm.Security.Xml.AllEmpty>
+
+  <!-- Only hashing name set, auth should be default -->
+  <Xtensive.Orm.Security.Xml.OnlyHashing.Sha1>
+    <HashingService>sha1</HashingService>
+  </Xtensive.Orm.Security.Xml.OnlyHashing.Sha1>
+  <Xtensive.Orm.Security.Xml.OnlyHashing.Sha256>
+    <HashingService>sha256</HashingService>
+  </Xtensive.Orm.Security.Xml.OnlyHashing.Sha256>
+  <Xtensive.Orm.Security.Xml.OnlyHashing.Sha384>
+    <HashingService>sha384</HashingService>
+  </Xtensive.Orm.Security.Xml.OnlyHashing.Sha384>
+  <Xtensive.Orm.Security.Xml.OnlyHashing.Sha512>
+    <HashingService>sha512</HashingService>
+  </Xtensive.Orm.Security.Xml.OnlyHashing.Sha512>
+  <Xtensive.Orm.Security.Xml.OnlyHashing.Md5>
+    <HashingService>md5</HashingService>
+  </Xtensive.Orm.Security.Xml.OnlyHashing.Md5>
+  <Xtensive.Orm.Security.Xml.OnlyHashing.Empty>
+    <HashingService></HashingService>
+  </Xtensive.Orm.Security.Xml.OnlyHashing.Empty>
+
+  <!-- Only auth service name set, hashing name should be default -->
+  <Xtensive.Orm.Security.Xml.OnlyAuth>
+    <AuthenticationService>NotDefault</AuthenticationService>
+  </Xtensive.Orm.Security.Xml.OnlyAuth>
+
+  <!-- Auth is empty and hashing doesn't exist, all should be default -->
+  <Xtensive.Orm.Security.Xml.OnlyAuth.Empty>
+    <AuthenticationService></AuthenticationService>
+  </Xtensive.Orm.Security.Xml.OnlyAuth.Empty>
+
+  <!-- Different namings schemes of elements -->
+  <!-- LC - lower case -->
+  <!-- UC - upper case -->
+  <!-- CC - camel case -->
+  <!-- PC - pascal case-->
+  <Xtensive.Orm.Security.Xml.Naming.LC>
+    <hashingservice>sha1</hashingservice>
+    <authenticationservice>NotDefault</authenticationservice>
+  </Xtensive.Orm.Security.Xml.Naming.LC>
+
+  <Xtensive.Orm.Security.Xml.Naming.UC>
+    <HASHINGSERVICE>sha1</HASHINGSERVICE>
+    <AUTHENTICATIONSERVICE>NotDefault</AUTHENTICATIONSERVICE>
+  </Xtensive.Orm.Security.Xml.Naming.UC>
+
+  <Xtensive.Orm.Security.Xml.Naming.CC>
+    <hashingService>sha1</hashingService>
+    <authenticationService>NotDefault</authenticationService>
+  </Xtensive.Orm.Security.Xml.Naming.CC>
+
+  <Xtensive.Orm.Security.Xml.Naming.PC>
+    <HashingService>sha1</HashingService>
+    <AuthenticationService>NotDefault</AuthenticationService>
+  </Xtensive.Orm.Security.Xml.Naming.PC>
+
+  <!-- Cases of mistyping of element names -->
+  <!-- LC - lower case -->
+  <!-- UC - upper case -->
+  <!-- CC - camel case -->
+  <!-- PC - pascal case-->
+  <Xtensive.Orm.Security.Xml.Mistype.LC>
+    <hashiingservice>sha1</hashiingservice>
+    <authentticationservice>NotDefault</authentticationservice>
+  </Xtensive.Orm.Security.Xml.Mistype.LC>
+
+  <Xtensive.Orm.Security.Xml.Mistype.UC>
+    <HASHIINGSERVICE>sha1</HASHIINGSERVICE>
+    <AUTHENTTICATIONSERVICE>NotDefault</AUTHENTTICATIONSERVICE>
+  </Xtensive.Orm.Security.Xml.Mistype.UC>
+
+  <Xtensive.Orm.Security.Xml.Mistype.CC>
+    <hashiingService>sha1</hashiingService>
+    <authentticationService>NotDefault</authentticationService>
+  </Xtensive.Orm.Security.Xml.Mistype.CC>
+
+  <Xtensive.Orm.Security.Xml.Mistype.PC>
+    <HashiingService>sha1</HashiingService>
+    <AuthentticationService>NotDefault</AuthentticationService>
+  </Xtensive.Orm.Security.Xml.Mistype.PC>
+
+  <!-- Cases of configuration when service name is represented by Name child node -->
+  <Xtensive.Orm.Security.Xml.NameNode.NamesEmpty>
+    <HashingService>
+      <Name></Name>
+    </HashingService>
+    <AuthenticationService>
+      <Name></Name>
+    </AuthenticationService>
+  </Xtensive.Orm.Security.Xml.NameNode.NamesEmpty>
+
+  <Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Sha1>
+    <HashingService>
+      <Name>sha1</Name>
+    </HashingService>
+  </Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Sha1>
+  <Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Sha256>
+    <HashingService>
+      <Name>sha256</Name>
+    </HashingService>
+  </Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Sha256>
+  <Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Sha384>
+    <HashingService>
+      <Name>sha384</Name>
+    </HashingService>
+  </Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Sha384>
+  <Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Sha512>
+    <HashingService>
+      <Name>sha512</Name>
+    </HashingService>
+  </Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Sha512>
+  <Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Md5>
+    <HashingService>
+      <Name>md5</Name>
+    </HashingService>
+  </Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Md5>
+  <Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Empty>
+    <HashingService>
+      <Name></Name>
+    </HashingService>
+  </Xtensive.Orm.Security.Xml.NameNode.OnlyHashing.Empty>
+
+  <Xtensive.Orm.Security.Xml.NameNode.OnlyAuth>
+    <AuthenticationService>
+      <Name>NotDefault</Name>
+    </AuthenticationService>
+  </Xtensive.Orm.Security.Xml.NameNode.OnlyAuth>
+  <Xtensive.Orm.Security.Xml.NameNode.OnlyAuth.Empty>
+    <AuthenticationService>
+      <Name></Name>
+    </AuthenticationService>
+  </Xtensive.Orm.Security.Xml.NameNode.OnlyAuth.Empty>
+
+  <Xtensive.Orm.Security.Xml.NameNode.Naming.LC>
+    <HashingService>
+      <name>sha1</name>
+    </HashingService>
+    <AuthenticationService>
+      <name>NotDefault</name>
+    </AuthenticationService>
+  </Xtensive.Orm.Security.Xml.NameNode.Naming.LC>
+
+  <Xtensive.Orm.Security.Xml.NameNode.Naming.UC>
+    <HashingService>
+      <NAME>sha1</NAME>
+    </HashingService>
+    <AuthenticationService>
+      <NAME>NotDefault</NAME>
+    </AuthenticationService>
+  </Xtensive.Orm.Security.Xml.NameNode.Naming.UC>
+
+  <Xtensive.Orm.Security.Xml.NameNode.Naming.CC>
+    <HashingService>
+      <naMe>sha1</naMe>
+    </HashingService>
+    <AuthenticationService>
+      <naMe>NotDefault</naMe>
+    </AuthenticationService>
+  </Xtensive.Orm.Security.Xml.NameNode.Naming.CC>
+
+  <Xtensive.Orm.Security.Xml.NameNode.Naming.PC>
+    <HashingService>
+      <NaMe>sha1</NaMe>
+    </HashingService>
+    <AuthenticationService>
+      <NaMe>NotDefault</NaMe>
+    </AuthenticationService>
+  </Xtensive.Orm.Security.Xml.NameNode.Naming.PC>
+  
+  
+  <!-- combinations of Xml-specifit cases, mostly old-fashion attributes -->
+  <Xtensive.Orm.Security.NameAttribute.NamesEmpty>
+    <hashingService name="" />
+    <authenticationService name="" />
+  </Xtensive.Orm.Security.NameAttribute.NamesEmpty>
+
+  <Xtensive.Orm.Security.NameAttribute.NameExistPartially1>
+    <hashingService name="" />
+    <authenticationService />
+  </Xtensive.Orm.Security.NameAttribute.NameExistPartially1>
+
+  <Xtensive.Orm.Security.NameAttribute.NameExistPartially2>
+    <hashingService />
+    <authenticationService name="" />
+  </Xtensive.Orm.Security.NameAttribute.NameExistPartially2>
+
+  <Xtensive.Orm.Security.NameAttribute.AllNames>
+    <hashingService name="sha1" />
+    <authenticationService name="NotDefault" />
+  </Xtensive.Orm.Security.NameAttribute.AllNames>
+
+  <Xtensive.Orm.Security.NameAttribute.OnlyHashing>
+    <hashingService name="sha1" />
+  </Xtensive.Orm.Security.NameAttribute.OnlyHashing>
+
+  <Xtensive.Orm.Security.NameAttribute.OnlyAuth>
+    <authenticationService name="NotDefault" />
+  </Xtensive.Orm.Security.NameAttribute.OnlyAuth>
+
+  <Xtensive.Orm.Security.NameAttribute.LC>
+    <hashingservice name="sha1" />
+    <authenticationservice name="NotDefault" />
+  </Xtensive.Orm.Security.NameAttribute.LC>
+
+  <Xtensive.Orm.Security.NameAttribute.UC>
+    <HASHINGSERVICE name="sha1" />
+    <AUTHENTICATIONSERVICE name="NotDefault" />
+  </Xtensive.Orm.Security.NameAttribute.UC>
+
+  <Xtensive.Orm.Security.NameAttribute.PC>
+    <HashingService name="sha1" />
+    <AuthenticationService name="NotDefault" />
+  </Xtensive.Orm.Security.NameAttribute.PC>
+</configuration>

--- a/Extensions/Xtensive.Orm.Security.Tests/Tests/ConfigurationTests.cs
+++ b/Extensions/Xtensive.Orm.Security.Tests/Tests/ConfigurationTests.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2021 Xtensive LLC.
+// Copyright (C) 2011-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -17,7 +17,7 @@ namespace Xtensive.Orm.Security.Tests
     [Test]
     public void HashingServiceNameTest()
     {
-      var section = (Configuration.ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security.WithName");
+      var section = (ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security.WithName");
       Assert.That(section, Is.Not.Null);
       Assert.That(section.HashingService, Is.Not.Null);
       Assert.That(section.HashingService.Name, Is.Not.Null);
@@ -29,9 +29,26 @@ namespace Xtensive.Orm.Security.Tests
     }
 
     [Test]
+    public void HashingServiceAndAuthenticationServiceNameTest()
+    {
+      var section = (ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security.AllDeclared");
+      Assert.That(section, Is.Not.Null);
+      Assert.That(section.HashingService, Is.Not.Null);
+      Assert.That(section.HashingService.Name, Is.Not.Null);
+      Assert.That(section.HashingService.Name, Is.EqualTo("sha1"));
+      Assert.That(section.AuthenticationService.Name, Is.Not.Null);
+      Assert.That(section.AuthenticationService.Name, Is.EqualTo("notdefault"));
+
+      var config = SecurityConfiguration.Load(Configuration, "Xtensive.Orm.Security.AllDeclared");
+      Assert.That(config, Is.Not.Null);
+      Assert.That(config.HashingServiceName, Is.EqualTo("sha1"));
+      Assert.That(config.AuthenticationServiceName, Is.EqualTo("notdefault"));
+    }
+
+    [Test]
     public void HashingServiceEmptyTest()
     {
-      var section = (Configuration.ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security.WithoutName");
+      var section = (ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security.WithoutName");
       Assert.That(section, Is.Not.Null);
       Assert.That(section.HashingService, Is.Not.Null);
       Assert.That(section.HashingService.Name, Is.Null.Or.Empty);
@@ -44,7 +61,7 @@ namespace Xtensive.Orm.Security.Tests
     [Test]
     public void HashingServiceAbsentTest()
     {
-      var section = (Configuration.ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security.Empty");
+      var section = (ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security.Empty");
       Assert.That(section, Is.Not.Null);
       Assert.That(section.HashingService, Is.Not.Null);
       Assert.That(section.HashingService.Name, Is.Null.Or.Empty);
@@ -57,7 +74,7 @@ namespace Xtensive.Orm.Security.Tests
     [Test]
     public void HashingServiceNoConfigTest()
     {
-      var section = (Configuration.ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security.XXX");
+      var section = (ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security.XXX");
       Assert.That(section, Is.Null);
 
       var config = SecurityConfiguration.Load(Configuration, "Xtensive.Orm.Security.XXX");
@@ -68,7 +85,7 @@ namespace Xtensive.Orm.Security.Tests
     [Test]
     public void HashingServiceDefaultTest()
     {
-      var section = (Configuration.ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security");
+      var section = (ConfigurationSection) Configuration.GetSection("Xtensive.Orm.Security");
       Assert.That(section, Is.Not.Null);
       Assert.That(section.HashingService, Is.Not.Null);
       Assert.That(section.HashingService.Name, Is.Not.Null.Or.Empty);

--- a/Extensions/Xtensive.Orm.Security.Tests/Tests/MicrosoftConfigurationTests.cs
+++ b/Extensions/Xtensive.Orm.Security.Tests/Tests/MicrosoftConfigurationTests.cs
@@ -8,7 +8,7 @@ using Xtensive.Orm.Security.Configuration;
 
 namespace Xtensive.Orm.Security.Tests.Configuration
 {
-  public sealed class JsonConfigurationTests : ModernConfigurationTests
+  public sealed class JsonConfigurationTests : MicrosoftConfigurationTests
   {
     protected override ConfigTypes ConfigFormat => ConfigTypes.Json;
 
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Security.Tests.Configuration
     }
   }
 
-  public sealed class XmlConfigurationTests : ModernConfigurationTests
+  public sealed class XmlConfigurationTests : MicrosoftConfigurationTests
   {
     protected override ConfigTypes ConfigFormat => ConfigTypes.Xml;
 
@@ -123,7 +123,7 @@ namespace Xtensive.Orm.Security.Tests.Configuration
 
 
   [TestFixture]
-  public abstract class ModernConfigurationTests : TestCommon.ModernConfigurationTestBase
+  public abstract class MicrosoftConfigurationTests : TestCommon.MicrosoftConfigurationTestBase
   {
     protected SecurityConfiguration LoadConfiguration(string sectionName, bool useRoot)
     {

--- a/Extensions/Xtensive.Orm.Security.Tests/Tests/ModernConfigurationTests.cs
+++ b/Extensions/Xtensive.Orm.Security.Tests/Tests/ModernConfigurationTests.cs
@@ -389,7 +389,7 @@ namespace Xtensive.Orm.Security.Tests.Configuration
     [Test]
     public void NameNodeInLowCase()
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.LC");
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.LC");
       var secConfig = SecurityConfiguration.Load(section);
       ValidateNamingConfigurationResults(secConfig);
     }
@@ -397,7 +397,7 @@ namespace Xtensive.Orm.Security.Tests.Configuration
     [Test]
     public void NameNodeInUpperCase()
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.UC");
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.UC");
       var secConfig = SecurityConfiguration.Load(section);
       ValidateNamingConfigurationResults(secConfig);
     }
@@ -405,7 +405,7 @@ namespace Xtensive.Orm.Security.Tests.Configuration
     [Test]
     public void NameNodeInCamelCase()
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.CC");
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.CC");
       var secConfig = SecurityConfiguration.Load(section);
       ValidateNamingConfigurationResults(secConfig);
     }
@@ -413,7 +413,7 @@ namespace Xtensive.Orm.Security.Tests.Configuration
     [Test]
     public void NameNodeInPascalCase()
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.PC");
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.PC");
       var secConfig = SecurityConfiguration.Load(section);
       ValidateNamingConfigurationResults(secConfig);
     }

--- a/Extensions/Xtensive.Orm.Security.Tests/Tests/ModernConfigurationTests.cs
+++ b/Extensions/Xtensive.Orm.Security.Tests/Tests/ModernConfigurationTests.cs
@@ -28,84 +28,93 @@ namespace Xtensive.Orm.Security.Tests.Configuration
     }
 
     [Test]
-    public void NameAttributeEmptyNamesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeEmptyNamesTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.NamesEmpty");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration("Xtensive.Orm.Security.NameAttribute.NamesEmpty", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void NameAttributeEmptyAndNonExistentNameTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeEmptyAndNonExistentNameTest1(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.NameExistPartially1");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration("Xtensive.Orm.Security.NameAttribute.NameExistPartially1", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void NameAttributeEmptyAndNonExistentNameTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeEmptyAndNonExistentNameTest2(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.NameExistPartially2");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration("Xtensive.Orm.Security.NameAttribute.NameExistPartially2", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void NameAttributeAllNamesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeAllNamesTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.AllNames");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration("Xtensive.Orm.Security.NameAttribute.AllNames", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
     }
 
     [Test]
-    public void NameAttributeOnlyHashingServiceTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeOnlyHashingServiceTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.OnlyHashing");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration("Xtensive.Orm.Security.NameAttribute.OnlyHashing", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void NameAttributeOnlyAuthServiceTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeOnlyAuthServiceTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.OnlyAuth");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration("Xtensive.Orm.Security.NameAttribute.OnlyAuth", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("plain"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
     }
 
     [Test]
-    public void NameAttributeLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeLowCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.LC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration("Xtensive.Orm.Security.NameAttribute.LC", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
     }
 
     [Test]
-    public void NameAttributeUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributeUpperCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.UC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration("Xtensive.Orm.Security.NameAttribute.UC", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
     }
 
     [Test]
-    public void NameAttributePascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameAttributePascalCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.PC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration("Xtensive.Orm.Security.NameAttribute.PC", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
@@ -116,129 +125,150 @@ namespace Xtensive.Orm.Security.Tests.Configuration
   [TestFixture]
   public abstract class ModernConfigurationTests : TestCommon.ModernConfigurationTestBase
   {
-    [Test]
-    public void EmptySectionCase()
+    protected SecurityConfiguration LoadConfiguration(string sectionName, bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Empty");
-      var secConfig = SecurityConfiguration.Load(section);
+      return useRoot
+        ? SecurityConfiguration.Load(configurationRoot, sectionName)
+        : SecurityConfiguration.Load(configurationRoot.GetSection(sectionName));
+    }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptySectionCaseTest(bool useRoot)
+    {
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.Empty", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void EmptyNames()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EmptyNamesTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.AllEmpty");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.AllEmpty", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void OnlyHashingServiceEmpty()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceEmptyTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Empty");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Empty", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void OnlyHashingServiceMd5()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceMd5Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Md5");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Md5", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("md5"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyHashingServiceSha1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceSha1Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha1");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha1", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyHashingServiceSha256()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceSha256Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha256");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha256", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha256"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyHashingServiceSha384()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceSha384Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha384");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha384", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha384"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyHashingServiceSha512()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceSha512Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha512");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha512", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha512"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyAuthenticationServiceEmptyName()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyAuthenticationServiceEmptyNameTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyAuth.Empty");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.OnlyAuth.Empty", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void OnlyAuthenticationServiceNotDefault()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyAuthenticationServiceNotDefaultTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyAuth");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.OnlyAuth", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("plain"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
     }
 
-
     #region Naming
+
     [Test]
-    public void NamingInLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInLowCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Naming.LC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.Naming.LC", useRoot);
       ValidateNamingConfigurationResults(secConfig);
     }
 
     [Test]
-    public void NamingInUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInUpperCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Naming.UC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.Naming.UC", useRoot);
       ValidateNamingConfigurationResults(secConfig);
     }
 
     [Test]
-    public void NamingInCamelCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInCamelCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Naming.CC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.Naming.CC", useRoot);
       ValidateNamingConfigurationResults(secConfig);
     }
 
     [Test]
-    public void NamingInPascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingInPascalCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Naming.PC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.Naming.PC", useRoot);
       ValidateNamingConfigurationResults(secConfig);
     }
 
@@ -248,38 +278,44 @@ namespace Xtensive.Orm.Security.Tests.Configuration
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
     }
+
     #endregion
 
     #region mistype cases
+
     [Test]
-    public void MistypeInLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInLowCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.LC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.LC", useRoot);
       ValidateMistypeConfigurationResults(secConfig);
     }
 
     [Test]
-    public void MistypeInUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInUpperCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.UC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.UC", useRoot);
       ValidateMistypeConfigurationResults(secConfig);
     }
 
     [Test]
-    public void MistypeInCamelCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInCamelCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.CC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.CC", useRoot);
       ValidateMistypeConfigurationResults(secConfig);
     }
 
     [Test]
-    public void MistypeInPascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MistypeInPascalCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.PC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.PC", useRoot);
       ValidateMistypeConfigurationResults(secConfig);
     }
 
@@ -290,131 +326,145 @@ namespace Xtensive.Orm.Security.Tests.Configuration
 
     #endregion
 
-    #region Name as node 
+    #region Name as node
 
     [Test]
-    public void NoNameNodes()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NoNameNodesTest(bool useRoot)
     {
       IgnoreIfXml();
 
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.Json.NameNode.AllEmpty");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.Json.NameNode.AllEmpty", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void NameNodesAreEmpty()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodesAreEmptyTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.Json.NameNode.NamesEmpty");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.Json.NameNode.NamesEmpty", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void OnlyHashingServiceNameIsEmpty()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceNameIsEmptyTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Empty");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Empty", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void OnlyHashingServiceWithNameNodeMd5()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceWithNameNodeMd5Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Md5");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Md5", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("md5"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyHashingServiceWithNameNodeSha1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceWithNameNodeSha1Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha1");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha1", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyHashingServiceWithNameNodeSha256()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceWithNameNodeSha256Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha256");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha256", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha256"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyHashingServiceWithNameNodeSha384()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceWithNameNodeSha384Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha384");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha384", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha384"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyHashingServiceWithNameNodeSha512()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyHashingServiceWithNameNodeSha512Test(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha512");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha512", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha512"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
     }
 
     [Test]
-    public void OnlyAuthenticationServiceWithNameNodeEmptyName()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyAuthenticationServiceWithNameNodeEmptyNameTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyAuth.Empty");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyAuth.Empty", useRoot);
       CheckConfigurationIsDefault(secConfig);
     }
 
     [Test]
-    public void OnlyAuthenticationServiceWithNameNodeNotDefault()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OnlyAuthenticationServiceWithNameNodeNotDefaultTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyAuth");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyAuth", useRoot);
       Assert.That(secConfig, Is.Not.Null);
       Assert.That(secConfig.HashingServiceName, Is.EqualTo("plain"));
       Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
     }
 
     [Test]
-    public void NameNodeInLowCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodeInLowCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.LC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.LC", useRoot);
       ValidateNamingConfigurationResults(secConfig);
     }
 
     [Test]
-    public void NameNodeInUpperCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodeInUpperCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.UC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.UC", useRoot);
       ValidateNamingConfigurationResults(secConfig);
     }
 
     [Test]
-    public void NameNodeInCamelCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodeInCamelCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.CC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.CC", useRoot);
       ValidateNamingConfigurationResults(secConfig);
     }
 
     [Test]
-    public void NameNodeInPascalCase()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NameNodeInPascalCaseTest(bool useRoot)
     {
-      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.PC");
-      var secConfig = SecurityConfiguration.Load(section);
+      var secConfig = LoadConfiguration($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.Naming.PC", useRoot);
       ValidateNamingConfigurationResults(secConfig);
     }
 

--- a/Extensions/Xtensive.Orm.Security.Tests/Tests/ModernConfigurationTests.cs
+++ b/Extensions/Xtensive.Orm.Security.Tests/Tests/ModernConfigurationTests.cs
@@ -1,0 +1,430 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using NUnit.Framework;
+using Microsoft.Extensions.Configuration;
+using Xtensive.Orm.Security.Configuration;
+
+namespace Xtensive.Orm.Security.Tests.Configuration
+{
+  public sealed class JsonConfigurationTests : ModernConfigurationTests
+  {
+    protected override ConfigTypes ConfigFormat => ConfigTypes.Json;
+
+    protected override void AddConfigurationFile(IConfigurationBuilder configurationBuilder)
+    {
+      _ = configurationBuilder.AddJsonFile("securitysettings.json");
+    }
+  }
+
+  public sealed class XmlConfigurationTests : ModernConfigurationTests
+  {
+    protected override ConfigTypes ConfigFormat => ConfigTypes.Xml;
+
+    protected override void AddConfigurationFile(IConfigurationBuilder configurationBuilder)
+    {
+      _ = configurationBuilder.AddXmlFile("SecuritySettings.config");
+    }
+
+    [Test]
+    public void NameAttributeEmptyNamesTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.NamesEmpty");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void NameAttributeEmptyAndNonExistentNameTest1()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.NameExistPartially1");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void NameAttributeEmptyAndNonExistentNameTest2()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.NameExistPartially2");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void NameAttributeAllNamesTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.AllNames");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
+    }
+
+    [Test]
+    public void NameAttributeOnlyHashingServiceTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.OnlyHashing");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void NameAttributeOnlyAuthServiceTest()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.OnlyAuth");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("plain"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
+    }
+
+    [Test]
+    public void NameAttributeLowCase()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.LC");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
+    }
+
+    [Test]
+    public void NameAttributeUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.UC");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
+    }
+
+    [Test]
+    public void NameAttributePascalCase()
+    {
+      var section = GetAndCheckConfigurationSection("Xtensive.Orm.Security.NameAttribute.PC");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
+    }
+  }
+
+
+  [TestFixture]
+  public abstract class ModernConfigurationTests : TestCommon.ModernConfigurationTestBase
+  {
+    [Test]
+    public void EmptySectionCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Empty");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void EmptyNames()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.AllEmpty");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void OnlyHashingServiceEmpty()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Empty");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void OnlyHashingServiceMd5()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Md5");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("md5"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyHashingServiceSha1()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha1");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyHashingServiceSha256()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha256");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha256"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyHashingServiceSha384()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha384");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha384"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyHashingServiceSha512()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyHashing.Sha512");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha512"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyAuthenticationServiceEmptyName()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyAuth.Empty");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void OnlyAuthenticationServiceNotDefault()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.OnlyAuth");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("plain"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
+    }
+
+
+    #region Naming
+    [Test]
+    public void NamingInLowCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Naming.LC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateNamingConfigurationResults(secConfig);
+    }
+
+    [Test]
+    public void NamingInUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Naming.UC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateNamingConfigurationResults(secConfig);
+    }
+
+    [Test]
+    public void NamingInCamelCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Naming.CC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateNamingConfigurationResults(secConfig);
+    }
+
+    [Test]
+    public void NamingInPascalCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Naming.PC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateNamingConfigurationResults(secConfig);
+    }
+
+    private static void ValidateNamingConfigurationResults(SecurityConfiguration secConfig)
+    {
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
+    }
+    #endregion
+
+    #region mistype cases
+    [Test]
+    public void MistypeInLowCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.LC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(secConfig);
+    }
+
+    [Test]
+    public void MistypeInUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.UC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(secConfig);
+    }
+
+    [Test]
+    public void MistypeInCamelCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.CC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(secConfig);
+    }
+
+    [Test]
+    public void MistypeInPascalCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.Mistype.PC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateMistypeConfigurationResults(secConfig);
+    }
+
+    private static void ValidateMistypeConfigurationResults(SecurityConfiguration secConfig)
+    {
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    #endregion
+
+    #region Name as node 
+
+    [Test]
+    public void NoNameNodes()
+    {
+      IgnoreIfXml();
+
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.Json.NameNode.AllEmpty");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void NameNodesAreEmpty()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.Json.NameNode.NamesEmpty");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void OnlyHashingServiceNameIsEmpty()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Empty");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void OnlyHashingServiceWithNameNodeMd5()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Md5");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("md5"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyHashingServiceWithNameNodeSha1()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha1");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha1"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyHashingServiceWithNameNodeSha256()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha256");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha256"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyHashingServiceWithNameNodeSha384()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha384");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha384"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyHashingServiceWithNameNodeSha512()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyHashing.Sha512");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("sha512"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+
+    [Test]
+    public void OnlyAuthenticationServiceWithNameNodeEmptyName()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyAuth.Empty");
+      var secConfig = SecurityConfiguration.Load(section);
+      CheckConfigurationIsDefault(secConfig);
+    }
+
+    [Test]
+    public void OnlyAuthenticationServiceWithNameNodeNotDefault()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Security.{ConfigFormat}.NameNode.OnlyAuth");
+      var secConfig = SecurityConfiguration.Load(section);
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("plain"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("notdefault"));
+    }
+
+    [Test]
+    public void NameNodeInLowCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.LC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateNamingConfigurationResults(secConfig);
+    }
+
+    [Test]
+    public void NameNodeInUpperCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.UC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateNamingConfigurationResults(secConfig);
+    }
+
+    [Test]
+    public void NameNodeInCamelCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.CC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateNamingConfigurationResults(secConfig);
+    }
+
+    [Test]
+    public void NameNodeInPascalCase()
+    {
+      var section = GetAndCheckConfigurationSection($"Xtensive.Orm.Localization.{ConfigFormat}.NameNode.Naming.PC");
+      var secConfig = SecurityConfiguration.Load(section);
+      ValidateNamingConfigurationResults(secConfig);
+    }
+
+    #endregion
+
+    protected static void CheckConfigurationIsDefault(SecurityConfiguration secConfig)
+    {
+      Assert.That(secConfig, Is.Not.Null);
+      Assert.That(secConfig.HashingServiceName, Is.EqualTo("plain"));
+      Assert.That(secConfig.AuthenticationServiceName, Is.EqualTo("default"));
+    }
+  }
+}

--- a/Extensions/Xtensive.Orm.Security.Tests/Xtensive.Orm.Security.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Security.Tests/Xtensive.Orm.Security.Tests.csproj
@@ -8,16 +8,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Extensions/Xtensive.Orm.Security.Tests/Xtensive.Orm.Security.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Security.Tests/Xtensive.Orm.Security.Tests.csproj
@@ -9,6 +9,16 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />
     <ProjectReference Include="..\TestCommon\TestCommon.csproj" />
@@ -19,5 +29,13 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="SecuritySettings.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="securitysettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Extensions/Xtensive.Orm.Security.Tests/Xtensive.Orm.Security.Tests.csproj
+++ b/Extensions/Xtensive.Orm.Security.Tests/Xtensive.Orm.Security.Tests.csproj
@@ -10,11 +10,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Extensions/Xtensive.Orm.Security.Tests/securitysettings.json
+++ b/Extensions/Xtensive.Orm.Security.Tests/securitysettings.json
@@ -1,0 +1,147 @@
+{
+  "Xtensive.Orm.Security.Json.Empty": {
+
+  },
+
+  "Xtensive.Orm.Security.Json.AllEmpty": {
+    "HashingService": "",
+    "AuthenticationService": ""
+  },
+
+  "Xtensive.Orm.Security.Json.OnlyHashing.Sha1": {
+    "HashingService": "sha1"
+  },
+  "Xtensive.Orm.Security.Json.OnlyHashing.Sha256": {
+    "HashingService": "sha256"
+  },
+  "Xtensive.Orm.Security.Json.OnlyHashing.Sha384": {
+    "HashingService": "sha384"
+  },
+  "Xtensive.Orm.Security.Json.OnlyHashing.Sha512": {
+    "HashingService": "sha512"
+  },
+  "Xtensive.Orm.Security.Json.OnlyHashing.Md5": {
+    "HashingService": "md5"
+  },
+  "Xtensive.Orm.Security.Json.OnlyHashing.Empty": {
+    "HashingService": ""
+  },
+
+  "Xtensive.Orm.Security.Json.OnlyAuth": {
+    "AuthenticationService": "NotDefault"
+  },
+  "Xtensive.Orm.Security.Json.OnlyAuth.Empty": {
+    "AuthenticationService": ""
+  },
+
+  "Xtensive.Orm.Security.Json.Naming.LC": {
+    "hashingservice": "sha1",
+    "authenticationservice": "NotDefault"
+  },
+  "Xtensive.Orm.Security.Json.Naming.UC": {
+    "HASHINGSERVICE": "sha1",
+    "AUTHENTICATIONSERVICE": "NotDefault"
+  },
+  "Xtensive.Orm.Security.Json.Naming.CC": {
+    "hashingService": "sha1",
+    "authenticationService": "NotDefault"
+  },
+  "Xtensive.Orm.Security.Json.Naming.PC": {
+    "HashingService": "sha1",
+    "AuthenticationService": "NotDefault"
+  },
+
+  "Xtensive.Orm.Security.Json.Mistype.LC": {
+    "hashiingservice": "sha1",
+    "authentticationservice": "NotDefault"
+  },
+  "Xtensive.Orm.Security.Json.Mistype.UC": {
+    "HASHIINGSERVICE": "sha1",
+    "AUTHENTTICATIONSERVICE": "NotDefault"
+  },
+  "Xtensive.Orm.Security.Json.Mistype.CC": {
+    "hashiingService": "sha1",
+    "authentticationService": "NotDefault"
+  },
+  "Xtensive.Orm.Security.Json.Mistype.PC": {
+    "HashiingSeervice": "sha1",
+    "AuthentticationService": "NotDefault"
+  },
+
+
+  "Xtensive.Orm.Security.Json.NameNode.AllEmpty": {
+    "HashingService": {
+    },
+    "AuthenticationService": {
+    }
+  },
+
+  "Xtensive.Orm.Security.Json.NameNode.NamesEmpty": {
+    "HashingService": {
+      "Name": ""
+    },
+    "AuthenticationService": {
+      "Name": ""
+    }
+  },
+
+  "Xtensive.Orm.Security.Json.NameNode.OnlyHashing.Sha1": {
+    "HashingService": {
+      "Name": "sha1"
+    }
+  },
+  "Xtensive.Orm.Security.Json.NameNode.OnlyHashing.Sha256": {
+    "HashingService": {
+      "Name": "sha256"
+    }
+  },
+  "Xtensive.Orm.Security.Json.NameNode.OnlyHashing.Sha384": {
+    "HashingService": {
+      "Name": "sha384"
+    }
+  },
+  "Xtensive.Orm.Security.Json.NameNode.OnlyHashing.Sha512": {
+    "HashingService": {
+      "Name": "sha512"
+    }
+  },
+  "Xtensive.Orm.Security.Json.NameNode.OnlyHashing.Md5": {
+    "HashingService": {
+      "Name": "md5"
+    }
+  },
+  "Xtensive.Orm.Security.Json.NameNode.OnlyHashing.Empty": {
+    "HashingService": {
+      "Name": ""
+    }
+  },
+
+  "Xtensive.Orm.Security.Json.NameNode.OnlyAuth": {
+    "AuthenticationService": {
+      "Name": "NotDefault"
+    }
+  },
+  "Xtensive.Orm.Security.Json.NameNode.OnlyAuth.Empty": {
+    "AuthenticationService": {
+      "Name": ""
+    }
+  },
+
+
+  "Xtensive.Orm.Security.Json.NameNode.Naming.LC": {
+    "HashingService": { "name": "sha1" },
+    "AuthenticationService": { "name": "NotDefault" }
+  },
+  "Xtensive.Orm.Security.Json.NameNode.Naming.UC": {
+    "HashingService": { "NAME": "sha1" },
+    "AuthenticationService": { "NAME": "NotDefault" }
+  },
+  "Xtensive.Orm.Security.Json.NameNode.Naming.CC": {
+    "HashingService": { "naMe": "sha1" },
+    "AuthenticationService": { "naMe": "NotDefault" }
+  },
+  "Xtensive.Orm.Security.Json.NameNode.Naming.PC": {
+    "HashingService": { "NaMe": "sha1" },
+    "AuthenticationService": { "NaMe": "NotDefault" }
+  }
+}

--- a/Extensions/Xtensive.Orm.Security/Configuration/Elements/ConfigurationSection.cs
+++ b/Extensions/Xtensive.Orm.Security/Configuration/Elements/ConfigurationSection.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011 Xtensive LLC.
+// Copyright (C) 2011-2024 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Dmitri Maximov
@@ -18,31 +18,29 @@ namespace Xtensive.Orm.Security.Configuration
     /// Gets default section name for security configuration.
     /// Value is "Xtensive.Orm.Security".
     /// </summary>
+    [Obsolete("Use SecurityConfiguration.DefaultSectionName instead")]
     public static readonly string DefaultSectionName = "Xtensive.Orm.Security";
-
-    private const string HashingServiceElementName = "hashingService";
-    private const string AuthenticationServiceElementName = "authenticationService";
 
     /// <summary>
     /// Gets or sets the hashing service.
     /// </summary>
     /// <value>The hashing service.</value>
-    [ConfigurationProperty(HashingServiceElementName, IsRequired = false)]
+    [ConfigurationProperty(SecurityConfiguration.HashingServiceElementName, IsRequired = false)]
     public HashingServiceConfigurationElement HashingService
     {
-      get { return (HashingServiceConfigurationElement) this[HashingServiceElementName]; }
-      set { this[HashingServiceElementName] = value; }
+      get { return (HashingServiceConfigurationElement) this[SecurityConfiguration.HashingServiceElementName]; }
+      set { this[SecurityConfiguration.HashingServiceElementName] = value; }
     }
 
     /// <summary>
     /// Gets or sets the authentication service.
     /// </summary>
     /// <value>The authentication service.</value>
-    [ConfigurationProperty(AuthenticationServiceElementName, IsRequired = false)]
+    [ConfigurationProperty(SecurityConfiguration.AuthenticationServiceElementName, IsRequired = false)]
     public AuthenticationServiceConfigurationElement AuthenticationService
     {
-      get { return (AuthenticationServiceConfigurationElement) this[AuthenticationServiceElementName]; }
-      set { this[AuthenticationServiceElementName] = value; }
+      get { return (AuthenticationServiceConfigurationElement) this[SecurityConfiguration.AuthenticationServiceElementName]; }
+      set { this[SecurityConfiguration.AuthenticationServiceElementName] = value; }
     }
   }
 }

--- a/Extensions/Xtensive.Orm.Security/Configuration/Elements/ConfigurationSection.cs
+++ b/Extensions/Xtensive.Orm.Security/Configuration/Elements/ConfigurationSection.cs
@@ -21,26 +21,29 @@ namespace Xtensive.Orm.Security.Configuration
     [Obsolete("Use SecurityConfiguration.DefaultSectionName instead")]
     public static readonly string DefaultSectionName = "Xtensive.Orm.Security";
 
+    private const string HashingServiceElementName = "hashingService";
+    private const string AuthenticationServiceElementName = "authenticationService";
+
     /// <summary>
     /// Gets or sets the hashing service.
     /// </summary>
     /// <value>The hashing service.</value>
-    [ConfigurationProperty(SecurityConfiguration.HashingServiceElementName, IsRequired = false)]
+    [ConfigurationProperty(HashingServiceElementName, IsRequired = false)]
     public HashingServiceConfigurationElement HashingService
     {
-      get { return (HashingServiceConfigurationElement) this[SecurityConfiguration.HashingServiceElementName]; }
-      set { this[SecurityConfiguration.HashingServiceElementName] = value; }
+      get { return (HashingServiceConfigurationElement) this[HashingServiceElementName]; }
+      set { this[HashingServiceElementName] = value; }
     }
 
     /// <summary>
     /// Gets or sets the authentication service.
     /// </summary>
     /// <value>The authentication service.</value>
-    [ConfigurationProperty(SecurityConfiguration.AuthenticationServiceElementName, IsRequired = false)]
+    [ConfigurationProperty(AuthenticationServiceElementName, IsRequired = false)]
     public AuthenticationServiceConfigurationElement AuthenticationService
     {
-      get { return (AuthenticationServiceConfigurationElement) this[SecurityConfiguration.AuthenticationServiceElementName]; }
-      set { this[SecurityConfiguration.AuthenticationServiceElementName] = value; }
+      get { return (AuthenticationServiceConfigurationElement) this[AuthenticationServiceElementName]; }
+      set { this[AuthenticationServiceElementName] = value; }
     }
   }
 }

--- a/Extensions/Xtensive.Orm.Security/Configuration/SecurityConfiguration.cs
+++ b/Extensions/Xtensive.Orm.Security/Configuration/SecurityConfiguration.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2011-2024 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2011.06.10
 
@@ -21,8 +21,7 @@ namespace Xtensive.Orm.Security.Configuration
   public class SecurityConfiguration : ConfigurationBase
   {
     /// <summary>
-    /// Default SectionName value:
-    /// "<see langword="Xtensive.Orm.Security" />".
+    /// Default section in configuration. Used if custom name is not provided.
     /// </summary>
     public const string DefaultSectionName = "Xtensive.Orm.Security";
 
@@ -119,14 +118,16 @@ namespace Xtensive.Orm.Security.Configuration
       var hashingService = configurationSection == null
         ? string.Empty
         : configurationSection.HashingService.Name;
-      if (!string.IsNullOrEmpty(hashingService))
+      if (!string.IsNullOrEmpty(hashingService)) {
         result.HashingServiceName = hashingService.ToLowerInvariant();
+      }
 
       var authenticationService = configurationSection == null
         ? string.Empty
         : configurationSection.AuthenticationService.Name;
-      if (!string.IsNullOrEmpty(authenticationService))
+      if (!string.IsNullOrEmpty(authenticationService)) {
         result.AuthenticationServiceName = authenticationService.ToLowerInvariant();
+      }
 
       return result;
     }
@@ -148,7 +149,7 @@ namespace Xtensive.Orm.Security.Configuration
         return Load(configurationSection);
       }
 
-      throw new NotSupportedException("Type of configuration is not supported");
+      throw new NotSupportedException("Type of configuration is not supported.");
     }
 
 
@@ -163,13 +164,12 @@ namespace Xtensive.Orm.Security.Configuration
       ArgumentValidator.EnsureArgumentNotNull(configurationRoot, nameof(configurationRoot));
 
       var configuration = new NamelessFormatSecurityConfigurationReader().Read(configurationRoot, sectionName ?? DefaultSectionName);
-      if (configuration != null)
+      if (configuration != null) {
         return configuration;
+      }
 
       configuration = new BasedOnNamesFormatSecurityConfigurationReader().Read(configurationRoot, sectionName ?? DefaultSectionName);
-      if (configuration != null)
-        return configuration;
-      return new SecurityConfiguration(true);
+      return configuration ?? new SecurityConfiguration(true);
     }
 
     /// <summary>
@@ -182,13 +182,12 @@ namespace Xtensive.Orm.Security.Configuration
       ArgumentValidator.EnsureArgumentNotNull(configurationSection, nameof(configurationSection));
 
       var configuration = new NamelessFormatSecurityConfigurationReader().Read(configurationSection);
-      if (configuration != null)
+      if (configuration != null) {
         return configuration;
+      }
 
       configuration = new BasedOnNamesFormatSecurityConfigurationReader().Read(configurationSection);
-      if (configuration != null)
-        return configuration;
-      return new SecurityConfiguration(true);
+      return configuration ?? new SecurityConfiguration(true);
     }
 
     /// <summary>

--- a/Extensions/Xtensive.Orm.Security/Configuration/SecurityConfiguration.cs
+++ b/Extensions/Xtensive.Orm.Security/Configuration/SecurityConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011 Xtensive LLC.
+// Copyright (C) 2011-2024 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Dmitri Maximov
@@ -6,6 +6,10 @@
 
 using System;
 using System.Configuration;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Configuration;
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Security.Configuration
 {
@@ -15,23 +19,83 @@ namespace Xtensive.Orm.Security.Configuration
   [Serializable]
   public class SecurityConfiguration
   {
+    #region nested types
+#pragma warning disable CS0661, CS0659 // Type defines operator == or operator != but does not override Object.GetHashCode()
+#if !NET6_0_OR_GREATER
+    /// <summary>
+    /// Represents Json and XML without neither name attributes nor name as child element;
+    /// </summary>
+    private struct SecurityOptions
+    {
+      public string HashingService { get; set; }
+
+      public string AuthenticationService { get; set; }
+
+      public static bool operator ==(SecurityOptions r1, SecurityOptions r2)
+      {
+        return (r1.HashingService, r1.AuthenticationService) == (r2.HashingService, r2.AuthenticationService);
+      }
+
+      public static bool operator !=(SecurityOptions r1, SecurityOptions r2)
+      {
+        return (r1.HashingService, r1.AuthenticationService) != (r2.HashingService, r2.AuthenticationService);
+      }
+
+      public override bool Equals(object obj)
+      {
+        if (obj is null)
+          return false;
+        if (obj is SecurityOptions objRep)
+          return (HashingService, AuthenticationService) == (objRep.HashingService, objRep.AuthenticationService);
+        return false;
+      }
+    }
+
+#endif
+#pragma warning restore CS0661, CS0659 // Type defines operator == or operator != but does not override Object.GetHashCode()
+
+#endregion
+
     /// <summary>
     /// Default SectionName value:
     /// "<see langword="Xtensive.Orm.Security" />".
     /// </summary>
     public const string DefaultSectionName = "Xtensive.Orm.Security";
 
+    internal const string HashingServiceElementName = "HashingService";
+    internal const string AuthenticationServiceElementName = "AuthenticationService";
+
+    private const string DefaultHashingServiceName = "plain";
+    private const string DefaultAuthenticationServiceName = "default";
+    private const string ServiceNameAttributeName = "name";
+
+#if NET6_0_OR_GREATER
     /// <summary>
     /// Gets or sets the name of the hashing service.
     /// </summary>
     /// <value>The name of the hashing service.</value>
-    public string HashingServiceName { get; private set; }
+    [ConfigurationKeyName(HashingServiceElementName)]
+    public string HashingServiceName { get; set; }
 
     /// <summary>
     /// Gets or sets the name of the authentication service.
     /// </summary>
     /// <value>The name of the authentication service.</value>
-    public string AuthenticationServiceName { get; private set; }
+    [ConfigurationKeyName(AuthenticationServiceElementName)]
+    public string AuthenticationServiceName { get; set; }
+#else
+    /// <summary>
+    /// Gets or sets the name of the hashing service.
+    /// </summary>
+    /// <value>The name of the hashing service.</value>
+    public string HashingServiceName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the authentication service.
+    /// </summary>
+    /// <value>The name of the authentication service.</value>
+    public string AuthenticationServiceName { get; set; }
+#endif
 
     /// <summary>
     /// Loads the <see cref="SecurityConfiguration"/>
@@ -79,29 +143,174 @@ namespace Xtensive.Orm.Security.Configuration
     /// <returns>The <see cref="SecurityConfiguration"/>.</returns>
     public static SecurityConfiguration Load(System.Configuration.Configuration configuration, string sectionName)
     {
-      var configurationSection = (ConfigurationSection)configuration.GetSection(sectionName);
+      var configurationSection = (ConfigurationSection) configuration.GetSection(sectionName);
       return GetConfigurationFromSection(configurationSection);
     }
 
     private static SecurityConfiguration GetConfigurationFromSection(ConfigurationSection configurationSection)
     {
-      var result = new SecurityConfiguration();
+      var result = new SecurityConfiguration(true);
 
-      string hashingService = configurationSection==null
-        ? string.Empty 
+      var hashingService = configurationSection == null
+        ? string.Empty
         : configurationSection.HashingService.Name;
-      if (string.IsNullOrEmpty(hashingService))
-        hashingService = "plain";
-      result.HashingServiceName = hashingService.ToLowerInvariant();
+      if (!string.IsNullOrEmpty(hashingService))
+        result.HashingServiceName = hashingService.ToLowerInvariant();
 
-      string authenticationService = configurationSection==null 
-        ? string.Empty 
+      var authenticationService = configurationSection == null
+        ? string.Empty
         : configurationSection.AuthenticationService.Name;
-      if (string.IsNullOrEmpty(authenticationService))
-        authenticationService = "default";
-      result.AuthenticationServiceName = authenticationService.ToLowerInvariant();
+      if (!string.IsNullOrEmpty(authenticationService))
+        result.AuthenticationServiceName = authenticationService.ToLowerInvariant();
 
       return result;
+    }
+
+    /// <summary>
+    /// Loads the <see cref="SecurityConfiguration"/> from given configuration section.
+    /// </summary>
+    /// <param name="configurationSection"><see cref="IConfigurationSection"/> to load from.</param>
+    /// <returns>Loaded configuration or configuration with default settings.</returns>
+    public static SecurityConfiguration Load(IConfigurationSection configurationSection)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(configurationSection, nameof(configurationSection));
+
+      // First attempt is to read modern xml or json
+      if (TryReadConfigurationAsTypeInstance(configurationSection, out var fromModerntStyle))
+        return fromModerntStyle;
+
+      // if failed then try to handle unusual formats or xml with name attribute
+      return TryReadUnusualOrOldFormats(configurationSection, out var fallbackConfiguration)
+        ? fallbackConfiguration
+        : new SecurityConfiguration(true);
+    }
+
+    /// <summary>
+    /// Tries to read configuration of most relevant format where service names declared as child nodes.
+    /// </summary>
+    /// <param name="configuration">A configuration section that contains data to read.</param>
+    /// <param name="securityConfiguration"></param>
+    /// <returns><see landword="true"/> if reading is successful, otherwise <see landword="true"/></returns>
+    private static bool TryReadConfigurationAsTypeInstance(IConfigurationSection configuration, out SecurityConfiguration securityConfiguration)
+    {
+      //  <Xtensive.Orm.Security>
+      //    <hashingService>sha1</hashingService>
+      //    <authenticationService>SomeServiceName</authenticationService>
+      //  </Xtensive.Orm.Security>
+      // or
+      //  "Xtensive.Orm.Security" : {
+      //    "hashingService" :"sha1",
+      //    "authenticationService" : "SomeServiceName"
+      //  }
+
+#if NET6_0_OR_GREATER
+      try {
+
+        var configAsIs = configuration.Get<SecurityConfiguration>();
+        if (configAsIs != null && (configAsIs.AuthenticationServiceName ?? configAsIs.HashingServiceName) != null) {
+          configAsIs.HashingServiceName = string.IsNullOrEmpty(configAsIs.HashingServiceName)
+            ? DefaultHashingServiceName
+            : configAsIs.HashingServiceName.ToLowerInvariant();
+          configAsIs.AuthenticationServiceName = string.IsNullOrEmpty(configAsIs.AuthenticationServiceName)
+            ? DefaultAuthenticationServiceName
+            : (configAsIs.AuthenticationServiceName?.ToLowerInvariant());
+          securityConfiguration = configAsIs;
+          return true;
+        }
+      }
+      catch {
+        securityConfiguration = null;
+        return false;
+      }
+#else
+      try {
+        var securityOptions = configuration.Get<SecurityOptions>();
+        if (securityOptions != default) {
+          securityConfiguration = new SecurityConfiguration(true);
+          if (!string.IsNullOrEmpty(securityOptions.HashingService))
+            securityConfiguration.HashingServiceName = securityOptions.HashingService.ToLowerInvariant();
+          if(!string.IsNullOrEmpty(securityOptions.AuthenticationService))
+            securityConfiguration.AuthenticationServiceName = securityOptions.AuthenticationService.ToLowerInvariant(); ;
+
+          return true;
+        }
+      }
+      catch {
+        securityConfiguration = null;
+        return false;
+      }
+#endif
+      var children = configuration.GetChildren().ToList();
+      if (!children.Any()) {
+        securityConfiguration = new SecurityConfiguration(true);
+        return true;
+      }
+      else {
+        securityConfiguration = null;
+        return false;
+      }
+    }
+
+    /// <summary>
+    /// Tries to read configuration of old format that supported by
+    /// old <see cref="System.Configuration.ConfigurationManager"/>
+    /// or configuration where name of service is element, not attribute.
+    /// </summary>
+    /// <param name="configuration">A configuration section that contains data to read.</param>
+    /// <param name="securityConfiguration">Read configuration or null if reading was not successful.</param>
+    /// <returns><see landword="true"/> if reading is successful, otherwise <see landword="true"/>.</returns>
+    private static bool TryReadUnusualOrOldFormats(IConfigurationSection configuration,
+      out SecurityConfiguration securityConfiguration)
+    {
+      var hashingServiceSection = configuration.GetSection(HashingServiceElementName);
+      var authenticationServiceSection = configuration.GetSection(AuthenticationServiceElementName);
+
+      if (hashingServiceSection == null && authenticationServiceSection == null) {
+        securityConfiguration = null;
+        return false;
+      }
+
+      var hashingServiceName = hashingServiceSection.GetSection(ServiceNameAttributeName)?.Value;
+      if (hashingServiceName == null) {
+        var children = hashingServiceSection.GetChildren().ToList();
+        if (children.Count > 0) {
+          hashingServiceName = children[0].GetSection(ServiceNameAttributeName).Value;
+        }
+      }
+
+      var authenticationServiceName = authenticationServiceSection.GetSection(ServiceNameAttributeName)?.Value;
+      if (authenticationServiceName == null) {
+        var children = authenticationServiceSection.GetChildren().ToList();
+        if (children.Count > 0) {
+          authenticationServiceName = children[0].GetSection(ServiceNameAttributeName).Value;
+        }
+      }
+      if ((hashingServiceName ?? authenticationServiceName) != null) {
+        securityConfiguration = new SecurityConfiguration(true);
+        if (!string.IsNullOrEmpty(hashingServiceName))
+          securityConfiguration.HashingServiceName = hashingServiceName.ToLowerInvariant();
+        if (!string.IsNullOrEmpty(authenticationServiceName))
+          securityConfiguration.AuthenticationServiceName = authenticationServiceName.ToLowerInvariant();
+
+        return true;
+      }
+      securityConfiguration = null;
+      return false;
+    }
+
+    /// <summary>
+    /// Creates instance of <see cref="SecurityConfiguration"/> with no properties initialized.
+    /// </summary>
+    public SecurityConfiguration()
+    {
+    }
+
+    private SecurityConfiguration(bool initWithDefaults)
+    {
+      if (initWithDefaults) {
+        HashingServiceName = DefaultHashingServiceName;
+        AuthenticationServiceName = DefaultAuthenticationServiceName;
+      }
     }
   }
 }

--- a/Extensions/Xtensive.Orm.Security/Configuration/SecurityConfigurationReaders.cs
+++ b/Extensions/Xtensive.Orm.Security/Configuration/SecurityConfigurationReaders.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Xtensive.Orm.Configuration;
+
+namespace Xtensive.Orm.Security.Configuration
+{
+  internal sealed class NamelessFormatSecurityConfigurationReader : SecurityConfigurationReader
+  {
+    protected override SecurityConfiguration ReadInternal(IConfigurationSection configuration)
+    {
+      //  <Xtensive.Orm.Security>
+      //    <hashingService>sha1</hashingService>
+      //    <authenticationService>SomeServiceName</authenticationService>
+      //  </Xtensive.Orm.Security>
+      // or
+      //  "Xtensive.Orm.Security" : {
+      //    "hashingService" :"sha1",
+      //    "authenticationService" : "SomeServiceName"
+      //  }
+
+      try {
+        var configAsIs = configuration.Get<SecurityConfiguration>();
+        if (configAsIs != null && (configAsIs.AuthenticationServiceName ?? configAsIs.HashingServiceName) != null) {
+          configAsIs.HashingServiceName = string.IsNullOrEmpty(configAsIs.HashingServiceName)
+            ? SecurityConfiguration.DefaultHashingServiceName
+            : configAsIs.HashingServiceName.ToLowerInvariant();
+          configAsIs.AuthenticationServiceName = string.IsNullOrEmpty(configAsIs.AuthenticationServiceName)
+            ? SecurityConfiguration.DefaultAuthenticationServiceName
+            : (configAsIs.AuthenticationServiceName?.ToLowerInvariant());
+          return configAsIs;
+        }
+      }
+      catch {
+        return null;
+      }
+
+      var children = configuration.GetChildren().ToList();
+      if (!children.Any()) {
+        return new SecurityConfiguration(true);
+      }
+      else {
+        return null;
+      }
+    }
+  }
+
+  internal sealed class BasedOnNamesFormatSecurityConfigurationReader : SecurityConfigurationReader
+  {
+    private const string ServiceNameAttributeName = "name";
+
+    protected override SecurityConfiguration ReadInternal(IConfigurationSection configuration)
+    {
+
+      var hashingServiceSection = configuration.GetSection(SecurityConfiguration.HashingServiceElementName);
+      var authenticationServiceSection = configuration.GetSection(SecurityConfiguration.AuthenticationServiceElementName);
+
+      if (hashingServiceSection == null && authenticationServiceSection == null) {
+        return null;
+      }
+
+      var hashingServiceName = hashingServiceSection.GetSection(ServiceNameAttributeName)?.Value;
+      if (hashingServiceName == null) {
+        var children = hashingServiceSection.GetChildren().ToList();
+        if (children.Count > 0) {
+          hashingServiceName = children[0].GetSection(ServiceNameAttributeName).Value;
+        }
+      }
+
+      var authenticationServiceName = authenticationServiceSection.GetSection(ServiceNameAttributeName)?.Value;
+      if (authenticationServiceName == null) {
+        var children = authenticationServiceSection.GetChildren().ToList();
+        if (children.Count > 0) {
+          authenticationServiceName = children[0].GetSection(ServiceNameAttributeName).Value;
+        }
+      }
+      if ((hashingServiceName ?? authenticationServiceName) != null) {
+        var securityConfiguration = new SecurityConfiguration(true);
+        if (!string.IsNullOrEmpty(hashingServiceName))
+          securityConfiguration.HashingServiceName = hashingServiceName.ToLowerInvariant();
+        if (!string.IsNullOrEmpty(authenticationServiceName))
+          securityConfiguration.AuthenticationServiceName = authenticationServiceName.ToLowerInvariant();
+
+        return securityConfiguration;
+      }
+      return null;
+    }
+  }
+
+  internal abstract class SecurityConfigurationReader : IConfigurationSectionReader<SecurityConfiguration>
+  {
+    public SecurityConfiguration Read(IConfigurationSection configurationSection) => ReadInternal(configurationSection);
+
+    public SecurityConfiguration Read(IConfigurationSection configurationSection, string nameOfConfiguration) =>
+      throw new NotSupportedException();
+
+    public SecurityConfiguration Read(IConfigurationRoot configurationRoot) =>
+      Read(configurationRoot, SecurityConfiguration.DefaultSectionName);
+
+    public SecurityConfiguration Read(IConfigurationRoot configurationRoot, string sectionName)
+    {
+      var section = configurationRoot.GetSection(sectionName);
+      return ReadInternal(section);
+    }
+
+    public SecurityConfiguration Read(IConfigurationRoot configurationRoot, string sectionName, string nameOfConfiguration) =>
+      throw new NotSupportedException();
+
+    protected abstract SecurityConfiguration ReadInternal(IConfigurationSection section);
+  }
+}

--- a/Extensions/Xtensive.Orm.Security/Configuration/SecurityConfigurationReaders.cs
+++ b/Extensions/Xtensive.Orm.Security/Configuration/SecurityConfigurationReaders.cs
@@ -1,9 +1,11 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 
 namespace Xtensive.Orm.Security.Configuration
@@ -12,16 +14,6 @@ namespace Xtensive.Orm.Security.Configuration
   {
     protected override SecurityConfiguration ReadInternal(IConfigurationSection configuration)
     {
-      //  <Xtensive.Orm.Security>
-      //    <hashingService>sha1</hashingService>
-      //    <authenticationService>SomeServiceName</authenticationService>
-      //  </Xtensive.Orm.Security>
-      // or
-      //  "Xtensive.Orm.Security" : {
-      //    "hashingService" :"sha1",
-      //    "authenticationService" : "SomeServiceName"
-      //  }
-
       try {
         var configAsIs = configuration.Get<SecurityConfiguration>();
         if (configAsIs != null && (configAsIs.AuthenticationServiceName ?? configAsIs.HashingServiceName) != null) {
@@ -38,13 +30,10 @@ namespace Xtensive.Orm.Security.Configuration
         return null;
       }
 
-      var children = configuration.GetChildren().ToList();
-      if (!children.Any()) {
-        return new SecurityConfiguration(true);
-      }
-      else {
-        return null;
-      }
+      var children = configuration.GetChildren();
+      return !children.Any()
+        ? new SecurityConfiguration(true)
+        : null;
     }
   }
 
@@ -79,10 +68,13 @@ namespace Xtensive.Orm.Security.Configuration
       }
       if ((hashingServiceName ?? authenticationServiceName) != null) {
         var securityConfiguration = new SecurityConfiguration(true);
-        if (!string.IsNullOrEmpty(hashingServiceName))
+        if (!hashingServiceName.IsNullOrEmpty()) {
           securityConfiguration.HashingServiceName = hashingServiceName.ToLowerInvariant();
-        if (!string.IsNullOrEmpty(authenticationServiceName))
+        }
+
+        if (!authenticationServiceName.IsNullOrEmpty()) {
           securityConfiguration.AuthenticationServiceName = authenticationServiceName.ToLowerInvariant();
+        }
 
         return securityConfiguration;
       }

--- a/Extensions/Xtensive.Orm.Security/DomainConfugurationExtensions.cs
+++ b/Extensions/Xtensive.Orm.Security/DomainConfugurationExtensions.cs
@@ -1,0 +1,108 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Security.Configuration;
+
+namespace Xtensive.Orm.Security
+{
+  /// <summary>
+  /// Contains extensions for DomainConfiguration that help to configure the extension.
+  /// </summary>
+  public static class DomainConfugurationSecurityExtensions
+  {
+    /// <summary>
+    /// Loads configuration by calling <see cref="SecurityConfiguration.Load()"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureSecurityExtension(this DomainConfiguration domainConfiguration) =>
+      ConfigureSecurityExtension(domainConfiguration, SecurityConfiguration.Load());
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="SecurityConfiguration.Load(string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationSectionName">Section name.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureSecurityExtension(this DomainConfiguration domainConfiguration,
+        string configurationSectionName) =>
+      ConfigureSecurityExtension(domainConfiguration, SecurityConfiguration.Load(configurationSectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="SecurityConfiguration.Load(System.Configuration.Configuration)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuraton to load from.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureSecurityExtension(this DomainConfiguration domainConfiguration,
+        System.Configuration.Configuration configuration) =>
+      ConfigureSecurityExtension(domainConfiguration, SecurityConfiguration.Load(configuration));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="SecurityConfiguration.Load(System.Configuration.Configuration)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuraton to load from.</param>
+    /// <param name="sectionName">Section in <paramref name="configuration"/></param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureSecurityExtension(this DomainConfiguration domainConfiguration,
+        System.Configuration.Configuration configuration, string sectionName) =>
+      ConfigureSecurityExtension(domainConfiguration, SecurityConfiguration.Load(configuration, sectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="SecurityConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configuration">Configuraton to load from.</param>
+    /// <param name="sectionName">Section in <paramref name="configuration"/></param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureSecurityExtension(this DomainConfiguration domainConfiguration,
+        IConfiguration configuration, string sectionName = null) =>
+      ConfigureSecurityExtension(domainConfiguration, SecurityConfiguration.Load(configuration, sectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="SecurityConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationRoot">Configuraton to load from.</param>
+    /// <param name="sectionName">Section in <paramref name="configurationRoot"/></param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureSecurityExtension(this DomainConfiguration domainConfiguration,
+        IConfigurationRoot configurationRoot, string sectionName = null) =>
+      ConfigureSecurityExtension(domainConfiguration, SecurityConfiguration.Load(configurationRoot, sectionName));
+
+    /// <summary>
+    /// Loads configuration by calling <see cref="SecurityConfiguration.Load(IConfigurationRoot, string)"/>
+    /// and uses it to configure the extension.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="configurationSection">Configuration section to load from.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureSecurityExtension(this DomainConfiguration domainConfiguration,
+        IConfigurationSection configurationSection) =>
+      ConfigureSecurityExtension(domainConfiguration, SecurityConfiguration.Load(configurationSection));
+
+    /// <summary>
+    /// Configures the extension with given security configuration instance.
+    /// </summary>
+    /// <param name="domainConfiguration">Domain configuration.</param>
+    /// <param name="securityConfiguration">Security configuration instance.</param>
+    /// <returns><paramref name="domainConfiguration"/> instance with configured extension.</returns>
+    public static DomainConfiguration ConfigureSecurityExtension(this DomainConfiguration domainConfiguration,
+      SecurityConfiguration securityConfiguration)
+    {
+      domainConfiguration.ExtensionConfigurations.Set(securityConfiguration);
+      domainConfiguration.Types.Register(typeof(DomainConfugurationSecurityExtensions).Assembly);
+      return domainConfiguration;
+    }
+  }
+}

--- a/Extensions/Xtensive.Orm.Security/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Security/NugetContent/ReadMe.md
@@ -8,7 +8,7 @@ There are 2 main parts that can also be used separately: authentication services
 
 Prerequisites
 -------------
-DataObjects.Net 7.0.x or later (http://dataobjects.net)
+DataObjects.Net 7.1.x or later (http://dataobjects.net)
 
 How to use
 ----------
@@ -42,6 +42,8 @@ and set up the desired hashing service:
     <!-- other options are: md5, sha1, sha256, sha384, sha512 -->
   </Xtensive.Orm.Security>
 ```
+
+Other examples of how to configure the extension are in section below
 
 Examples
 --------
@@ -311,4 +313,256 @@ customers that have IsAutomobileIndustry property set to true, e.g.:
       transaction.Complete();
     }
   }
+```
+
+
+
+Examples of how to configure extension
+--------------------------------------
+
+Additionally to "How to use" section it provides extra examples of how to configure and/or read extension configuration.
+
+The example in "How to use" section uses old fasioned API of configuration files, yet usable in many applications. But
+there are some cases which may require usage of different API or work-around certain cases with existing one.
+
+**Example #1** Reading old-style configuration of an assembly in NET 5 and newer.
+
+Due to new architecture without AppDomain (which among the other things was in charge of gathering configuration files of loaded assemblies
+as it would be one configuration file) System.Configuration.ConfigurationManager now reads only configuration file of actual executable, loaded 
+assemblies' configuration files stay unreachable by default, though there is need to read some data from them.
+A great example is test projects which are usually get loaded by test runner executable, and the only configuration accessible in this case
+is test runner one.
+
+Extra step is required to read configuration files in such cases. Thankfully ConfigurationManager has methods to get access to assemblies' configurations.
+
+To get access to an assembly configuration file it should be opened explicitly by
+
+```csharp
+  var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
+```
+
+The instance returned from ```OpenExeConfiguration``` provides access to sections of the assembly configuration. DataObjects.Net configurations
+(```DomainConfiguration```, ```SecurityConfiguration```, etc.) have ```Load()``` methods that can recieve this instance.
+```SecurityConfiguration``` can be read like so
+
+```csharp
+  var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
+  var securityConfig = SecurityConfiguration.Load(configuration);
+
+  // loaded configuration should be manually placed to
+  domainConfiguration.ExtensionConfigurations.Set(securityConfig);
+```
+
+The ```domainConfiguration.ExtensionConfigurations``` is a new unified place from which an extension will try to get its configuration
+instead of calling default parameterless ```Load()``` method, which has not a lot of sense now, though the method is kept as a second source
+for backwards compatibility.
+
+For more convenience, DomainConfiguration extensions are provided, which make code more neat and clear.
+For instance,
+
+```csharp
+  var configuration = ConfigurationManager.OpenExeConfiguration(typeof(SomeTypeInConfigOwnerAssembly).Assembly.Location);
+
+  var domainConfiguration = DomainConfiguration.Load(configuration);
+
+  // the extension hides getting configuration with SecurityConfiguration.Load(configuration)
+  // and also putting it to ExtensionConfigurations collection.
+  domainConfiguration.ConfigureSecurityExtension(configuration);
+```
+
+Remember the requirement to register ```Xtensive.Orm.Security``` to domain? The extension tries to register this assembly to ```DomainConfiguration.Types``` collection
+so even if you miss registration but called extension method required types of Security extension will be registered in Domain types.
+
+Custom section names are also supported if for some reason default section name is not used.
+
+
+**Example #3** Reading old-style configuration of an assembly in a project that uses appsettings.json file.
+
+If for some reason there is need to keep the old-style configuration then there is a work-around as well.
+Static configuration manager provides method ```OpenMappedExeConfiguration()``` which allows to get access to
+any *.config file as ```System.Configuration.Configuration``` instance. For example
+
+```csharp
+  ExeConfigurationFileMap configFileMap = new ExeConfigurationFileMap();
+  configFileMap.ExeConfigFilename = "Orm.config"; //or other file name, the file should exist bin folder
+  var configuration = System.Configuration.ConfigurationManager.OpenMappedExeConfiguration(configFileMap, ConfigurationUserLevel.None);
+```
+
+After that, as in previous example, the instance can be passed to ```Load``` method of ```SecurityConfiguration``` to read extension configuration
+and later put it to ```DomainConfiguration.ExtensionConfigurations```.
+After ```System.Configuration.Configuration``` instance is providedit is possible to pass it into Load method of different DataObjects.Net configurations,
+including ```SecurityConfiguration```. Then put security configuration to ```DomainConfiguration.ExtensionConfigurations``` collection.
+
+```csharp
+  var securityConfiguration = SecurityConfiguration.Load(configuration);
+
+  domainConfiguration.ExtensionConfigurations.Set(securityConfiguration);
+```
+
+or to extension method
+
+```csharp
+  domainConfiguration.ConfigureSecurityExtension(configuration);
+```
+
+
+**Example #4** Configure using Microsoft.Extensions.Configuration API.
+
+This API allows to have configurations in various forms including JSON and XML formats.
+Loading of such files may differ depending on .NET version, check Microsoft manuals for instructions.
+
+Allowed JSON and XML configuration definition look like below
+
+```xml
+<configuration>
+  <Xtensive.Orm.Security>
+    <HashingService>sha512</HashingService>
+    <AuthenticationService>CustomAuthenticationService</AuthenticationService>
+  </Xtensive.Orm.Security>
+</configuration>
+```
+
+```json
+{
+  "Xtensive.Orm.Security": {
+    "HashingService" : "sha512",
+    "AuthenticationService" : "CustomAuthenticationService"
+  }
+}
+```
+
+The API has certain issues with Xml elements with attributes so it is recommended to use
+more up-to-date attributeless nodes.
+For JSON it is pretty clear.
+
+```SecurityConfiguration.Load``` method can accept different types of abstractions from the
+API, including
+- ```Microsoft.Extensions.Configuration.IConfiguration```,
+- ```Microsoft.Extensions.Configuration.IConfigurationRoot```
+- ```Microsoft.Extensions.Configuration.IConfigurationSection```.
+
+Loading of configuration may look like
+
+```csharp
+  
+  var app = builder.Build();
+
+  // tries to load from default section "Xtensive.Orm.Security"
+  var securityConfig = SecurityConfiguration.Load(app.Configuration);
+
+  domainConfiguration.ExtensionConfigurations.Set(securityConfig);
+```
+
+or, with use of extension
+
+
+```csharp
+  
+  var app = builder.Build();
+
+  // Tries to load from default section "Xtensive.Orm.Security"
+  // and put it into domainConfiguration.ExtensionConfigurations.
+  // Additionally, registers types of "Xtensive.Orm.Security" assembly.
+
+  domainConfiguration.ConfigureSecurityExtension(app.Configuration);
+```
+
+
+
+**Example #5** Configure using Microsoft.Extensions.Configuration API from section with non-default name.
+
+For configurations like
+
+```xml
+<configuration>
+  <Orm.Security>
+    <HashingService>sha512</HashingService>
+    <AuthenticationService>CustomAuthenticationService</AuthenticationService>
+  </Orm.Security>
+</configuration>
+```
+
+```json
+{
+  "Orm.Security": {
+    "HashingService" : "sha512",
+    "AuthenticationService" : "CustomAuthenticationService"
+  }
+}
+
+Loading of configuration may look like
+
+```csharp
+  
+  var app = builder.Build();
+
+  var securityConfig = SecurityConfiguration.Load(app.Configuration, "Orm.Security");
+
+  domainConfiguration.ExtensionConfigurations.Set(securityConfig);
+```
+
+or with use of extension
+
+```csharp
+  
+  var app = builder.Build();
+
+  domainConfiguration.ConfigureSecurityExtension(app.Configuration, "Orm.Security");
+```
+
+
+**Example #6** Configure using Microsoft.Extensions.Configuration API from sub-section deeper in section tree.
+
+If for some reason extension configuration should be moved deeper in section tree like something below
+
+```xml
+<configuration>
+  <Orm.Extensions>
+    <Xtensive.Orm.Security>
+      <HashingService>sha512</HashingService>
+      <AuthenticationService>CustomAuthenticationService</AuthenticationService>
+    </Xtensive.Orm.Security>
+  </Orm.Extensions>
+</configuration>
+```
+
+or in JSON
+
+```json
+{
+  "Orm.Extensions": {
+    "Xtensive.Orm.Security": {
+      "HashingService" : "sha512",
+      "AuthenticationService" : "CustomAuthenticationService"
+    }
+  }
+}
+```
+
+Then section must be provided manually, code may look like
+
+```csharp
+  
+  var app = builder.Build();
+
+  var configurationRoot = app.Configuration;
+  var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");
+  var securitySection = extensionsGroupSection.GetSection("Xtensive.Orm.Security");
+
+  var securityConfig = SecurityConfiguration.Load(securitySection);
+
+  domainConfiguration.ExtensionConfigurations.Set(securityConfig);
+```
+
+or with use of extension method
+
+```csharp
+  
+  var app = builder.Build();
+
+  var configurationRoot = app.Configuration;
+  var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");
+  var securitySection = extensionsGroupSection.GetSection("Xtensive.Orm.Security");
+
+  domainConfiguration.ConfigureSecurityExtension(securitySection);
 ```

--- a/Extensions/Xtensive.Orm.Security/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Security/NugetContent/ReadMe.md
@@ -328,12 +328,12 @@ there are some cases which may require usage of different API or work-around cer
 **Example #1** Reading old-style configuration of an assembly in NET 5 and newer.
 
 Due to new architecture without AppDomain (which among the other things was in charge of gathering configuration files of loaded assemblies
-as it would be one configuration file) System.Configuration.ConfigurationManager now reads only configuration file of actual executable, loaded 
+as it would be one configuration file) ```System.Configuration.ConfigurationManager``` now reads only configuration file of actual executable, loaded 
 assemblies' configuration files stay unreachable by default, though there is need to read some data from them.
 A great example is test projects which are usually get loaded by test runner executable, and the only configuration accessible in this case
 is test runner one.
 
-Extra step is required to read configuration files in such cases. Thankfully ConfigurationManager has methods to get access to assemblies' configurations.
+Extra step is required to read configuration files in such cases. Thankfully, ```ConfigurationManager``` has methods to get access to assemblies' configurations.
 
 To get access to an assembly configuration file it should be opened explicitly by
 
@@ -353,11 +353,11 @@ The instance returned from ```OpenExeConfiguration``` provides access to section
   domainConfiguration.ExtensionConfigurations.Set(securityConfig);
 ```
 
-The ```domainConfiguration.ExtensionConfigurations``` is a new unified place from which an extension will try to get its configuration
+The ```domainConfiguration.ExtensionConfigurations``` is a new unified place from which the extension will try to get its configuration
 instead of calling default parameterless ```Load()``` method, which has not a lot of sense now, though the method is kept as a second source
 for backwards compatibility.
 
-For more convenience, DomainConfiguration extensions are provided, which make code more neat and clear.
+For more convenience, ```DomainConfiguration``` extensions are provided, which make code more neater.
 For instance,
 
 ```csharp
@@ -376,11 +376,11 @@ so even if you miss registration but called extension method required types of S
 Custom section names are also supported if for some reason default section name is not used.
 
 
-**Example #3** Reading old-style configuration of an assembly in a project that uses appsettings.json file.
+**Example #2** Reading old-style configuration of an assembly in a project that uses appsettings.json file.
 
 If for some reason there is need to keep the old-style configuration then there is a work-around as well.
 Static configuration manager provides method ```OpenMappedExeConfiguration()``` which allows to get access to
-any *.config file as ```System.Configuration.Configuration``` instance. For example
+any *.config file as ```System.Configuration.Configuration``` instance. For example,
 
 ```csharp
   ExeConfigurationFileMap configFileMap = new ExeConfigurationFileMap();
@@ -389,9 +389,7 @@ any *.config file as ```System.Configuration.Configuration``` instance. For exam
 ```
 
 After that, as in previous example, the instance can be passed to ```Load``` method of ```SecurityConfiguration``` to read extension configuration
-and later put it to ```DomainConfiguration.ExtensionConfigurations```.
-After ```System.Configuration.Configuration``` instance is providedit is possible to pass it into Load method of different DataObjects.Net configurations,
-including ```SecurityConfiguration```. Then put security configuration to ```DomainConfiguration.ExtensionConfigurations``` collection.
+and later put it to ```DomainConfiguration.ExtensionConfigurations```
 
 ```csharp
   var securityConfiguration = SecurityConfiguration.Load(configuration);
@@ -399,14 +397,14 @@ including ```SecurityConfiguration```. Then put security configuration to ```Dom
   domainConfiguration.ExtensionConfigurations.Set(securityConfiguration);
 ```
 
-or to extension method
+Extension usage will look like
 
 ```csharp
   domainConfiguration.ConfigureSecurityExtension(configuration);
 ```
 
 
-**Example #4** Configure using Microsoft.Extensions.Configuration API.
+**Example #3** Configure using Microsoft.Extensions.Configuration API.
 
 This API allows to have configurations in various forms including JSON and XML formats.
 Loading of such files may differ depending on .NET version, check Microsoft manuals for instructions.
@@ -431,14 +429,13 @@ Allowed JSON and XML configuration definition look like below
 }
 ```
 
-The API has certain issues with Xml elements with attributes so it is recommended to use
+The API has certain issues with XML elements with attributes so it is recommended to use
 more up-to-date attributeless nodes.
-For JSON it is pretty clear.
+For JSON it is pretty clear, almost averyone knows its format.
 
-```SecurityConfiguration.Load``` method can accept different types of abstractions from the
-API, including
-- ```Microsoft.Extensions.Configuration.IConfiguration```,
-- ```Microsoft.Extensions.Configuration.IConfigurationRoot```
+```SecurityConfiguration.Load``` method can accept different types of abstractions from the API, including
+- ```Microsoft.Extensions.Configuration.IConfiguration```;
+- ```Microsoft.Extensions.Configuration.IConfigurationRoot```;
 - ```Microsoft.Extensions.Configuration.IConfigurationSection```.
 
 Loading of configuration may look like
@@ -447,18 +444,22 @@ Loading of configuration may look like
   
   var app = builder.Build();
 
+  //...
+
   // tries to load from default section "Xtensive.Orm.Security"
   var securityConfig = SecurityConfiguration.Load(app.Configuration);
 
   domainConfiguration.ExtensionConfigurations.Set(securityConfig);
 ```
 
-or, with use of extension
+or, with use of extension, like
 
 
 ```csharp
   
   var app = builder.Build();
+
+  //...
 
   // Tries to load from default section "Xtensive.Orm.Security"
   // and put it into domainConfiguration.ExtensionConfigurations.
@@ -469,7 +470,7 @@ or, with use of extension
 
 
 
-**Example #5** Configure using Microsoft.Extensions.Configuration API from section with non-default name.
+**Example #4** Configure using Microsoft.Extensions.Configuration API from section with non-default name.
 
 For configurations like
 
@@ -493,25 +494,27 @@ For configurations like
 Loading of configuration may look like
 
 ```csharp
-  
   var app = builder.Build();
+
+  //...
 
   var securityConfig = SecurityConfiguration.Load(app.Configuration, "Orm.Security");
 
   domainConfiguration.ExtensionConfigurations.Set(securityConfig);
 ```
 
-or with use of extension
+or, with use of extension, like
 
 ```csharp
-  
   var app = builder.Build();
+
+  //...
 
   domainConfiguration.ConfigureSecurityExtension(app.Configuration, "Orm.Security");
 ```
 
 
-**Example #6** Configure using Microsoft.Extensions.Configuration API from sub-section deeper in section tree.
+**Example #5** Configure using Microsoft.Extensions.Configuration API from sub-section deeper in section tree.
 
 If for some reason extension configuration should be moved deeper in section tree like something below
 
@@ -545,6 +548,8 @@ Then section must be provided manually, code may look like
   
   var app = builder.Build();
 
+  //...
+
   var configurationRoot = app.Configuration;
   var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");
   var securitySection = extensionsGroupSection.GetSection("Xtensive.Orm.Security");
@@ -554,11 +559,13 @@ Then section must be provided manually, code may look like
   domainConfiguration.ExtensionConfigurations.Set(securityConfig);
 ```
 
-or with use of extension method
+or, with use of extension method, like
 
 ```csharp
   
   var app = builder.Build();
+
+  //...
 
   var configurationRoot = app.Configuration;
   var extensionsGroupSection = configurationRoot.GetSection("Orm.Extensions");

--- a/Extensions/Xtensive.Orm.Security/SessionExtensions.cs
+++ b/Extensions/Xtensive.Orm.Security/SessionExtensions.cs
@@ -4,6 +4,7 @@
 // Created by: Dmitri Maximov
 // Created:    2011.05.22
 
+using System;
 using System.Security.Principal;
 using Xtensive.Core;
 using Xtensive.Orm.Security;
@@ -12,6 +13,7 @@ using IPrincipal = Xtensive.Orm.Security.IPrincipal;
 
 namespace Xtensive.Orm
 {
+
   /// <summary>
   /// Session extension methods for security-related stuff.
   /// </summary>
@@ -24,12 +26,16 @@ namespace Xtensive.Orm
     /// <returns><see cref="SecurityConfiguration"/> instance.</returns>
     public static SecurityConfiguration GetSecurityConfiguration(this Session session)
     {
-      var result = session.Domain.Extensions.Get<SecurityConfiguration>();
-      if (result == null) {
-        result = SecurityConfiguration.Load();
-        session.Domain.Extensions.Set(result);
+      var fromNewSource = session.Domain.Configuration.ExtensionConfigurations.Get<SecurityConfiguration>();
+      if (fromNewSource!=null)
+        return fromNewSource;
+      
+      var fromOldSource = session.Domain.Extensions.Get<SecurityConfiguration>();
+      if (fromOldSource == null) {
+        fromOldSource = SecurityConfiguration.Load();
+        session.Domain.Extensions.Set(fromOldSource);
       }
-      return result;
+      return fromOldSource;
     }
 
     /// <summary>

--- a/Extensions/Xtensive.Orm.Security/Xtensive.Orm.Security.csproj
+++ b/Extensions/Xtensive.Orm.Security/Xtensive.Orm.Security.csproj
@@ -18,9 +18,13 @@
   <Import Project="$(SolutionDir)MSBuild\DataObjects.Net.InternalBuild.targets" />
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Orm\Xtensive.Orm\Xtensive.Orm.csproj" />

--- a/Extensions/Xtensive.Orm.Security/Xtensive.Orm.Security.csproj
+++ b/Extensions/Xtensive.Orm.Security/Xtensive.Orm.Security.csproj
@@ -18,8 +18,8 @@
   <Import Project="$(SolutionDir)MSBuild\DataObjects.Net.InternalBuild.targets" />
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />

--- a/Extensions/Xtensive.Orm.Security/Xtensive.Orm.Security.csproj
+++ b/Extensions/Xtensive.Orm.Security/Xtensive.Orm.Security.csproj
@@ -18,11 +18,11 @@
   <Import Project="$(SolutionDir)MSBuild\DataObjects.Net.InternalBuild.targets" />
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>

--- a/Extensions/Xtensive.Orm.Tracking/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Tracking/NugetContent/ReadMe.md
@@ -1,4 +1,4 @@
-﻿Xtensive.Orm.Tracking
+Xtensive.Orm.Tracking
 =====================
 
 Summary
@@ -7,7 +7,7 @@ Provides tracking/auditing funtionality on Session/Domain level.
 
 Prerequisites
 -------------
-DataObjects.Net 7.0.x or later (http://dataobjects.net)
+DataObjects.Net 7.1.x or later (http://dataobjects.net)
 
 Implementation
 --------------

--- a/Extensions/Xtensive.Orm.Web/NugetContent/ReadMe.md
+++ b/Extensions/Xtensive.Orm.Web/NugetContent/ReadMe.md
@@ -1,4 +1,4 @@
-﻿Xtensive.Orm.Web
+Xtensive.Orm.Web
 ================
 
 Summary
@@ -11,7 +11,7 @@ by default unless an exeption appeared. (more info on https://dataobjects.net)
 
 Prerequisites
 -------------
-DataObjects.Net 7 or later (https://dataobjects.net)
+DataObjects.Net 7.1 or later (https://dataobjects.net)
 
 Usage of action filter
 ----------------------

--- a/Orm/Xtensive.Orm.Tests/Configuration/MicrosoftConfigurationTests.cs
+++ b/Orm/Xtensive.Orm.Tests/Configuration/MicrosoftConfigurationTests.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Orm.Tests.Configuration.TypesToUseInTests
 namespace Xtensive.Orm.Tests.Configuration
 {
   [TestFixture]
-  public sealed class AppConfigStyleConfigurationTest : ConfigurationFileTestBase
+  public sealed class AppConfigStyleConfigurationTest : MicrosoftConfigurationTestBase
   {
     protected override string Postfix => "AppConfig";
 
@@ -85,7 +85,7 @@ namespace Xtensive.Orm.Tests.Configuration
   }
 
   [TestFixture]
-  public sealed class XmlConfigurationTest : ConfigurationFileTestBase
+  public sealed class XmlConfigurationTest : MicrosoftConfigurationTestBase
   {
     protected override string Postfix => "Xml";
 
@@ -96,7 +96,7 @@ namespace Xtensive.Orm.Tests.Configuration
   }
 
   [TestFixture]
-  public sealed class JsonConfigurationTest : ConfigurationFileTestBase
+  public sealed class JsonConfigurationTest : MicrosoftConfigurationTestBase
   {
     protected override string Postfix => "Json";
 
@@ -106,13 +106,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
   }
 
-  public abstract class ConfigurationFileTestBase
+  public abstract class MicrosoftConfigurationTestBase
   {
-
     private IConfigurationRoot configuration;
     private IConfigurationSection configurationSection;
 
-    
     protected abstract string Postfix { get; }
     protected virtual bool NameAttributeUnique => true;
 

--- a/Orm/Xtensive.Orm.Tests/Configuration/ModernConfigurationTests.cs
+++ b/Orm/Xtensive.Orm.Tests/Configuration/ModernConfigurationTests.cs
@@ -74,7 +74,6 @@ namespace Xtensive.Orm.Tests.Configuration
   [TestFixture]
   public sealed class AppConfigStyleConfigurationTest : ConfigurationFileTestBase
   {
-    protected override string DefaultSectionName => "Xtensive.Orm.AppConfig";
     protected override string Postfix => "AppConfig";
 
     protected override bool NameAttributeUnique => false;
@@ -88,7 +87,6 @@ namespace Xtensive.Orm.Tests.Configuration
   [TestFixture]
   public sealed class XmlConfigurationTest : ConfigurationFileTestBase
   {
-    protected override string DefaultSectionName => "Xtensive.Orm.Xml";
     protected override string Postfix => "Xml";
 
     protected override void RegisterConfigurationFile(ConfigurationBuilder builder)
@@ -100,7 +98,6 @@ namespace Xtensive.Orm.Tests.Configuration
   [TestFixture]
   public sealed class JsonConfigurationTest : ConfigurationFileTestBase
   {
-    protected override string DefaultSectionName => "Xtensive.Orm.Json";
     protected override string Postfix => "Json";
 
     protected override void RegisterConfigurationFile(ConfigurationBuilder builder)
@@ -115,9 +112,11 @@ namespace Xtensive.Orm.Tests.Configuration
     private IConfigurationRoot configuration;
     private IConfigurationSection configurationSection;
 
-    protected abstract string DefaultSectionName { get; }
+    
     protected abstract string Postfix { get; }
     protected virtual bool NameAttributeUnique => true;
+
+    protected virtual string DefaultSectionName => $"Xtensive.Orm.{Postfix}";
 
     [OneTimeSetUp]
     public void OneTimeSetup()
@@ -136,10 +135,11 @@ namespace Xtensive.Orm.Tests.Configuration
 
     protected abstract void RegisterConfigurationFile(ConfigurationBuilder builder);
 
-    private DomainConfiguration LoadDomainConfiguration(string domainName)
+    private DomainConfiguration LoadDomainConfiguration(string domainName, bool useRoot)
     {
-      var domainConfiguration = DomainConfiguration.Load(configurationSection, domainName);
-      return domainConfiguration;
+      return useRoot
+        ? DomainConfiguration.Load(configuration, DefaultSectionName, domainName)
+        : DomainConfiguration.Load(configurationSection, domainName);
     }
     private LoggingConfiguration LoadLoggingConfiguration(IConfigurationSection customConfigurationSection = null)
     {
@@ -151,9 +151,11 @@ namespace Xtensive.Orm.Tests.Configuration
     #region Simple Domain settings that used to be attributes
 
     [Test]
-    public void ProviderAndConnectionStringTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ProviderAndConnectionStringTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithProviderAndConnectionString");
+      var domainConfig = LoadDomainConfiguration("DomainWithProviderAndConnectionString", useRoot);
       Assert.That(domainConfig.ConnectionInfo.Provider, Is.EqualTo(WellKnown.Provider.Sqlite));
       Assert.That(domainConfig.ConnectionInfo.ConnectionString, Is.EqualTo("Data Source=DO-Testsaaa.db3"));
       Assert.That(domainConfig.ConnectionInfo.ConnectionUrl, Is.Null);
@@ -162,9 +164,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void ConnectionUrlTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ConnectionUrlTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithConnectionUrl");
+      var domainConfig = LoadDomainConfiguration("DomainWithConnectionUrl", useRoot);
       Assert.That(domainConfig.ConnectionInfo.Provider, Is.EqualTo(WellKnown.Provider.Sqlite));
       Assert.That(domainConfig.ConnectionInfo.ConnectionString, Is.Null);
       Assert.That(domainConfig.ConnectionInfo.ConnectionUrl.Url, Is.EqualTo("sqlite:///DO-Tests.db3"));
@@ -173,65 +177,83 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void CustomValidKeyCacheSizeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomValidKeyCacheSizeTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidKeyCacheSize");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidKeyCacheSize", useRoot);
 
       ValidateAllDefaultExcept(domainConfig, ((d) => d.KeyCacheSize, 192));
     }
 
     [Test]
-    public void CustomInvalidKeyCacheSizeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomInvalidKeyCacheSizeTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidKeyCacheSize"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidKeyCacheSize", useRoot));
 
     }
 
     [Test]
-    public void CustomValidKeyGeneratorCacheSizeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomValidKeyGeneratorCacheSizeTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidKeyGeneratorCacheSize");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidKeyGeneratorCacheSize", useRoot);
 
       ValidateAllDefaultExcept(domainConfig, ((d) => d.KeyGeneratorCacheSize, 192));
     }
 
     [Test]
-    public void CustomInvalidKeyGeneratorCacheSizeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomInvalidKeyGeneratorCacheSizeTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidKeyGeneratorCacheSize"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidKeyGeneratorCacheSize", useRoot));
     }
 
     [Test]
-    public void CustomValidQueryCacheSizeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomValidQueryCacheSizeTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidQueryCacheSize");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidQueryCacheSize", useRoot);
 
       ValidateAllDefaultExcept(domainConfig, ((d) => d.QueryCacheSize, 192));
     }
 
     [Test]
-    public void CustomInvalidQueryCacheSizeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomInvalidQueryCacheSizeTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidQueryCacheSize"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidQueryCacheSize", useRoot));
     }
 
     [Test]
-    public void CustomValidRecordSetMappingCacheSizeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomValidRecordSetMappingCacheSizeTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidRecordSetMappingCacheSize");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidRecordSetMappingCacheSize", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.RecordSetMappingCacheSize, 192));
     }
 
     [Test]
-    public void CustomInvalidRecordSetMappingCacheSizeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomInvalidRecordSetMappingCacheSizeTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidRecordSetMappingCacheSize"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidRecordSetMappingCacheSize", useRoot));
     }
 
     [Test]
-    public void CustomDefaultDatabaseTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomDefaultDatabaseTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomDatabase");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomDatabase", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "MyFancyDatabase"),
         ((d) => d.IsMultidatabase, true),
@@ -240,9 +262,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void CustomDefaultSchemaTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CustomDefaultSchemaTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomSchema");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomSchema", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultSchema, "MyFancySchema"),
         ((d) => d.IsMultidatabase, false),
@@ -250,340 +274,413 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void UpgradeModesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void UpgradeModesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode1");
+      var domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode1", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Default));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode2");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode2", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Recreate));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode3");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode3", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Perform));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode4");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode4", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.PerformSafely));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode5");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode5", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Validate));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode6");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode6", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.LegacyValidate));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode7");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode7", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Skip));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode8");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode8", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.LegacySkip));
       domainConfig.Lock();
     }
 
     [Test]
-    public void WrongUpgradeModeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void WrongUpgradeModeTest(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithWrongUpgradeMode"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithWrongUpgradeMode", useRoot));
     }
 
     [Test]
-    public void ForeighKeyModesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ForeighKeyModesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode1");
+      var domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode1", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.None));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode2");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode2", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Hierarchy));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode3");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode3", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Reference));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode4");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode4", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.All));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode5");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode5", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Default));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode6");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode6", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Hierarchy | ForeignKeyMode.Reference));
       domainConfig.Lock();
     }
 
     [Test]
-    public void InvalidForeighKeyModeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidForeighKeyModeTest(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidForeignKeyMode"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidForeignKeyMode", useRoot));
     }
 
     [Test]
-    public void ChangeTrackingModesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ChangeTrackingModesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode1");
+      var domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode1", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Off));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode2");
+      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode2", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Auto));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode3");
+      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode3", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Manual));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode4");
+      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode4", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.OffWithNoPopulation));
       domainConfig.Lock();
 
-      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode5");
+      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode5", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Default));
       domainConfig.Lock();
     }
 
     [Test]
-    public void InvalidChangeTrackingModeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidChangeTrackingModeTest(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidChangeTrackingMode"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidChangeTrackingMode", useRoot));
     }
 
     [Test]
-    public void DomainOptionsTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DomainOptionsTest1(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithDomainOptionsValid1");
+      var domainConfig = LoadDomainConfiguration("DomainWithDomainOptionsValid1", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.Options, DomainOptions.Default));
       domainConfig.Lock();
     }
 
     [Test]
-    public void DomainOptionsTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DomainOptionsTest2(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithDomainOptionsValid2");
+      var domainConfig = LoadDomainConfiguration("DomainWithDomainOptionsValid2", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.Options, DomainOptions.None));
       domainConfig.Lock();
     }
+
     [Test]
-    public void InvalidDomainOptionsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidDomainOptionsTest(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithDomainOptionsInvalid"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithDomainOptionsInvalid", useRoot));
     }
 
     [Test]
-    public void CollationTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CollationTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithColation");
+      var domainConfig = LoadDomainConfiguration("DomainWithColation", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.Collation, "generalci"));
     }
 
     [Test]
-    public void BriefSchemaSyncExceptionsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void BriefSchemaSyncExceptionsTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithBriefSchemaSyncExceptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithBriefSchemaSyncExceptions", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.SchemaSyncExceptionFormat, SchemaSyncExceptionFormat.Brief));
     }
 
     [Test]
-    public void DetailedSchemaSyncExceptionsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DetailedSchemaSyncExceptionsTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithDetailedSchemaSyncExceptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithDetailedSchemaSyncExceptions", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.SchemaSyncExceptionFormat, SchemaSyncExceptionFormat.Detailed));
     }
 
     [Test]
-    public void DefaultSchemaSyncExceptionsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DefaultSchemaSyncExceptionsTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithDefaultSchemaSyncExceptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithDefaultSchemaSyncExceptions", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.SchemaSyncExceptionFormat, SchemaSyncExceptionFormat.Default));
     }
 
     [Test]
-    public void InvalidSchemaSyncExceptionsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidSchemaSyncExceptionsTest(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidSchemaSyncExceptions"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidSchemaSyncExceptions", useRoot));
     }
 
     [Test]
-    public void TagsLocationNowhereTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TagsLocationNowhereTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationNowhere");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationNowhere", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.Nowhere));
     }
 
     [Test]
-    public void TagsLocationBeforeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TagsLocationBeforeTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationBefore");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationBefore", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.BeforeStatement));
     }
 
     [Test]
-    public void TagsLocationWithinTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TagsLocationWithinTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationWithin");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationWithin", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.WithinStatement));
     }
 
     [Test]
-    public void TagsLocationAfterTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TagsLocationAfterTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationAfter");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationAfter", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.AfterStatement));
     }
 
     [Test]
-    public void TagsLocationDefaultTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TagsLocationDefaultTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationDefault");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationDefault", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.Default));
     }
 
     [Test]
-    public void InvalidTagsLocationTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidTagsLocationTest(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithTagsLocationInvalid"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithTagsLocationInvalid", useRoot));
     }
 
     [Test]
-    public void ForcedServerVersionTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ForcedServerVersionTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithForcedServerVersion");
+      var domainConfig = LoadDomainConfiguration("DomainWithForcedServerVersion", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.ForcedServerVersion, "10.0.0.0"));
     }
 
     [Test]
-    public void InitializationSqlTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InitializationSqlTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithInitSql");
+      var domainConfig = LoadDomainConfiguration("DomainWithInitSql", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.ConnectionInitializationSql, "use [OtherDb]"));
     }
 
     [Test]
-    public void IncludeSqlInExceptionsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void IncludeSqlInExceptionsTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("IncludeSqlInExceptionsTrue");
+      var domainConfig = LoadDomainConfiguration("IncludeSqlInExceptionsTrue", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.IncludeSqlInExceptions, true));
     }
 
     [Test]
-    public void DontIncludeSqlInExceptionsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DontIncludeSqlInExceptionsTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("IncludeSqlInExceptionsFalse");
+      var domainConfig = LoadDomainConfiguration("IncludeSqlInExceptionsFalse", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.IncludeSqlInExceptions, false));
     }
 
     [Test]
-    public void AllowCyclicDatabaseDependanciesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void AllowCyclicDatabaseDependanciesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("AllowCyclicDatabaseDependenciesTrue");
+      var domainConfig = LoadDomainConfiguration("AllowCyclicDatabaseDependenciesTrue", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.AllowCyclicDatabaseDependencies, true));
     }
 
     [Test]
-    public void DisallowCyclicDatabaseDependanciesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DisallowCyclicDatabaseDependanciesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("AllowCyclicDatabaseDependenciesFalse");
+      var domainConfig = LoadDomainConfiguration("AllowCyclicDatabaseDependenciesFalse", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.AllowCyclicDatabaseDependencies, false));
     }
 
     [Test]
-    public void BuildInParallelTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void BuildInParallelTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("BuildInParallelTrue");
+      var domainConfig = LoadDomainConfiguration("BuildInParallelTrue", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.BuildInParallel, true));
     }
 
     [Test]
-    public void DontBuildInParallelTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DontBuildInParallelTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("BuildInParallelFalse");
+      var domainConfig = LoadDomainConfiguration("BuildInParallelFalse", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.BuildInParallel, false));
     }
 
     [Test]
-    public void AllowMultidatabaseKeysTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void AllowMultidatabaseKeysTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("MultidatabaseKeysTrue");
+      var domainConfig = LoadDomainConfiguration("MultidatabaseKeysTrue", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.MultidatabaseKeys, true));
     }
 
     [Test]
-    public void DisallowMultidatabaseKeysTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DisallowMultidatabaseKeysTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("MultidatabaseKeysFalse");
+      var domainConfig = LoadDomainConfiguration("MultidatabaseKeysFalse", useRoot);
       ValidateAllDefaultExcept(domainConfig, ((d) => d.MultidatabaseKeys, false));
     }
 
     [Test]
-    public void ShareStorageSchemaOverNodesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ShareStorageSchemaOverNodesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("SharedStorageSchemaOn");
+      var domainConfig = LoadDomainConfiguration("SharedStorageSchemaOn", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.ShareStorageSchemaOverNodes, true));
     }
 
     [Test]
-    public void DontShareStorageSchemaOverNodesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DontShareStorageSchemaOverNodesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("SharedStorageSchemaOff");
+      var domainConfig = LoadDomainConfiguration("SharedStorageSchemaOff", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.ShareStorageSchemaOverNodes, false));
     }
 
     [Test]
-    public void EnsureConnectionIsAliveTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EnsureConnectionIsAliveTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("EnableConnectionIsAliveTrue");
+      var domainConfig = LoadDomainConfiguration("EnableConnectionIsAliveTrue", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.EnsureConnectionIsAlive, true));
     }
 
     [Test]
-    public void DontCheckConnectionIsAliveTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DontCheckConnectionIsAliveTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("EnableConnectionIsAliveFalse");
+      var domainConfig = LoadDomainConfiguration("EnableConnectionIsAliveFalse", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.EnsureConnectionIsAlive, false));
     }
 
     [Test]
-    public void PreferTypeIdAsQueryParameterTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void PreferTypeIdAsQueryParameterTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("PreferTypeIdsAsQueryParametersTrue");
+      var domainConfig = LoadDomainConfiguration("PreferTypeIdsAsQueryParametersTrue", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.PreferTypeIdsAsQueryParameters, true));
     }
 
     [Test]
-    public void DontPreferTypeIdAsQueryParameterTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DontPreferTypeIdAsQueryParameterTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("PreferTypeIdsAsQueryParametersFalse");
+      var domainConfig = LoadDomainConfiguration("PreferTypeIdsAsQueryParametersFalse", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.PreferTypeIdsAsQueryParameters, false));
     }
@@ -592,9 +689,11 @@ namespace Xtensive.Orm.Tests.Configuration
     #region NamingConvention
 
     [Test]
-    public void NamingConventionSettingsTest01()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest01(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention1");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention1", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -608,9 +707,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest02()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest02(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention2");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention2", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Lowercase));
@@ -624,9 +725,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest03()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest03(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention3");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention3", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.AsIs));
@@ -640,9 +743,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest04()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest04(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention4");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention4", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Default));
@@ -656,9 +761,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest05()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest05(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention5");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention5", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -667,9 +774,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest06()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest06(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention6");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention6", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -678,9 +787,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest07()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest07(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention7");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention7", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -689,9 +800,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest08()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest08(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention8");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention8", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -700,9 +813,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest09()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest09(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention9");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention9", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -711,9 +826,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest10()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest10(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention10");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention10", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -723,9 +840,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionSettingsTest11()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionSettingsTest11(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention11");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention11", useRoot);
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -734,21 +853,27 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void NamingConventionInvalidSettingsTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionInvalidSettingsTest1(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException> (()=> LoadDomainConfiguration("DomainWithInvalidNamingConvention1"));
+      _ = Assert.Throws<InvalidOperationException> (() => LoadDomainConfiguration("DomainWithInvalidNamingConvention1", useRoot));
     }
 
     [Test]
-    public void NamingConventionInvalidSettingsTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionInvalidSettingsTest2(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidNamingConvention2"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidNamingConvention2", useRoot));
     }
 
     [Test]
-    public void NamingConventionInvalidSettingsTest3()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NamingConventionInvalidSettingsTest3(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidNamingConvention3"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidNamingConvention3", useRoot));
     }
 
     #endregion
@@ -756,27 +881,33 @@ namespace Xtensive.Orm.Tests.Configuration
     #region VersioningConvention
 
     [Test]
-    public void VersioningConventionPessimisticTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void VersioningConventionPessimisticTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention1");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention1", useRoot);
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Pessimistic));
       Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
     }
 
     [Test]
-    public void VersioningConventionOptimisticTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void VersioningConventionOptimisticTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention2");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention2", useRoot);
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Optimistic));
       Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
     }
 
     [Test]
-    public void VersioningConventionDefaultTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void VersioningConventionDefaultTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention3");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention3", useRoot);
       ValidateAllDefault(domainConfig);
 
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Default));
@@ -784,9 +915,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void VersioningConventionDenyEntitySetChangeVersionTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void VersioningConventionDenyEntitySetChangeVersionTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention4");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention4", useRoot);
       ValidateAllDefault(domainConfig);
 
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Optimistic));
@@ -794,27 +927,34 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void VersioningConventionAllowEntitySetChangeVersionTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void VersioningConventionAllowEntitySetChangeVersionTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention5");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention5", useRoot);
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Optimistic));
       Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
     }
 
     [Test]
-    public void VersioningConventionInvalidTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void VersioningConventionInvalidTest(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidVersioningConvention1"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidVersioningConvention1", useRoot));
     }
 
     #endregion
 
     #region Types registration
+
     [Test]
-    public void TypesRegistrationAsTypesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TypesRegistrationAsTypesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithTypes");
+      var domainConfig = LoadDomainConfiguration("DomainWithTypes", useRoot);
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity1)), Is.True);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity2)), Is.True);
@@ -822,9 +962,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void TypesRegistrationAsAssembliesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TypesRegistrationAsAssembliesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithAssemblies");
+      var domainConfig = LoadDomainConfiguration("DomainWithAssemblies", useRoot);
       ValidateAllDefault(domainConfig);
       var ormAssembly = typeof(DomainConfiguration).Assembly;
       Assert.That(domainConfig.Types.Count, Is.GreaterThan(0));
@@ -832,18 +974,22 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void TypesRegistrationAsAssembliesWithNamespace()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TypesRegistrationAsAssembliesWithNamespace(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithAssembliesAndNamespaces");
+      var domainConfig = LoadDomainConfiguration("DomainWithAssembliesAndNamespaces", useRoot);
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity1)), Is.True);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity2)), Is.True);
     }
 
     [Test]
-    public void MixedTypeRegistration()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MixedTypeRegistration(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithMixedRegistrations");
+      var domainConfig = LoadDomainConfiguration("DomainWithMixedRegistrations", useRoot);
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity1)), Is.True);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity2)), Is.True);
@@ -853,11 +999,13 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void InvalidTypeRegistration1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidTypeRegistration1(bool useRoot)
     {
       // same type twice
 
-      var domainConfig = LoadDomainConfiguration("DomainWithInvalidRegistrations1");
+      var domainConfig = LoadDomainConfiguration("DomainWithInvalidRegistrations1", useRoot);
 
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity1)), Is.True);
@@ -866,10 +1014,12 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void InvalidTypeRegistration2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidTypeRegistration2(bool useRoot)
     {
       // same Assembly
-      var domainConfig = LoadDomainConfiguration("DomainWithInvalidRegistrations2");
+      var domainConfig = LoadDomainConfiguration("DomainWithInvalidRegistrations2", useRoot);
 
       ValidateAllDefault(domainConfig);
       var ormAssembly = typeof(DomainConfiguration).Assembly;
@@ -878,37 +1028,47 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void InvalidTypeRegistration3()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidTypeRegistration3(bool useRoot)
     {
       // same assembly and namespace
-      var domainConfig = LoadDomainConfiguration("DomainWithInvalidRegistrations3");
+      var domainConfig = LoadDomainConfiguration("DomainWithInvalidRegistrations3", useRoot);
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity1)), Is.True);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity2)), Is.True);
     }
 
     [Test]
-    public void InvalidTypeRegistration4()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidTypeRegistration4(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations4"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations4", useRoot));
     }
 
     [Test]
-    public void InvalidTypeRegistration5()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidTypeRegistration5(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations5"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations5", useRoot));
     }
 
     [Test]
-    public void InvalidTypeRegistration6()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidTypeRegistration6(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations6"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations6", useRoot));
     }
 
     [Test]
-    public void InvalidTypeRegistration7()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void InvalidTypeRegistration7(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations7"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations7", useRoot));
     }
 
     #endregion
@@ -916,9 +1076,11 @@ namespace Xtensive.Orm.Tests.Configuration
     #region Sessions
 
     [Test]
-    public void MultipleSessionsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MultipleSessionsTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithMultipleSessionConfigurations");
+      var domainConfig = LoadDomainConfiguration("DomainWithMultipleSessionConfigurations", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -940,9 +1102,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionWithEmptyNameTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithEmptyNameTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionEmptyName");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionEmptyName", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -953,9 +1117,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionWithCustomNameTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithCustomNameTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomName");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomName", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -968,9 +1134,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionWithCustomUserNameTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithCustomUserNameTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomUser");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomUser", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -982,9 +1150,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionWithOptionsTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithOptionsTest1(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionDefaultOptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionDefaultOptions", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -996,9 +1166,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionWithOptionsTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithOptionsTest2(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionServerProfile");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionServerProfile", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1010,9 +1182,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionWithOptionsTest3()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithOptionsTest3(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionClientProfile");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionClientProfile", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1024,9 +1198,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionWithOptionsTest4()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithOptionsTest4(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomOptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomOptions", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1038,9 +1214,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionWithCollectionSizesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithCollectionSizesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionWithCollectionSizes");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionWithCollectionSizes", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1054,9 +1232,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionCustomCacheTypeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionCustomCacheTypeTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomCacheType");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomCacheType", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1068,9 +1248,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionCustomIsolationLevelTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionCustomIsolationLevelTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomIsolationLevel");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomIsolationLevel", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1082,9 +1264,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionCustomCommandTimeoutTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionCustomCommandTimeoutTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomCommandTimeout");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomCommandTimeout", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1096,9 +1280,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionCustomPreloadingPolicyTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionCustomPreloadingPolicyTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomPreloadingPolicy");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomPreloadingPolicy", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1110,9 +1296,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionCustomConnectionStringTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionCustomConnectionStringTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomConnectionString");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomConnectionString", useRoot);
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1123,9 +1311,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionCustomConnectionUrlTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionCustomConnectionUrlTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomConnectionUrl");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomConnectionUrl", useRoot);
       ValidateAllDefault(domainConfig);
       var sessions = domainConfig.Sessions;
       Assert.That(sessions.Count, Is.EqualTo(1));
@@ -1135,57 +1325,75 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void SessionWithInvalidOptions()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithInvalidOptions(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithSessionInvalidOptions"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithSessionInvalidOptions", useRoot));
     }
 
     [Test]
-    public void SessionWithInvalidCacheSizeTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithInvalidCacheSizeTest1(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheSize1"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheSize1", useRoot));
     }
 
     [Test]
-    public void SessionWithInvalidCacheSizeTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithInvalidCacheSizeTest2(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheSize2"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheSize2", useRoot));
     }
 
     [Test]
-    public void SessionWithInvalidCacheSizeTest3()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithInvalidCacheSizeTest3(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheSize3"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheSize3", useRoot));
     }
 
     [Test]
-    public void SessionWithInvalidBatchSizeTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithInvalidBatchSizeTest1(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidBatchSize1"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidBatchSize1", useRoot));
     }
 
     [Test]
-    public void SessionWithInvalidBatchSizeTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithInvalidBatchSizeTest2(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidBatchSize2"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidBatchSize2", useRoot));
     }
 
     [Test]
-    public void SessionWithInvalidEntityChangeRegistryTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithInvalidEntityChangeRegistryTest1(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry1"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry1", useRoot));
     }
 
     [Test]
-    public void SessionWithInvalidEntityChangeRegistryTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithInvalidEntityChangeRegistryTest2(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry2"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry2", useRoot));
     }
 
     [Test]
-    public void SessionWithInvalidCacheType1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SessionWithInvalidCacheType1(bool useRoot)
     {
-      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheType"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheType", useRoot));
     }
 
     #endregion
@@ -1193,9 +1401,11 @@ namespace Xtensive.Orm.Tests.Configuration
     #region Databases configuration
 
     [Test]
-    public void DatabaseConfigurationOnlyAliasTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DatabaseConfigurationOnlyAliasTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithDatabases1");
+      var domainConfig = LoadDomainConfiguration("DomainWithDatabases1", useRoot);
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Databases.Count, Is.EqualTo(2));
       var db1 = domainConfig.Databases[0];
@@ -1211,9 +1421,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void DatabaseConfigurationWithTypeIdsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DatabaseConfigurationWithTypeIdsTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithDatabases2");
+      var domainConfig = LoadDomainConfiguration("DomainWithDatabases2", useRoot);
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Databases.Count, Is.EqualTo(2));
       var db1 = domainConfig.Databases[0];
@@ -1229,27 +1441,35 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void DatabaseConfigurationNegativeMinTypeIdTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DatabaseConfigurationNegativeMinTypeIdTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases1"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases1", useRoot));
     }
 
     [Test]
-    public void DatabaseConfigurationInvalidMinTypeIdTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DatabaseConfigurationInvalidMinTypeIdTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases2"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases2", useRoot));
     }
 
     [Test]
-    public void DatabaseConfigurationNegativeMaxTypeIdTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DatabaseConfigurationNegativeMaxTypeIdTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases3"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases3", useRoot));
     }
 
     [Test]
-    public void DatabaseConfigurationInvalidMaxTypeIdTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DatabaseConfigurationInvalidMaxTypeIdTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases4"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases4", useRoot));
     }
 
     #endregion
@@ -1257,71 +1477,87 @@ namespace Xtensive.Orm.Tests.Configuration
     #region KeyGenerators
 
     [Test]
-    public void SimpleKeyGeneratorTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SimpleKeyGeneratorTest(bool useRoot)
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomGenerator");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomGenerator", useRoot);
       ValidateAllDefault(domainConfig);
     }
 
     [Test]
-    public void KeyGeneratorWithDatabaseNamesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void KeyGeneratorWithDatabaseNamesTest(bool useRoot)
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNames");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNames", useRoot);
       ValidateAllDefault(domainConfig);
     }
 
     [Test]
-    public void KeyGeneratorWithDatabaseNamesAllParamsTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void KeyGeneratorWithDatabaseNamesAllParamsTest(bool useRoot)
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNamesAndKeyParams");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNamesAndKeyParams", useRoot);
       ValidateAllDefault(domainConfig);
     }
 
     [Test]
-    public void KeyGeneratorsWithDatabaseAliasesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void KeyGeneratorsWithDatabaseAliasesTest(bool useRoot)
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      var domainConfig = LoadDomainConfiguration("DomainWithCustomGeneratorsWithDatabasesAliases");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomGeneratorsWithDatabasesAliases", useRoot);
       ValidateAllDefault(domainConfig);
     }
 
     [Test]
-    public void KeyGeneratorsWithConflictByDatabaseTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void KeyGeneratorsWithConflictByDatabaseTest1(bool useRoot)
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorsConflict1"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorsConflict1", useRoot));
     }
 
     [Test]
-    public void KeyGeneratorsWithConflictByDatabaseTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void KeyGeneratorsWithConflictByDatabaseTest2(bool useRoot)
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorsConflict2"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorsConflict2", useRoot));
     }
 
     [Test]
-    public void KeyGeneratorWithNegativeSeedTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void KeyGeneratorWithNegativeSeedTest(bool useRoot)
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorNegativeSeed"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorNegativeSeed", useRoot));
     }
 
     [Test]
-    public void KeyGeneratorWithNegativeCacheSizeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void KeyGeneratorWithNegativeCacheSizeTest(bool useRoot)
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorNegativeCache"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorNegativeCache", useRoot));
     }
 
     #endregion
@@ -1329,35 +1565,45 @@ namespace Xtensive.Orm.Tests.Configuration
     #region IgnoreRules
 
     [Test]
-    public void IgnoreRulesTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void IgnoreRulesTest(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithIgnoreRules");
+      var domainConfig = LoadDomainConfiguration("DomainWithIgnoreRules", useRoot);
       ValidateAllDefault(domainConfig);
       ValidateIgnoreRules(domainConfig.IgnoreRules);
     }
 
     [Test]
-    public void IgnoreColumnAndIndexAtTheSameTimeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void IgnoreColumnAndIndexAtTheSameTimeTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules1"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules1", useRoot));
     }
 
     [Test]
-    public void IgnoreTableAndColumnAndIndexAtTheSameTimeTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void IgnoreTableAndColumnAndIndexAtTheSameTimeTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules2"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules2", useRoot));
     }
 
     [Test]
-    public void IgnoreDatabaseOnlyTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void IgnoreDatabaseOnlyTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules3"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules3", useRoot));
     }
 
     [Test]
-    public void IgnoreDatabaseAndSchemaOnlyTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void IgnoreDatabaseAndSchemaOnlyTest(bool useRoot)
     {
-      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules4"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules4", useRoot));
     }
 
     private void ValidateIgnoreRules(IgnoreRuleCollection rules)
@@ -1496,9 +1742,11 @@ namespace Xtensive.Orm.Tests.Configuration
     #region MappingRules
 
     [Test]
-    public void MappingRulesTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesTest1(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules1");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules1", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1515,9 +1763,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void MappingRulesTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesTest2(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules2");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules2", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1531,14 +1781,14 @@ namespace Xtensive.Orm.Tests.Configuration
       Assert.That(rule.Namespace, Is.Null);
       Assert.That(rule.Database, Is.Null);
       Assert.That(rule.Schema, Is.EqualTo("Model1"));
-
-     
     }
 
     [Test]
-    public void MappingRulesTest3()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesTest3(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules3");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules3", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1556,9 +1806,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void MappingRulesTest4()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesTest4(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules4");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules4", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1576,9 +1828,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void MappingRulesTest5()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesTest5(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules5");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules5", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1596,9 +1850,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void MappingRulesTest6()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesTest6(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules6");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules6", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1615,9 +1871,11 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void MappingRulesTest7()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesTest7(bool useRoot)
     {
-      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules7");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules7", useRoot);
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1634,52 +1892,66 @@ namespace Xtensive.Orm.Tests.Configuration
     }
 
     [Test]
-    public void MappingRuleWithConflictByAssemblyTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRuleWithConflictByAssemblyTest(bool useRoot)
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => LoadDomainConfiguration("DomainWithConflictMappingRules1"));
+        () => LoadDomainConfiguration("DomainWithConflictMappingRules1", useRoot));
     }
 
     [Test]
-    public void MappingRuleWithConflictByNamespaceTest()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRuleWithConflictByNamespaceTest(bool useRoot)
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => LoadDomainConfiguration("DomainWithConflictMappingRules2"));
+        () => LoadDomainConfiguration("DomainWithConflictMappingRules2", useRoot));
     }
 
     [Test]
-    public void MappingRulesInvalidTest1()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesInvalidTest1(bool useRoot)
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => LoadDomainConfiguration("DomainWithInvalidMappingRules1"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules1", useRoot));
     }
 
     [Test]
-    public void MappingRulesInvalidTest2()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesInvalidTest2(bool useRoot)
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => LoadDomainConfiguration("DomainWithInvalidMappingRules2"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules2", useRoot));
     }
 
     [Test]
-    public void MappingRulesInvalidTest3()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesInvalidTest3(bool useRoot)
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => LoadDomainConfiguration("DomainWithInvalidMappingRules3"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules3", useRoot));
     }
 
     [Test]
-    public void MappingRulesInvalidTest4()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesInvalidTest4(bool useRoot)
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => LoadDomainConfiguration("DomainWithInvalidMappingRules4"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules4", useRoot));
     }
 
     [Test]
-    public void MappingRulesInvalidTest5()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MappingRulesInvalidTest5(bool useRoot)
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => LoadDomainConfiguration("DomainWithInvalidMappingRules5"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules5", useRoot));
     }
 
     #endregion
@@ -1759,22 +2031,6 @@ namespace Xtensive.Orm.Tests.Configuration
       Assert.That(domainConfiguration.ShareStorageSchemaOverNodes, Is.EqualTo(DomainConfiguration.DefaultShareStorageSchemaOverNodes));
       Assert.That(domainConfiguration.TagsLocation, Is.EqualTo(DomainConfiguration.DefaultTagLocation));
       Assert.That(domainConfiguration.UpgradeMode, Is.EqualTo(DomainConfiguration.DefaultUpgradeMode));
-    }
-
-    private void ValidateAllDefault(SessionConfiguration sessionConfiguration)
-    {
-      Assert.That(sessionConfiguration.UserName, Is.Empty);
-      Assert.That(sessionConfiguration.Password, Is.Empty);
-      Assert.That(sessionConfiguration.Options, Is.EqualTo(SessionConfiguration.DefaultSessionOptions));
-      Assert.That(sessionConfiguration.CacheSize, Is.EqualTo(SessionConfiguration.DefaultCacheSize));
-      Assert.That(sessionConfiguration.CacheType, Is.EqualTo(SessionConfiguration.DefaultCacheType));
-      Assert.That(sessionConfiguration.DefaultIsolationLevel, Is.EqualTo(SessionConfiguration.DefaultDefaultIsolationLevel));
-      Assert.That(sessionConfiguration.DefaultCommandTimeout, Is.Null);
-      Assert.That(sessionConfiguration.BatchSize, Is.EqualTo(SessionConfiguration.DefaultBatchSize));
-      Assert.That(sessionConfiguration.EntityChangeRegistrySize, Is.EqualTo(SessionConfiguration.DefaultEntityChangeRegistrySize));
-      Assert.That(sessionConfiguration.ReaderPreloading, Is.EqualTo(SessionConfiguration.DefaultReaderPreloadingPolicy));
-      Assert.That(sessionConfiguration.ServiceContainerType, Is.Null);
-      Assert.That(sessionConfiguration.ConnectionInfo, Is.Null);
     }
 
     private void ValidateAllDefaultExcept<TConfiguration, T1>(TConfiguration configuration,

--- a/Orm/Xtensive.Orm.Tests/Configuration/ModernConfigurationTests.cs
+++ b/Orm/Xtensive.Orm.Tests/Configuration/ModernConfigurationTests.cs
@@ -1,0 +1,1993 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Transactions;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Xtensive.Core;
+using Xtensive.Orm.Configuration;
+
+namespace Xtensive.Orm.Tests.Configuration.TypesToUseInTests
+{
+  namespace NestedNamespace
+  {
+    [HierarchyRoot]
+    public class DummyNestedEntity1 : Entity
+    {
+      [Key, Field]
+      public int Id { get; private set; }
+
+      [Field]
+      public string Name { get; set; }
+    }
+
+    [HierarchyRoot]
+    public class DummyNestedEntity2 : Entity
+    {
+      [Key, Field]
+      public int Id { get; private set; }
+
+      [Field]
+      public string Name { get; set; }
+    }
+  }
+
+  [HierarchyRoot]
+  public class DummyEntity1 : Entity
+  {
+    [Key, Field]
+    public int Id { get; private set; }
+
+    [Field]
+    public string Name { get; set; }
+  }
+
+  [HierarchyRoot]
+  public class DummyEntity2 : Entity
+  {
+    [Key, Field]
+    public int Id { get; private set; }
+
+    [Field]
+    public string Name { get; set; }
+  }
+
+  [HierarchyRoot]
+  public class DummyEntity3 : Entity
+  {
+    [Key, Field]
+    public int Id { get; private set; }
+
+    [Field]
+    public string Name { get; set; }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Configuration
+{
+  [TestFixture]
+  public sealed class AppConfigStyleConfigurationTest : ConfigurationFileTestBase
+  {
+    protected override string DefaultSectionName => "Xtensive.Orm.AppConfig";
+
+    protected override bool NameAttributeUnique => false;
+
+    protected override void RegisterConfigurationFile(ConfigurationBuilder builder)
+    {
+      _ = builder.AddXmlFile("domainSettings.config");
+    }
+  }
+
+  [TestFixture]
+  public sealed class XmlConfigurationTest : ConfigurationFileTestBase
+  {
+    protected override string DefaultSectionName => "Xtensive.Orm.Xml";
+
+    protected override void RegisterConfigurationFile(ConfigurationBuilder builder)
+    {
+      _ = builder.AddXmlFile("domainSettings.config");
+    }
+  }
+
+  [TestFixture]
+  public sealed class JsonConfigurationTest : ConfigurationFileTestBase
+  {
+    protected override string DefaultSectionName => "Xtensive.Orm.Json";
+
+    protected override void RegisterConfigurationFile(ConfigurationBuilder builder)
+    {
+      _ = builder.AddJsonFile("domainSettings.json");
+    }
+  }
+
+  public abstract class ConfigurationFileTestBase
+  {
+
+    private IConfigurationRoot configuration;
+    private IConfigurationSection configurationSection;
+
+    protected abstract string DefaultSectionName { get; }
+    protected virtual bool NameAttributeUnique => true;
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+      var configurationBuilder = new ConfigurationBuilder();
+      _ = configurationBuilder.SetBasePath(Directory.GetCurrentDirectory());
+
+      RegisterConfigurationFile(configurationBuilder);
+      configuration = configurationBuilder.Build();
+
+      configurationSection = configuration.GetSection(DefaultSectionName);
+      if (!configurationSection.GetChildren().Any()) {
+        throw new InconclusiveException($"{DefaultSectionName} section seems to be empty. Check registered file with domain settings");
+      }
+    }
+
+    protected abstract void RegisterConfigurationFile(ConfigurationBuilder builder);
+
+    private DomainConfiguration GetDomainConfiguration(string domainName)
+    {
+      var domainConfiguration = DomainConfiguration.Load(configurationSection, domainName);
+      return domainConfiguration;
+    }
+
+    #region Simple Domain settings that used to be attributes
+
+    [Test]
+    public void ProviderAndConnectionStringTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithProviderAndConnectionString");
+      Assert.That(domainConfig.ConnectionInfo.Provider, Is.EqualTo(WellKnown.Provider.Sqlite));
+      Assert.That(domainConfig.ConnectionInfo.ConnectionString, Is.EqualTo("Data Source=DO-Testsaaa.db3"));
+      Assert.That(domainConfig.ConnectionInfo.ConnectionUrl, Is.Null);
+
+      ValidateAllDefault(domainConfig);
+    }
+
+    [Test]
+    public void ConnectionUrlTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithConnectionUrl");
+      Assert.That(domainConfig.ConnectionInfo.Provider, Is.EqualTo(WellKnown.Provider.Sqlite));
+      Assert.That(domainConfig.ConnectionInfo.ConnectionString, Is.Null);
+      Assert.That(domainConfig.ConnectionInfo.ConnectionUrl.Url, Is.EqualTo("sqlite:///DO-Tests.db3"));
+
+      ValidateAllDefault(domainConfig);
+    }
+
+    [Test]
+    public void CustomValidKeyCacheSizeTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithCustomValidKeyCacheSize");
+
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.KeyCacheSize, 192));
+    }
+
+    [Test]
+    public void CustomInvalidKeyCacheSizeTest()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomInvalidKeyCacheSize"));
+
+    }
+
+    [Test]
+    public void CustomValidKeyGeneratorCacheSizeTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithCustomValidKeyGeneratorCacheSize");
+
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.KeyGeneratorCacheSize, 192));
+    }
+
+    [Test]
+    public void CustomInvalidKeyGeneratorCacheSizeTest()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomInvalidKeyGeneratorCacheSize"));
+    }
+
+    [Test]
+    public void CustomValidQueryCacheSizeTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithCustomValidQueryCacheSize");
+
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.QueryCacheSize, 192));
+    }
+
+    [Test]
+    public void CustomInvalidQueryCacheSizeTest()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomInvalidQueryCacheSize"));
+    }
+
+    [Test]
+    public void CustomValidRecordSetMappingCacheSizeTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithCustomValidRecordSetMappingCacheSize");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.RecordSetMappingCacheSize, 192));
+    }
+
+    [Test]
+    public void CustomInvalidRecordSetMappingCacheSizeTest()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomInvalidRecordSetMappingCacheSize"));
+    }
+
+    [Test]
+    public void CustomDefaultDatabaseTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithCustomDatabase");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.DefaultDatabase, "MyFancyDatabase"),
+        ((d) => d.IsMultidatabase, true),
+        ((d) => d.IsMultischema, true)
+        );
+    }
+
+    [Test]
+    public void CustomDefaultSchemaTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithCustomSchema");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.DefaultSchema, "MyFancySchema"),
+        ((d) => d.IsMultidatabase, false),
+        ((d) => d.IsMultischema, true));
+    }
+
+    [Test]
+    public void UpgradeModesTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithUpgradeMode1");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.UpgradeMode, DomainUpgradeMode.Default));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode2");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.UpgradeMode, DomainUpgradeMode.Recreate));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode3");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.UpgradeMode, DomainUpgradeMode.Perform));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode4");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.UpgradeMode, DomainUpgradeMode.PerformSafely));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode5");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.UpgradeMode, DomainUpgradeMode.Validate));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode6");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.UpgradeMode, DomainUpgradeMode.LegacyValidate));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode7");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.UpgradeMode, DomainUpgradeMode.Skip));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode8");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.UpgradeMode, DomainUpgradeMode.LegacySkip));
+      domainConfig.Lock();
+    }
+
+    [Test]
+    public void WrongUpgradeModeTest()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithWrongUpgradeMode"));
+    }
+
+    [Test]
+    public void ForeighKeyModesTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode1");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.None));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode2");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Hierarchy));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode3");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Reference));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode4");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.All));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode5");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Default));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode6");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Hierarchy | ForeignKeyMode.Reference));
+      domainConfig.Lock();
+    }
+
+    [Test]
+    public void InvalidForeighKeyModeTest()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidForeignKeyMode"));
+    }
+
+    [Test]
+    public void ChangeTrackingModesTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode1");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Off));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode2");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Auto));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode3");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Manual));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode4");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.OffWithNoPopulation));
+      domainConfig.Lock();
+
+      domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode5");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Default));
+      domainConfig.Lock();
+    }
+
+    [Test]
+    public void InvalidChangeTrackingModeTest()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidChangeTrackingMode"));
+    }
+
+    [Test]
+    public void DomainOptionsTest1()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithDomainOptionsValid1");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.Options, DomainOptions.Default));
+      domainConfig.Lock();
+    }
+
+    [Test]
+    public void DomainOptionsTest2()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithDomainOptionsValid2");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.Options, DomainOptions.None));
+      domainConfig.Lock();
+    }
+    [Test]
+    public void InvalidDomainOptionsTest()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithDomainOptionsInvalid"));
+    }
+
+    [Test]
+    public void CollationTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithColation");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.Collation, "generalci"));
+    }
+
+    [Test]
+    public void BriefSchemaSyncExceptionsTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithBriefSchemaSyncExceptions");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.SchemaSyncExceptionFormat, SchemaSyncExceptionFormat.Brief));
+    }
+
+    [Test]
+    public void DetailedSchemaSyncExceptionsTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithDetailedSchemaSyncExceptions");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.SchemaSyncExceptionFormat, SchemaSyncExceptionFormat.Detailed));
+    }
+
+    [Test]
+    public void DefaultSchemaSyncExceptionsTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithDefaultSchemaSyncExceptions");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.SchemaSyncExceptionFormat, SchemaSyncExceptionFormat.Default));
+    }
+
+    [Test]
+    public void InvalidSchemaSyncExceptionsTest()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidSchemaSyncExceptions"));
+    }
+
+    [Test]
+    public void TagsLocationNowhereTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationNowhere");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.TagsLocation, TagsLocation.Nowhere));
+    }
+
+    [Test]
+    public void TagsLocationBeforeTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationBefore");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.TagsLocation, TagsLocation.BeforeStatement));
+    }
+
+    [Test]
+    public void TagsLocationWithinTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationWithin");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.TagsLocation, TagsLocation.WithinStatement));
+    }
+
+    [Test]
+    public void TagsLocationAfterTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationAfter");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.TagsLocation, TagsLocation.AfterStatement));
+    }
+
+    [Test]
+    public void TagsLocationDefaultTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationDefault");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.TagsLocation, TagsLocation.Default));
+    }
+
+    [Test]
+    public void InvalidTagsLocationTest()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithTagsLocationInvalid"));
+    }
+
+    [Test]
+    public void ForcedServerVersionTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithForcedServerVersion");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.ForcedServerVersion, "10.0.0.0"));
+    }
+
+    [Test]
+    public void InitializationSqlTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithInitSql");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.ConnectionInitializationSql, "use [OtherDb]"));
+    }
+
+    [Test]
+    public void IncludeSqlInExceptionsTest()
+    {
+      var domainConfig = GetDomainConfiguration("IncludeSqlInExceptionsTrue");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.IncludeSqlInExceptions, true));
+    }
+
+    [Test]
+    public void DontIncludeSqlInExceptionsTest()
+    {
+      var domainConfig = GetDomainConfiguration("IncludeSqlInExceptionsFalse");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.IncludeSqlInExceptions, false));
+    }
+
+    [Test]
+    public void AllowCyclicDatabaseDependanciesTest()
+    {
+      var domainConfig = GetDomainConfiguration("AllowCyclicDatabaseDependenciesTrue");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.AllowCyclicDatabaseDependencies, true));
+    }
+
+    [Test]
+    public void DisallowCyclicDatabaseDependanciesTest()
+    {
+      var domainConfig = GetDomainConfiguration("AllowCyclicDatabaseDependenciesFalse");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.AllowCyclicDatabaseDependencies, false));
+    }
+
+    [Test]
+    public void BuildInParallelTest()
+    {
+      var domainConfig = GetDomainConfiguration("BuildInParallelTrue");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.BuildInParallel, true));
+    }
+
+    [Test]
+    public void DontBuildInParallelTest()
+    {
+      var domainConfig = GetDomainConfiguration("BuildInParallelFalse");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.BuildInParallel, false));
+    }
+
+    [Test]
+    public void AllowMultidatabaseKeysTest()
+    {
+      var domainConfig = GetDomainConfiguration("MultidatabaseKeysTrue");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.MultidatabaseKeys, true));
+    }
+
+    [Test]
+    public void DisallowMultidatabaseKeysTest()
+    {
+      var domainConfig = GetDomainConfiguration("MultidatabaseKeysFalse");
+      ValidateAllDefaultExcept(domainConfig, ((d) => d.MultidatabaseKeys, false));
+    }
+
+    [Test]
+    public void ShareStorageSchemaOverNodesTest()
+    {
+      var domainConfig = GetDomainConfiguration("SharedStorageSchemaOn");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.ShareStorageSchemaOverNodes, true));
+    }
+
+    [Test]
+    public void DontShareStorageSchemaOverNodesTest()
+    {
+      var domainConfig = GetDomainConfiguration("SharedStorageSchemaOff");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.ShareStorageSchemaOverNodes, false));
+    }
+
+    [Test]
+    public void EnsureConnectionIsAliveTest()
+    {
+      var domainConfig = GetDomainConfiguration("EnableConnectionIsAliveTrue");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.EnsureConnectionIsAlive, true));
+    }
+
+    [Test]
+    public void DontCheckConnectionIsAliveTest()
+    {
+      var domainConfig = GetDomainConfiguration("EnableConnectionIsAliveFalse");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.EnsureConnectionIsAlive, false));
+    }
+
+    [Test]
+    public void PreferTypeIdAsQueryParameterTest()
+    {
+      var domainConfig = GetDomainConfiguration("PreferTypeIdsAsQueryParametersTrue");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.PreferTypeIdsAsQueryParameters, true));
+    }
+
+    [Test]
+    public void DontPreferTypeIdAsQueryParameterTest()
+    {
+      var domainConfig = GetDomainConfiguration("PreferTypeIdsAsQueryParametersFalse");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.PreferTypeIdsAsQueryParameters, false));
+    }
+    #endregion
+
+    #region NamingConvention
+
+    [Test]
+    public void NamingConventionSettingsTest01()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention1");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Synonymize));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.UnderscoreHyphens | NamingRules.RemoveDots));
+
+      var synonyms = namingConvention.NamespaceSynonyms;
+      Assert.That(synonyms.Count, Is.EqualTo(2));
+      Assert.That(synonyms["Xtensive.Orm"], Is.EqualTo("system"));
+      Assert.That(synonyms["Xtensive.Orm.Tests"], Is.EqualTo("theRest"));
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest02()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention2");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Lowercase));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Synonymize));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.UnderscoreHyphens | NamingRules.RemoveDots));
+
+      var synonyms = namingConvention.NamespaceSynonyms;
+      Assert.That(synonyms.Count, Is.EqualTo(2));
+      Assert.That(synonyms["Xtensive.Orm"], Is.EqualTo("system"));
+      Assert.That(synonyms["Xtensive.Orm.Tests"], Is.EqualTo("theRest"));
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest03()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention3");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.AsIs));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Synonymize));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.UnderscoreHyphens | NamingRules.RemoveDots));
+
+      var synonyms = namingConvention.NamespaceSynonyms;
+      Assert.That(synonyms.Count, Is.EqualTo(2));
+      Assert.That(synonyms["Xtensive.Orm"], Is.EqualTo("system"));
+      Assert.That(synonyms["Xtensive.Orm.Tests"], Is.EqualTo("theRest"));
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest04()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention4");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Default));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Synonymize));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.UnderscoreHyphens | NamingRules.RemoveDots));
+
+      var synonyms = namingConvention.NamespaceSynonyms;
+      Assert.That(synonyms.Count, Is.EqualTo(2));
+      Assert.That(synonyms["Xtensive.Orm"], Is.EqualTo("system"));
+      Assert.That(synonyms["Xtensive.Orm.Tests"], Is.EqualTo("theRest"));
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest05()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention5");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.AsIs));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.UnderscoreHyphens | NamingRules.RemoveDots));
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest06()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention6");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Hash));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.UnderscoreHyphens | NamingRules.RemoveDots));
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest07()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention7");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Omit));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.UnderscoreHyphens | NamingRules.RemoveDots));
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest08()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention8");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Default));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.UnderscoreHyphens | NamingRules.RemoveDots));
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest09()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention9");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Hash));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.UnderscoreDots | NamingRules.RemoveHyphens));
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest10()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention10");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Hash));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.None));
+
+    }
+
+    [Test]
+    public void NamingConventionSettingsTest11()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention11");
+      ValidateAllDefault(domainConfig);
+      var namingConvention = domainConfig.NamingConvention;
+      Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
+      Assert.That(namingConvention.NamespacePolicy, Is.EqualTo(NamespacePolicy.Hash));
+      Assert.That(namingConvention.NamingRules, Is.EqualTo(NamingRules.Default));
+    }
+
+    [Test]
+    public void NamingConventionInvalidSettingsTest1()
+    {
+      _ = Assert.Throws<InvalidOperationException> (()=> GetDomainConfiguration("DomainWithInvalidNamingConvention1"));
+    }
+
+    [Test]
+    public void NamingConventionInvalidSettingsTest2()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidNamingConvention2"));
+    }
+
+    [Test]
+    public void NamingConventionInvalidSettingsTest3()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidNamingConvention3"));
+    }
+
+    #endregion
+
+    #region VersioningConvention
+
+    [Test]
+    public void VersioningConventionPessimisticTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention1");
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Pessimistic));
+      Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
+    }
+
+    [Test]
+    public void VersioningConventionOptimisticTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention2");
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Optimistic));
+      Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
+    }
+
+    [Test]
+    public void VersioningConventionDefaultTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention3");
+      ValidateAllDefault(domainConfig);
+
+      Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Default));
+      Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
+    }
+
+    [Test]
+    public void VersioningConventionDenyEntitySetChangeVersionTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention4");
+      ValidateAllDefault(domainConfig);
+
+      Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Optimistic));
+      Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(true));
+    }
+
+    [Test]
+    public void VersioningConventionAllowEntitySetChangeVersionTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention5");
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Optimistic));
+      Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
+    }
+
+    [Test]
+    public void VersioningConventionInvalidTest()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidVersioningConvention1"));
+    }
+
+    #endregion
+
+    #region Types registration
+    [Test]
+    public void TypesRegistrationAsTypesTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithTypes");
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity1)), Is.True);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity2)), Is.True);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity3)), Is.False);
+    }
+
+    [Test]
+    public void TypesRegistrationAsAssembliesTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithAssemblies");
+      ValidateAllDefault(domainConfig);
+      var ormAssembly = typeof(DomainConfiguration).Assembly;
+      Assert.That(domainConfig.Types.Count, Is.GreaterThan(0));
+      Assert.That(domainConfig.Types.All((t) => t.Assembly == ormAssembly), Is.True);
+    }
+
+    [Test]
+    public void TypesRegistrationAsAssembliesWithNamespace()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithAssembliesAndNamespaces");
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity1)), Is.True);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity2)), Is.True);
+    }
+
+    [Test]
+    public void MixedTypeRegistration()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithMixedRegistrations");
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity1)), Is.True);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity2)), Is.True);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity3)), Is.False);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity1)), Is.True);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity2)), Is.True);
+    }
+
+    [Test]
+    public void InvalidTypeRegistration1()
+    {
+      // same type twice
+
+      var domainConfig = GetDomainConfiguration("DomainWithInvalidRegistrations1");
+
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity1)), Is.True);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity2)), Is.False);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity3)), Is.False);
+    }
+
+    [Test]
+    public void InvalidTypeRegistration2()
+    {
+      // same Assembly
+      var domainConfig = GetDomainConfiguration("DomainWithInvalidRegistrations2");
+
+      ValidateAllDefault(domainConfig);
+      var ormAssembly = typeof(DomainConfiguration).Assembly;
+      Assert.That(domainConfig.Types.Count, Is.GreaterThan(0));
+      Assert.That(domainConfig.Types.All((t) => t.Assembly == ormAssembly), Is.True);
+    }
+
+    [Test]
+    public void InvalidTypeRegistration3()
+    {
+      // same assembly and namespace
+      var domainConfig = GetDomainConfiguration("DomainWithInvalidRegistrations3");
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity1)), Is.True);
+      Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity2)), Is.True);
+    }
+
+    [Test]
+    public void InvalidTypeRegistration4()
+    {
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidRegistrations4"));
+    }
+
+    [Test]
+    public void InvalidTypeRegistration5()
+    {
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidRegistrations5"));
+    }
+
+    [Test]
+    public void InvalidTypeRegistration6()
+    {
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidRegistrations6"));
+    }
+
+    [Test]
+    public void InvalidTypeRegistration7()
+    {
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidRegistrations7"));
+    }
+
+    #endregion
+
+    #region Sessions
+
+    [Test]
+    public void MultipleSessionsTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithMultipleSessionConfigurations");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(2));
+      var session = sessions[0];
+      Assert.That(session.Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(session,
+        ((s) => s.CacheType, SessionCacheType.Infinite),
+        ((s) => s.BatchSize, 20),
+        ((s) => s.EntityChangeRegistrySize, 255),
+        ((s) => s.Options, SessionOptions.AllowSwitching | SessionOptions.AutoActivation | SessionOptions.ReadRemovedObjects | SessionOptions.ValidateEntityVersions));
+
+      session = sessions[1];
+      Assert.That(session.Name, Is.EqualTo(WellKnown.Sessions.System));
+      ValidateAllDefaultExcept(session,
+        ((s) => s.CacheType, SessionCacheType.Infinite),
+        ((s) => s.BatchSize, 30),
+        ((s) => s.Options, SessionOptions.ServerProfile));
+    }
+
+    [Test]
+    public void SessionWithEmptyNameTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionEmptyName");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.Options, SessionOptions.ClientProfile));
+    }
+
+    [Test]
+    public void SessionWithCustomNameTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomName");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.Not.EqualTo(WellKnown.Sessions.Default));
+      Assert.That(sessions[0].Name, Is.EqualTo("UserCreated"));
+
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.Options, SessionOptions.ClientProfile));
+    }
+
+    [Test]
+    public void SessionWithCustomUserNameTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomUser");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.UserName, "User"),
+        ((s) => s.Password, "126654"));
+    }
+
+    [Test]
+    public void SessionWithOptionsTest1()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionDefaultOptions");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.Options, SessionOptions.Default));
+
+    }
+
+    [Test]
+    public void SessionWithOptionsTest2()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionServerProfile");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+         ((s) => s.Options, SessionOptions.ServerProfile));
+
+    }
+
+    [Test]
+    public void SessionWithOptionsTest3()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionClientProfile");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.Options, SessionOptions.ClientProfile));
+
+    }
+
+    [Test]
+    public void SessionWithOptionsTest4()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomOptions");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.Options, SessionOptions.AllowSwitching | SessionOptions.AutoActivation | SessionOptions.ReadRemovedObjects | SessionOptions.ValidateEntityVersions));
+
+    }
+
+    [Test]
+    public void SessionWithCollectionSizesTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionWithCollectionSizes");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.CacheSize, 399),
+        ((s) => s.BatchSize, 20),
+        ((s) => s.EntityChangeRegistrySize, 255));
+
+    }
+
+    [Test]
+    public void SessionCustomCacheTypeTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomCacheType");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.CacheType, SessionCacheType.Infinite));
+
+    }
+
+    [Test]
+    public void SessionCustomIsolationLevelTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomIsolationLevel");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.DefaultIsolationLevel, IsolationLevel.ReadCommitted));
+
+    }
+
+    [Test]
+    public void SessionCustomCommandTimeoutTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomCommandTimeout");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.DefaultCommandTimeout, (int?)300));
+
+    }
+
+    [Test]
+    public void SessionCustomPreloadingPolicyTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomPreloadingPolicy");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.ReaderPreloading, ReaderPreloadingPolicy.Always));
+
+    }
+
+    [Test]
+    public void SessionCustomConnectionStringTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomConnectionString");
+      ValidateAllDefault(domainConfig);
+
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.ConnectionInfo, new ConnectionInfo("_dummy_", "Data Source=localhost;Initial Catalog=DO-Tests;Integrated Security=True;MultipleActiveResultSets=True")));
+    }
+
+    [Test]
+    public void SessionCustomConnectionUrlTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomConnectionUrl");
+      ValidateAllDefault(domainConfig);
+      var sessions = domainConfig.Sessions;
+      Assert.That(sessions.Count, Is.EqualTo(1));
+      Assert.That(sessions[0].Name, Is.EqualTo(WellKnown.Sessions.Default));
+      ValidateAllDefaultExcept(sessions[0],
+        ((s) => s.ConnectionInfo, new ConnectionInfo("sqlserver://localhost/DO-Tests")));
+    }
+
+    [Test]
+    public void SessionWithInvalidOptions()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithSessionInvalidOptions"));
+    }
+
+    [Test]
+    public void SessionWithInvalidCacheSizeTest1()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidCacheSize1"));
+    }
+
+    [Test]
+    public void SessionWithInvalidCacheSizeTest2()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidCacheSize2"));
+    }
+
+    [Test]
+    public void SessionWithInvalidCacheSizeTest3()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidCacheSize3"));
+    }
+
+    [Test]
+    public void SessionWithInvalidBatchSizeTest1()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidBatchSize1"));
+    }
+
+    [Test]
+    public void SessionWithInvalidBatchSizeTest2()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidBatchSize2"));
+    }
+
+    [Test]
+    public void SessionWithInvalidEntityChangeRegistryTest1()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry1"));
+    }
+
+    [Test]
+    public void SessionWithInvalidEntityChangeRegistryTest2()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry2"));
+    }
+
+    [Test]
+    public void SessionWithInvalidCacheType1()
+    {
+      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithSessionInvalidCacheType"));
+    }
+
+    #endregion
+
+    #region Databases configuration
+
+    [Test]
+    public void DatabaseConfigurationOnlyAliasTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithDatabases1");
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.Databases.Count, Is.EqualTo(2));
+      var db1 = domainConfig.Databases[0];
+      Assert.That(db1.Name, Is.EqualTo("main"));
+      Assert.That(db1.RealName, Is.EqualTo("DO-Tests-1"));
+      Assert.That(db1.MinTypeId, Is.EqualTo(Orm.Model.TypeInfo.MinTypeId));
+      Assert.That(db1.MaxTypeId, Is.EqualTo(int.MaxValue));
+      var db2 = domainConfig.Databases[1];
+      Assert.That(db2.Name, Is.EqualTo("other"));
+      Assert.That(db2.RealName, Is.EqualTo("DO-Tests-2"));
+      Assert.That(db2.MinTypeId, Is.EqualTo(Orm.Model.TypeInfo.MinTypeId));
+      Assert.That(db2.MaxTypeId, Is.EqualTo(int.MaxValue));
+    }
+
+    [Test]
+    public void DatabaseConfigurationWithTypeIdsTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithDatabases2");
+      ValidateAllDefault(domainConfig);
+      Assert.That(domainConfig.Databases.Count, Is.EqualTo(2));
+      var db1 = domainConfig.Databases[0];
+      Assert.That(db1.Name, Is.EqualTo("main"));
+      Assert.That(db1.RealName, Is.EqualTo("DO-Tests-1"));
+      Assert.That(db1.MinTypeId, Is.EqualTo(100));
+      Assert.That(db1.MaxTypeId, Is.EqualTo(1000));
+      var db2 = domainConfig.Databases[1];
+      Assert.That(db2.Name, Is.EqualTo("other"));
+      Assert.That(db2.RealName, Is.EqualTo("DO-Tests-2"));
+      Assert.That(db2.MinTypeId, Is.EqualTo(2000));
+      Assert.That(db2.MaxTypeId, Is.EqualTo(3000));
+    }
+
+    [Test]
+    public void DatabaseConfigurationNegativeMinTypeIdTest()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithInvalidDatabases1"));
+    }
+
+    [Test]
+    public void DatabaseConfigurationInvalidMinTypeIdTest()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithInvalidDatabases2"));
+    }
+
+    [Test]
+    public void DatabaseConfigurationNegativeMaxTypeIdTest()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithInvalidDatabases3"));
+    }
+
+    [Test]
+    public void DatabaseConfigurationInvalidMaxTypeIdTest()
+    {
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithInvalidDatabases4"));
+    }
+
+    #endregion
+
+    #region KeyGenerators
+
+    [Test]
+    public void SimpleKeyGeneratorTest()
+    {
+      if (!NameAttributeUnique)
+        throw new IgnoreException("");
+      var domainConfig = GetDomainConfiguration("DomainWithCustomGenerator");
+      ValidateAllDefault(domainConfig);
+    }
+
+    [Test]
+    public void KeyGeneratorWithDatabaseNamesTest()
+    {
+      if (!NameAttributeUnique)
+        throw new IgnoreException("");
+      var domainConfig = GetDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNames");
+      ValidateAllDefault(domainConfig);
+    }
+
+    [Test]
+    public void KeyGeneratorWithDatabaseNamesAllParamsTest()
+    {
+      if (!NameAttributeUnique)
+        throw new IgnoreException("");
+      var domainConfig = GetDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNamesAndKeyParams");
+      ValidateAllDefault(domainConfig);
+    }
+
+    [Test]
+    public void KeyGeneratorsWithDatabaseAliasesTest()
+    {
+      if (!NameAttributeUnique)
+        throw new IgnoreException("");
+      var domainConfig = GetDomainConfiguration("DomainWithCustomGeneratorsWithDatabasesAliases");
+      ValidateAllDefault(domainConfig);
+    }
+
+    [Test]
+    public void KeyGeneratorsWithConflictByDatabaseTest1()
+    {
+      if (!NameAttributeUnique)
+        throw new IgnoreException("");
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithCustomGeneratorsConflict1"));
+    }
+
+    [Test]
+    public void KeyGeneratorsWithConflictByDatabaseTest2()
+    {
+      if (!NameAttributeUnique)
+        throw new IgnoreException("");
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithCustomGeneratorsConflict2"));
+    }
+
+    [Test]
+    public void KeyGeneratorWithNegativeSeedTest()
+    {
+      if (!NameAttributeUnique)
+        throw new IgnoreException("");
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomGeneratorNegativeSeed"));
+    }
+
+    [Test]
+    public void KeyGeneratorWithNegativeCacheSizeTest()
+    {
+      if (!NameAttributeUnique)
+        throw new IgnoreException("");
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomGeneratorNegativeCache"));
+    }
+
+    #endregion
+
+    #region IgnoreRules
+
+    [Test]
+    public void IgnoreRulesTest()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithIgnoreRules");
+      ValidateAllDefault(domainConfig);
+      ValidateIgnoreRules(domainConfig.IgnoreRules);
+    }
+
+    [Test]
+    public void IgnoreColumnAndIndexAtTheSameTimeTest()
+    {
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidIgnoreRules1"));
+    }
+
+    [Test]
+    public void IgnoreTableAndColumnAndIndexAtTheSameTimeTest()
+    {
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidIgnoreRules2"));
+    }
+
+    [Test]
+    public void IgnoreDatabaseOnlyTest()
+    {
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidIgnoreRules3"));
+    }
+
+    [Test]
+    public void IgnoreDatabaseAndSchemaOnlyTest()
+    {
+      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidIgnoreRules4"));
+    }
+
+    private void ValidateIgnoreRules(IgnoreRuleCollection rules)
+    {
+      Assert.That(rules.Count, Is.EqualTo(18));
+
+      var rule = rules[0];
+      Assert.That(rule.Database, Is.EqualTo("Other-DO40-Tests"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema1"));
+      Assert.That(rule.Table, Is.EqualTo("table1"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[1];
+      Assert.That(rule.Database, Is.EqualTo("some-database"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema2"));
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.EqualTo("column2"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[2];
+      Assert.That(rule.Database, Is.EqualTo("some-database"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema2"));
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index2"));
+
+      rule = rules[3];
+      Assert.That(rule.Database, Is.EqualTo("some-database"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema3"));
+      Assert.That(rule.Table, Is.EqualTo("table2"));
+      Assert.That(rule.Column, Is.EqualTo("col3"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[4];
+      Assert.That(rule.Database, Is.EqualTo("some-database"));
+      Assert.That(rule.Schema, Is.EqualTo("some-schema3"));
+      Assert.That(rule.Table, Is.EqualTo("table2"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index3"));
+
+      rule = rules[5];
+      Assert.That(rule.Database, Is.EqualTo("another-some-database"));
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.EqualTo("some-table"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[6];
+      Assert.That(rule.Database, Is.EqualTo("database1"));
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.EqualTo("some-column"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[7];
+      Assert.That(rule.Database, Is.EqualTo("database1"));
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("some-index"));
+
+      rule = rules[8];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.EqualTo("table1"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[9];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.EqualTo("column2"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[10];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index2"));
+
+      rule = rules[11];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.EqualTo("table2"));
+      Assert.That(rule.Column, Is.EqualTo("column3"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[12];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.EqualTo("schema1"));
+      Assert.That(rule.Table, Is.EqualTo("table2"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index3"));
+
+      rule = rules[13];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.EqualTo("table4"));
+      Assert.That(rule.Column, Is.EqualTo("column3"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[14];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.EqualTo("table4"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("index2"));
+
+      rule = rules[15];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.EqualTo("single-table"));
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[16];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.EqualTo("single-column"));
+      Assert.That(rule.Index, Is.Null.Or.Empty);
+
+      rule = rules[17];
+      Assert.That(rule.Database, Is.Null.Or.Empty);
+      Assert.That(rule.Schema, Is.Null.Or.Empty);
+      Assert.That(rule.Table, Is.Null.Or.Empty);
+      Assert.That(rule.Column, Is.Null.Or.Empty);
+      Assert.That(rule.Index, Is.EqualTo("single-index"));
+    }
+
+    #endregion
+
+    #region MappingRules
+
+    [Test]
+    public void MappingRulesTest1()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithMappingRules1");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.DefaultDatabase, "main"),
+        ((d) => d.DefaultSchema, "dbo"),
+        ((d) => d.IsMultidatabase, true),
+        ((d) => d.IsMultischema, true));
+      var rules = domainConfig.MappingRules;
+
+      Assert.That(rules.Count, Is.EqualTo(1));
+      var rule = rules[0];
+      Assert.That(rule.Assembly, Is.EqualTo(typeof(JsonConfigurationTest).Assembly));
+      Assert.That(rule.Namespace, Is.Null);
+      Assert.That(rule.Database, Is.EqualTo("DO-Tests-1"));
+      Assert.That(rule.Schema, Is.Null);
+    }
+
+    [Test]
+    public void MappingRulesTest2()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithMappingRules2");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.DefaultDatabase, "main"),
+        ((d) => d.DefaultSchema, "dbo"),
+        ((d) => d.IsMultidatabase, true),
+        ((d) => d.IsMultischema, true));
+      var rules = domainConfig.MappingRules;
+
+      Assert.That(rules.Count, Is.EqualTo(1));
+      var rule = rules[0];
+      Assert.That(rule.Assembly, Is.EqualTo(typeof(JsonConfigurationTest).Assembly));
+      Assert.That(rule.Namespace, Is.Null);
+      Assert.That(rule.Database, Is.Null);
+      Assert.That(rule.Schema, Is.EqualTo("Model1"));
+
+     
+    }
+
+    [Test]
+    public void MappingRulesTest3()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithMappingRules3");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.DefaultDatabase, "main"),
+        ((d) => d.DefaultSchema, "dbo"),
+        ((d) => d.IsMultidatabase, true),
+        ((d) => d.IsMultischema, true));
+      var rules = domainConfig.MappingRules;
+
+      Assert.That(rules.Count, Is.EqualTo(1));
+      var rule = rules[0];
+
+      Assert.That(rule.Assembly, Is.Null);
+      Assert.That(rule.Namespace, Is.EqualTo("Xtensive.Orm.Configuration.Options"));
+      Assert.That(rule.Database, Is.EqualTo("DO-Tests-2"));
+      Assert.That(rule.Schema, Is.Null);
+    }
+
+    [Test]
+    public void MappingRulesTest4()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithMappingRules4");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.DefaultDatabase, "main"),
+        ((d) => d.DefaultSchema, "dbo"),
+        ((d) => d.IsMultidatabase, true),
+        ((d) => d.IsMultischema, true));
+      var rules = domainConfig.MappingRules;
+
+      Assert.That(rules.Count, Is.EqualTo(1));
+      var rule = rules[0];
+
+      Assert.That(rule.Assembly, Is.Null);
+      Assert.That(rule.Namespace, Is.EqualTo("Xtensive.Orm.Tests.Configuration"));
+      Assert.That(rule.Database, Is.Null);
+      Assert.That(rule.Schema, Is.EqualTo("Model2"));
+    }
+
+    [Test]
+    public void MappingRulesTest5()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithMappingRules5");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.DefaultDatabase, "main"),
+        ((d) => d.DefaultSchema, "dbo"),
+        ((d) => d.IsMultidatabase, true),
+        ((d) => d.IsMultischema, true));
+      var rules = domainConfig.MappingRules;
+
+      Assert.That(rules.Count, Is.EqualTo(1));
+      var rule = rules[0];
+
+      Assert.That(rule.Assembly, Is.EqualTo(typeof (JsonConfigurationTest).Assembly));
+      Assert.That(rule.Namespace, Is.EqualTo("Xtensive.Orm.Tests.Configuration.TypesToUseInTests"));
+      Assert.That(rule.Database, Is.EqualTo("DO-Tests-3"));
+      Assert.That(rule.Schema, Is.Null);
+    }
+
+    [Test]
+    public void MappingRulesTest6()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithMappingRules6");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.DefaultDatabase, "main"),
+        ((d) => d.DefaultSchema, "dbo"),
+        ((d) => d.IsMultidatabase, true),
+        ((d) => d.IsMultischema, true));
+      var rules = domainConfig.MappingRules;
+
+      Assert.That(rules.Count, Is.EqualTo(1));
+      var rule = rules[0];
+      Assert.That(rule.Assembly, Is.EqualTo(typeof(JsonConfigurationTest).Assembly));
+      Assert.That(rule.Namespace, Is.EqualTo("Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"));
+      Assert.That(rule.Database, Is.Null);
+      Assert.That(rule.Schema, Is.EqualTo("Model3"));
+    }
+
+    [Test]
+    public void MappingRulesTest7()
+    {
+      var domainConfig = GetDomainConfiguration("DomainWithMappingRules7");
+      ValidateAllDefaultExcept(domainConfig,
+        ((d) => d.DefaultDatabase, "main"),
+        ((d) => d.DefaultSchema, "dbo"),
+        ((d) => d.IsMultidatabase, true),
+        ((d) => d.IsMultischema, true));
+      var rules = domainConfig.MappingRules;
+
+      Assert.That(rules.Count, Is.EqualTo(1));
+      var rule = rules[0];
+      Assert.That(rule.Assembly, Is.EqualTo(typeof(JsonConfigurationTest).Assembly));
+      Assert.That(rule.Namespace, Is.EqualTo("Xtensive.Orm.Tests.Indexing"));
+      Assert.That(rule.Database, Is.EqualTo("main"));
+      Assert.That(rule.Schema, Is.EqualTo("Model4"));
+    }
+
+    [Test]
+    public void MappingRuleWithConflictByAssemblyTest()
+    {
+      var exception = Assert.Throws<System.ArgumentException>(
+        () => GetDomainConfiguration("DomainWithConflictMappingRules1"));
+    }
+
+    [Test]
+    public void MappingRuleWithConflictByNamespaceTest()
+    {
+      var exception = Assert.Throws<System.ArgumentException>(
+        () => GetDomainConfiguration("DomainWithConflictMappingRules2"));
+    }
+
+    [Test]
+    public void MappingRulesInvalidTest1()
+    {
+      var exception = Assert.Throws<System.ArgumentException>(
+        () => GetDomainConfiguration("DomainWithInvalidMappingRules1"));
+    }
+
+    [Test]
+    public void MappingRulesInvalidTest2()
+    {
+      var exception = Assert.Throws<System.ArgumentException>(
+        () => GetDomainConfiguration("DomainWithInvalidMappingRules2"));
+    }
+
+    [Test]
+    public void MappingRulesInvalidTest3()
+    {
+      var exception = Assert.Throws<System.ArgumentException>(
+        () => GetDomainConfiguration("DomainWithInvalidMappingRules3"));
+    }
+
+    [Test]
+    public void MappingRulesInvalidTest4()
+    {
+      var exception = Assert.Throws<System.ArgumentException>(
+        () => GetDomainConfiguration("DomainWithInvalidMappingRules4"));
+    }
+
+    [Test]
+    public void MappingRulesInvalidTest5()
+    {
+      var exception = Assert.Throws<System.ArgumentException>(
+        () => GetDomainConfiguration("DomainWithInvalidMappingRules5"));
+    }
+
+    #endregion
+
+
+
+    private void ValidateAllDefault(DomainConfiguration domainConfiguration)
+    {
+      Assert.That(domainConfiguration.AllowCyclicDatabaseDependencies, Is.EqualTo(DomainConfiguration.DefaultAllowCyclicDatabaseDependencies));
+      Assert.That(domainConfiguration.BuildInParallel, Is.EqualTo(DomainConfiguration.DefaultBuildInParallel));
+      Assert.That(domainConfiguration.Collation, Is.EqualTo(string.Empty));
+      Assert.That(domainConfiguration.ConnectionInitializationSql, Is.EqualTo(string.Empty));
+      Assert.That(domainConfiguration.DefaultDatabase, Is.EqualTo(string.Empty));
+      Assert.That(domainConfiguration.DefaultSchema, Is.EqualTo(string.Empty));
+      Assert.That(domainConfiguration.EnsureConnectionIsAlive, Is.EqualTo(DomainConfiguration.DefaultEnsureConnectionIsAlive));
+      Assert.That(domainConfiguration.ForcedServerVersion, Is.EqualTo(string.Empty));
+      Assert.That(domainConfiguration.ForeignKeyMode, Is.EqualTo(DomainConfiguration.DefaultForeignKeyMode));
+      Assert.That(domainConfiguration.FullTextChangeTrackingMode, Is.EqualTo(DomainConfiguration.DefaultFullTextChangeTrackingMode));
+      Assert.That(domainConfiguration.IncludeSqlInExceptions, Is.EqualTo(DomainConfiguration.DefaultIncludeSqlInExceptions));
+      Assert.That(domainConfiguration.IsMultidatabase, Is.False);
+      Assert.That(domainConfiguration.IsMultischema, Is.False);
+      Assert.That(domainConfiguration.KeyCacheSize, Is.EqualTo(DomainConfiguration.DefaultKeyCacheSize));
+      Assert.That(domainConfiguration.KeyGeneratorCacheSize, Is.EqualTo(DomainConfiguration.DefaultKeyGeneratorCacheSize));
+      Assert.That(domainConfiguration.MultidatabaseKeys, Is.EqualTo(DomainConfiguration.DefaultMultidatabaseKeys));
+      Assert.That(domainConfiguration.Options, Is.EqualTo(DomainConfiguration.DefaultDomainOptions));
+      Assert.That(domainConfiguration.PreferTypeIdsAsQueryParameters, Is.EqualTo(DomainConfiguration.DefaultPreferTypeIdsAsQueryParameters));
+      Assert.That(domainConfiguration.QueryCacheSize, Is.EqualTo(DomainConfiguration.DefaultQueryCacheSize));
+      Assert.That(domainConfiguration.RecordSetMappingCacheSize, Is.EqualTo(DomainConfiguration.DefaultRecordSetMappingCacheSize));
+      Assert.That(domainConfiguration.SchemaSyncExceptionFormat, Is.EqualTo(DomainConfiguration.DefaultSchemaSyncExceptionFormat));
+      Assert.That(domainConfiguration.ShareStorageSchemaOverNodes, Is.EqualTo(DomainConfiguration.DefaultShareStorageSchemaOverNodes));
+      Assert.That(domainConfiguration.TagsLocation, Is.EqualTo(DomainConfiguration.DefaultTagLocation));
+      Assert.That(domainConfiguration.UpgradeMode, Is.EqualTo(DomainConfiguration.DefaultUpgradeMode));
+    }
+
+    private void ValidateAllDefault(SessionConfiguration sessionConfiguration)
+    {
+      Assert.That(sessionConfiguration.UserName, Is.Empty);
+      Assert.That(sessionConfiguration.Password, Is.Empty);
+      Assert.That(sessionConfiguration.Options, Is.EqualTo(SessionConfiguration.DefaultSessionOptions));
+      Assert.That(sessionConfiguration.CacheSize, Is.EqualTo(SessionConfiguration.DefaultCacheSize));
+      Assert.That(sessionConfiguration.CacheType, Is.EqualTo(SessionConfiguration.DefaultCacheType));
+      Assert.That(sessionConfiguration.DefaultIsolationLevel, Is.EqualTo(SessionConfiguration.DefaultDefaultIsolationLevel));
+      Assert.That(sessionConfiguration.DefaultCommandTimeout, Is.Null);
+      Assert.That(sessionConfiguration.BatchSize, Is.EqualTo(SessionConfiguration.DefaultBatchSize));
+      Assert.That(sessionConfiguration.EntityChangeRegistrySize, Is.EqualTo(SessionConfiguration.DefaultEntityChangeRegistrySize));
+      Assert.That(sessionConfiguration.ReaderPreloading, Is.EqualTo(SessionConfiguration.DefaultReaderPreloadingPolicy));
+      Assert.That(sessionConfiguration.ServiceContainerType, Is.Null);
+      Assert.That(sessionConfiguration.ConnectionInfo, Is.Null);
+    }
+
+    private void ValidateAllDefaultExcept<TConfiguration, T1>(TConfiguration configuration,
+      (Expression<Func<TConfiguration, T1>> expression, T1 expectedValue) property)
+    {
+      Assert.That(configuration, Is.Not.Null);
+      var excludedProperties = new List<string>();
+
+
+      if (!TryExtractPropertyFormLambda(property.expression, out var prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property.expression.Compile()(configuration),
+        Is.EqualTo(property.expectedValue));
+
+      excludedProperties.Add(prop.Name);
+
+      if (configuration is DomainConfiguration domainConfiguration)
+        ValidateAllPropertiesExcept(domainConfiguration, excludedProperties);
+      else if (configuration is SessionConfiguration sessionConfiguration)
+        ValidateAllPropertiesExcept(sessionConfiguration, excludedProperties);
+      else
+        throw new ArgumentOutOfRangeException(nameof(configuration));
+
+    }
+
+
+    private void ValidateAllDefaultExcept<TConfiguration, T1, T2>(TConfiguration configuration,
+      (Expression<Func<TConfiguration, T1>> expression, T1 expectedValue) property1,
+      (Expression<Func<TConfiguration, T2>> expression, T2 expectedValue) property2)
+    {
+      Assert.That(configuration, Is.Not.Null);
+      var excludedProperties = new List<string>();
+
+      if (!TryExtractPropertyFormLambda(property1.expression, out var prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property1.expression.Compile()(configuration),
+        Is.EqualTo(property1.expectedValue));
+
+      excludedProperties.Add(prop.Name);
+
+      if (!TryExtractPropertyFormLambda(property2.expression, out prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property2.expression.Compile()(configuration),
+        Is.EqualTo(property2.expectedValue));
+
+      excludedProperties.Add(prop.Name);
+
+      if(configuration is DomainConfiguration domainConfiguration)
+        ValidateAllPropertiesExcept(domainConfiguration, excludedProperties);
+      else if (configuration is SessionConfiguration sessionConfiguration)
+        ValidateAllPropertiesExcept(sessionConfiguration, excludedProperties);
+      else
+        throw new ArgumentOutOfRangeException(nameof(configuration));
+    }
+
+    private void ValidateAllDefaultExcept<TConfiguration, T1, T2, T3>(TConfiguration configuration,
+      (Expression<Func<TConfiguration, T1>> expression, T1 expectedValue) property1,
+      (Expression<Func<TConfiguration, T2>> expression, T2 expectedValue) property2,
+      (Expression<Func<TConfiguration, T3>> expression, T3 expectedValue) property3)
+    {
+      Assert.That(configuration, Is.Not.Null);
+      var excludedProperties = new List<string>();
+
+      if (!TryExtractPropertyFormLambda(property1.expression, out var prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property1.expression.Compile()(configuration),
+        Is.EqualTo(property1.expectedValue));
+
+      excludedProperties.Add(prop.Name);
+
+      if (!TryExtractPropertyFormLambda(property2.expression, out prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property2.expression.Compile()(configuration),
+        Is.EqualTo(property2.expectedValue));
+
+      excludedProperties.Add(prop.Name);
+
+      if (!TryExtractPropertyFormLambda(property3.expression, out prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property3.expression.Compile()(configuration),
+        Is.EqualTo(property3.expectedValue));
+
+      excludedProperties.Add(prop.Name);
+
+      if (configuration is DomainConfiguration domainConfiguration)
+        ValidateAllPropertiesExcept(domainConfiguration, excludedProperties);
+      else if (configuration is SessionConfiguration sessionConfiguration)
+        ValidateAllPropertiesExcept(sessionConfiguration, excludedProperties);
+      else
+        throw new ArgumentOutOfRangeException(nameof(configuration));
+    }
+
+    private void ValidateAllDefaultExcept<TConfiguration, T1, T2, T3, T4>(TConfiguration configuration,
+      (Expression<Func<TConfiguration, T1>> expression, T1 expectedValue) property1,
+      (Expression<Func<TConfiguration, T2>> expression, T2 expectedValue) property2,
+      (Expression<Func<TConfiguration, T3>> expression, T3 expectedValue) property3,
+      (Expression<Func<TConfiguration, T4>> expression, T4 expectedValue) property4)
+    {
+      Assert.That(configuration, Is.Not.Null);
+      var excludedProperties = new List<string>();
+
+      if (!TryExtractPropertyFormLambda(property1.expression, out var prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property1.expression.Compile()(configuration),
+        Is.EqualTo(property1.expectedValue));
+
+      excludedProperties.Add(prop.Name);
+
+      if (!TryExtractPropertyFormLambda(property2.expression, out prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property2.expression.Compile()(configuration),
+        Is.EqualTo(property2.expectedValue));
+      
+      excludedProperties.Add(prop.Name);
+
+      if (!TryExtractPropertyFormLambda(property3.expression, out prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property3.expression.Compile()(configuration),
+        Is.EqualTo(property3.expectedValue));
+
+      excludedProperties.Add(prop.Name);
+
+      if (!TryExtractPropertyFormLambda(property4.expression, out prop))
+        throw new InconclusiveException("");
+
+      Assert.That(property4.expression.Compile()(configuration),
+        Is.EqualTo(property4.expectedValue));
+
+      excludedProperties.Add(prop.Name);
+
+      if (configuration is DomainConfiguration domainConfiguration)
+        ValidateAllPropertiesExcept(domainConfiguration, excludedProperties);
+      else if (configuration is SessionConfiguration sessionConfiguration)
+        ValidateAllPropertiesExcept(sessionConfiguration, excludedProperties);
+      else
+        throw new ArgumentOutOfRangeException(nameof(configuration));
+    }
+
+    public bool TryExtractPropertyFormLambda<TConfiguration, T>(Expression<Func<TConfiguration, T>> lambda,
+      out System.Reflection.PropertyInfo property)
+    {
+      if (lambda.Body.StripCasts() is MemberExpression mExpression && mExpression.Member is System.Reflection.PropertyInfo prop) {
+        property = prop;
+        return true;
+      }
+      property = null;
+      return false;
+    }
+
+    private void ValidateAllPropertiesExcept(DomainConfiguration domainConfiguration, List<string> excludedProperties)
+    {
+      if (!nameof(domainConfiguration.AllowCyclicDatabaseDependencies).In(excludedProperties))
+        Assert.That(domainConfiguration.AllowCyclicDatabaseDependencies, Is.EqualTo(DomainConfiguration.DefaultAllowCyclicDatabaseDependencies));
+
+      if (!nameof(domainConfiguration.BuildInParallel).In(excludedProperties))
+        Assert.That(domainConfiguration.BuildInParallel, Is.EqualTo(DomainConfiguration.DefaultBuildInParallel));
+
+      if (!nameof(domainConfiguration.Collation).In(excludedProperties))
+        Assert.That(domainConfiguration.Collation, Is.EqualTo(string.Empty));
+
+      if (!nameof(domainConfiguration.ConnectionInitializationSql).In(excludedProperties))
+        Assert.That(domainConfiguration.ConnectionInitializationSql, Is.EqualTo(string.Empty));
+
+      if (!nameof(domainConfiguration.DefaultDatabase).In(excludedProperties))
+        Assert.That(domainConfiguration.DefaultDatabase, Is.EqualTo(string.Empty));
+
+      if (!nameof(domainConfiguration.DefaultSchema).In(excludedProperties))
+        Assert.That(domainConfiguration.DefaultSchema, Is.EqualTo(string.Empty));
+
+      if (!nameof(domainConfiguration.EnsureConnectionIsAlive).In(excludedProperties))
+        Assert.That(domainConfiguration.EnsureConnectionIsAlive, Is.EqualTo(DomainConfiguration.DefaultEnsureConnectionIsAlive));
+
+      if (!nameof(domainConfiguration.ForcedServerVersion).In(excludedProperties))
+        Assert.That(domainConfiguration.ForcedServerVersion, Is.EqualTo(string.Empty));
+
+      if (!nameof(domainConfiguration.ForeignKeyMode).In(excludedProperties))
+        Assert.That(domainConfiguration.ForeignKeyMode, Is.EqualTo(DomainConfiguration.DefaultForeignKeyMode));
+
+      if (!nameof(domainConfiguration.FullTextChangeTrackingMode).In(excludedProperties))
+        Assert.That(domainConfiguration.FullTextChangeTrackingMode, Is.EqualTo(DomainConfiguration.DefaultFullTextChangeTrackingMode));
+
+      if (!nameof(domainConfiguration.IncludeSqlInExceptions).In(excludedProperties))
+        Assert.That(domainConfiguration.IncludeSqlInExceptions, Is.EqualTo(DomainConfiguration.DefaultIncludeSqlInExceptions));
+
+      if (!nameof(domainConfiguration.IsMultidatabase).In(excludedProperties))
+        Assert.That(domainConfiguration.IsMultidatabase, Is.False);
+
+      if (!nameof(domainConfiguration.IsMultischema).In(excludedProperties))
+        Assert.That(domainConfiguration.IsMultischema, Is.False);
+
+      if (!nameof(domainConfiguration.KeyCacheSize).In(excludedProperties))
+        Assert.That(domainConfiguration.KeyCacheSize, Is.EqualTo(DomainConfiguration.DefaultKeyCacheSize));
+
+      if (!nameof(domainConfiguration.KeyGeneratorCacheSize).In(excludedProperties))
+        Assert.That(domainConfiguration.KeyGeneratorCacheSize, Is.EqualTo(DomainConfiguration.DefaultKeyGeneratorCacheSize));
+
+      if (!nameof(domainConfiguration.MultidatabaseKeys).In(excludedProperties))
+        Assert.That(domainConfiguration.MultidatabaseKeys, Is.EqualTo(DomainConfiguration.DefaultMultidatabaseKeys));
+
+      if (!nameof(domainConfiguration.Options).In(excludedProperties))
+        Assert.That(domainConfiguration.Options, Is.EqualTo(DomainConfiguration.DefaultDomainOptions));
+
+      if (!nameof(domainConfiguration.PreferTypeIdsAsQueryParameters).In(excludedProperties))
+        Assert.That(domainConfiguration.PreferTypeIdsAsQueryParameters, Is.EqualTo(DomainConfiguration.DefaultPreferTypeIdsAsQueryParameters));
+
+      if (!nameof(domainConfiguration.QueryCacheSize).In(excludedProperties))
+        Assert.That(domainConfiguration.QueryCacheSize, Is.EqualTo(DomainConfiguration.DefaultQueryCacheSize));
+
+      if (!nameof(domainConfiguration.RecordSetMappingCacheSize).In(excludedProperties))
+        Assert.That(domainConfiguration.RecordSetMappingCacheSize, Is.EqualTo(DomainConfiguration.DefaultRecordSetMappingCacheSize));
+
+      if (!nameof(domainConfiguration.SchemaSyncExceptionFormat).In(excludedProperties))
+        Assert.That(domainConfiguration.SchemaSyncExceptionFormat, Is.EqualTo(DomainConfiguration.DefaultSchemaSyncExceptionFormat));
+
+      if (!nameof(domainConfiguration.ShareStorageSchemaOverNodes).In(excludedProperties))
+        Assert.That(domainConfiguration.ShareStorageSchemaOverNodes, Is.EqualTo(DomainConfiguration.DefaultShareStorageSchemaOverNodes));
+
+      if (!nameof(domainConfiguration.TagsLocation).In(excludedProperties))
+        Assert.That(domainConfiguration.TagsLocation, Is.EqualTo(DomainConfiguration.DefaultTagLocation));
+
+      if (!nameof(domainConfiguration.UpgradeMode).In(excludedProperties))
+        Assert.That(domainConfiguration.UpgradeMode, Is.EqualTo(DomainConfiguration.DefaultUpgradeMode));
+    }
+
+    private void ValidateAllPropertiesExcept(SessionConfiguration sessionConfiguration, List<string> excludedProperties)
+    {
+      if (!nameof(sessionConfiguration.UserName).In(excludedProperties))
+        Assert.That(sessionConfiguration.UserName, Is.Empty);
+
+      if (!nameof(sessionConfiguration.Password).In(excludedProperties))
+        Assert.That(sessionConfiguration.Password, Is.Empty);
+
+      if (!nameof(sessionConfiguration.Options).In(excludedProperties))
+        Assert.That(sessionConfiguration.Options, Is.EqualTo(SessionConfiguration.DefaultSessionOptions));
+
+      if (!nameof(sessionConfiguration.CacheSize).In(excludedProperties))
+        Assert.That(sessionConfiguration.CacheSize, Is.EqualTo(SessionConfiguration.DefaultCacheSize));
+
+      if (!nameof(sessionConfiguration.CacheType).In(excludedProperties))
+        Assert.That(sessionConfiguration.CacheType, Is.EqualTo(SessionConfiguration.DefaultCacheType));
+
+      if (!nameof(sessionConfiguration.DefaultIsolationLevel).In(excludedProperties))
+        Assert.That(sessionConfiguration.DefaultIsolationLevel, Is.EqualTo(SessionConfiguration.DefaultDefaultIsolationLevel));
+
+      if (!nameof(sessionConfiguration.DefaultCommandTimeout).In(excludedProperties))
+        Assert.That(sessionConfiguration.DefaultCommandTimeout, Is.Null);
+
+      if (!nameof(sessionConfiguration.BatchSize).In(excludedProperties))
+        Assert.That(sessionConfiguration.BatchSize, Is.EqualTo(SessionConfiguration.DefaultBatchSize));
+
+      if (!nameof(sessionConfiguration.EntityChangeRegistrySize).In(excludedProperties))
+        Assert.That(sessionConfiguration.EntityChangeRegistrySize, Is.EqualTo(SessionConfiguration.DefaultEntityChangeRegistrySize));
+
+      if (!nameof(sessionConfiguration.ReaderPreloading).In(excludedProperties))
+        Assert.That(sessionConfiguration.ReaderPreloading, Is.EqualTo(SessionConfiguration.DefaultReaderPreloadingPolicy));
+
+      if (!nameof(sessionConfiguration.ServiceContainerType).In(excludedProperties))
+        Assert.That(sessionConfiguration.ServiceContainerType, Is.Null);
+
+      if (!nameof(sessionConfiguration.ConnectionInfo).In(excludedProperties))
+        Assert.That(sessionConfiguration.ConnectionInfo, Is.Null);
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Configuration/ModernConfigurationTests.cs
+++ b/Orm/Xtensive.Orm.Tests/Configuration/ModernConfigurationTests.cs
@@ -75,6 +75,7 @@ namespace Xtensive.Orm.Tests.Configuration
   public sealed class AppConfigStyleConfigurationTest : ConfigurationFileTestBase
   {
     protected override string DefaultSectionName => "Xtensive.Orm.AppConfig";
+    protected override string Postfix => "AppConfig";
 
     protected override bool NameAttributeUnique => false;
 
@@ -88,6 +89,7 @@ namespace Xtensive.Orm.Tests.Configuration
   public sealed class XmlConfigurationTest : ConfigurationFileTestBase
   {
     protected override string DefaultSectionName => "Xtensive.Orm.Xml";
+    protected override string Postfix => "Xml";
 
     protected override void RegisterConfigurationFile(ConfigurationBuilder builder)
     {
@@ -99,6 +101,7 @@ namespace Xtensive.Orm.Tests.Configuration
   public sealed class JsonConfigurationTest : ConfigurationFileTestBase
   {
     protected override string DefaultSectionName => "Xtensive.Orm.Json";
+    protected override string Postfix => "Json";
 
     protected override void RegisterConfigurationFile(ConfigurationBuilder builder)
     {
@@ -113,6 +116,7 @@ namespace Xtensive.Orm.Tests.Configuration
     private IConfigurationSection configurationSection;
 
     protected abstract string DefaultSectionName { get; }
+    protected abstract string Postfix { get; }
     protected virtual bool NameAttributeUnique => true;
 
     [OneTimeSetUp]
@@ -132,18 +136,24 @@ namespace Xtensive.Orm.Tests.Configuration
 
     protected abstract void RegisterConfigurationFile(ConfigurationBuilder builder);
 
-    private DomainConfiguration GetDomainConfiguration(string domainName)
+    private DomainConfiguration LoadDomainConfiguration(string domainName)
     {
       var domainConfiguration = DomainConfiguration.Load(configurationSection, domainName);
       return domainConfiguration;
     }
+    private LoggingConfiguration LoadLoggingConfiguration(IConfigurationSection customConfigurationSection = null)
+    {
+      var loggingConfiguration = LoggingConfiguration.Load(customConfigurationSection ?? configurationSection);
+      return loggingConfiguration;
+    }
+
 
     #region Simple Domain settings that used to be attributes
 
     [Test]
     public void ProviderAndConnectionStringTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithProviderAndConnectionString");
+      var domainConfig = LoadDomainConfiguration("DomainWithProviderAndConnectionString");
       Assert.That(domainConfig.ConnectionInfo.Provider, Is.EqualTo(WellKnown.Provider.Sqlite));
       Assert.That(domainConfig.ConnectionInfo.ConnectionString, Is.EqualTo("Data Source=DO-Testsaaa.db3"));
       Assert.That(domainConfig.ConnectionInfo.ConnectionUrl, Is.Null);
@@ -154,7 +164,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void ConnectionUrlTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithConnectionUrl");
+      var domainConfig = LoadDomainConfiguration("DomainWithConnectionUrl");
       Assert.That(domainConfig.ConnectionInfo.Provider, Is.EqualTo(WellKnown.Provider.Sqlite));
       Assert.That(domainConfig.ConnectionInfo.ConnectionString, Is.Null);
       Assert.That(domainConfig.ConnectionInfo.ConnectionUrl.Url, Is.EqualTo("sqlite:///DO-Tests.db3"));
@@ -165,7 +175,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void CustomValidKeyCacheSizeTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithCustomValidKeyCacheSize");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidKeyCacheSize");
 
       ValidateAllDefaultExcept(domainConfig, ((d) => d.KeyCacheSize, 192));
     }
@@ -173,14 +183,14 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void CustomInvalidKeyCacheSizeTest()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomInvalidKeyCacheSize"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidKeyCacheSize"));
 
     }
 
     [Test]
     public void CustomValidKeyGeneratorCacheSizeTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithCustomValidKeyGeneratorCacheSize");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidKeyGeneratorCacheSize");
 
       ValidateAllDefaultExcept(domainConfig, ((d) => d.KeyGeneratorCacheSize, 192));
     }
@@ -188,13 +198,13 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void CustomInvalidKeyGeneratorCacheSizeTest()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomInvalidKeyGeneratorCacheSize"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidKeyGeneratorCacheSize"));
     }
 
     [Test]
     public void CustomValidQueryCacheSizeTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithCustomValidQueryCacheSize");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidQueryCacheSize");
 
       ValidateAllDefaultExcept(domainConfig, ((d) => d.QueryCacheSize, 192));
     }
@@ -202,26 +212,26 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void CustomInvalidQueryCacheSizeTest()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomInvalidQueryCacheSize"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidQueryCacheSize"));
     }
 
     [Test]
     public void CustomValidRecordSetMappingCacheSizeTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithCustomValidRecordSetMappingCacheSize");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomValidRecordSetMappingCacheSize");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.RecordSetMappingCacheSize, 192));
     }
 
     [Test]
     public void CustomInvalidRecordSetMappingCacheSizeTest()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomInvalidRecordSetMappingCacheSize"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomInvalidRecordSetMappingCacheSize"));
     }
 
     [Test]
     public void CustomDefaultDatabaseTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithCustomDatabase");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomDatabase");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "MyFancyDatabase"),
         ((d) => d.IsMultidatabase, true),
@@ -232,7 +242,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void CustomDefaultSchemaTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithCustomSchema");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomSchema");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultSchema, "MyFancySchema"),
         ((d) => d.IsMultidatabase, false),
@@ -242,42 +252,42 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void UpgradeModesTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithUpgradeMode1");
+      var domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode1");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Default));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode2");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode2");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Recreate));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode3");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode3");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Perform));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode4");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode4");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.PerformSafely));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode5");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode5");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Validate));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode6");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode6");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.LegacyValidate));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode7");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode7");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.Skip));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithUpgradeMode8");
+      domainConfig = LoadDomainConfiguration("DomainWithUpgradeMode8");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.UpgradeMode, DomainUpgradeMode.LegacySkip));
       domainConfig.Lock();
@@ -286,33 +296,33 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void WrongUpgradeModeTest()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithWrongUpgradeMode"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithWrongUpgradeMode"));
     }
 
     [Test]
     public void ForeighKeyModesTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode1");
+      var domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode1");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.None));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode2");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode2");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Hierarchy));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode3");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode3");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Reference));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode4");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode4");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.All));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode5");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode5");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Default));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithForeignKeyMode6");
+      domainConfig = LoadDomainConfiguration("DomainWithForeignKeyMode6");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.ForeignKeyMode, ForeignKeyMode.Hierarchy | ForeignKeyMode.Reference));
       domainConfig.Lock();
     }
@@ -320,29 +330,29 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void InvalidForeighKeyModeTest()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidForeignKeyMode"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidForeignKeyMode"));
     }
 
     [Test]
     public void ChangeTrackingModesTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode1");
+      var domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode1");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Off));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode2");
+      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode2");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Auto));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode3");
+      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode3");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Manual));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode4");
+      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode4");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.OffWithNoPopulation));
       domainConfig.Lock();
 
-      domainConfig = GetDomainConfiguration("DomainWithChangeTrackingMode5");
+      domainConfig = LoadDomainConfiguration("DomainWithChangeTrackingMode5");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.FullTextChangeTrackingMode, FullTextChangeTrackingMode.Default));
       domainConfig.Lock();
     }
@@ -350,13 +360,13 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void InvalidChangeTrackingModeTest()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidChangeTrackingMode"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidChangeTrackingMode"));
     }
 
     [Test]
     public void DomainOptionsTest1()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithDomainOptionsValid1");
+      var domainConfig = LoadDomainConfiguration("DomainWithDomainOptionsValid1");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.Options, DomainOptions.Default));
       domainConfig.Lock();
     }
@@ -364,54 +374,54 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void DomainOptionsTest2()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithDomainOptionsValid2");
+      var domainConfig = LoadDomainConfiguration("DomainWithDomainOptionsValid2");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.Options, DomainOptions.None));
       domainConfig.Lock();
     }
     [Test]
     public void InvalidDomainOptionsTest()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithDomainOptionsInvalid"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithDomainOptionsInvalid"));
     }
 
     [Test]
     public void CollationTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithColation");
+      var domainConfig = LoadDomainConfiguration("DomainWithColation");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.Collation, "generalci"));
     }
 
     [Test]
     public void BriefSchemaSyncExceptionsTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithBriefSchemaSyncExceptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithBriefSchemaSyncExceptions");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.SchemaSyncExceptionFormat, SchemaSyncExceptionFormat.Brief));
     }
 
     [Test]
     public void DetailedSchemaSyncExceptionsTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithDetailedSchemaSyncExceptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithDetailedSchemaSyncExceptions");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.SchemaSyncExceptionFormat, SchemaSyncExceptionFormat.Detailed));
     }
 
     [Test]
     public void DefaultSchemaSyncExceptionsTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithDefaultSchemaSyncExceptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithDefaultSchemaSyncExceptions");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.SchemaSyncExceptionFormat, SchemaSyncExceptionFormat.Default));
     }
 
     [Test]
     public void InvalidSchemaSyncExceptionsTest()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidSchemaSyncExceptions"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidSchemaSyncExceptions"));
     }
 
     [Test]
     public void TagsLocationNowhereTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationNowhere");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationNowhere");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.Nowhere));
     }
@@ -419,7 +429,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void TagsLocationBeforeTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationBefore");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationBefore");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.BeforeStatement));
     }
@@ -427,7 +437,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void TagsLocationWithinTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationWithin");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationWithin");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.WithinStatement));
     }
@@ -435,7 +445,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void TagsLocationAfterTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationAfter");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationAfter");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.AfterStatement));
     }
@@ -443,7 +453,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void TagsLocationDefaultTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithTagsLocationDefault");
+      var domainConfig = LoadDomainConfiguration("DomainWithTagsLocationDefault");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.TagsLocation, TagsLocation.Default));
     }
@@ -451,13 +461,13 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void InvalidTagsLocationTest()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithTagsLocationInvalid"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithTagsLocationInvalid"));
     }
 
     [Test]
     public void ForcedServerVersionTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithForcedServerVersion");
+      var domainConfig = LoadDomainConfiguration("DomainWithForcedServerVersion");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.ForcedServerVersion, "10.0.0.0"));
     }
@@ -465,7 +475,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void InitializationSqlTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithInitSql");
+      var domainConfig = LoadDomainConfiguration("DomainWithInitSql");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.ConnectionInitializationSql, "use [OtherDb]"));
     }
@@ -473,7 +483,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void IncludeSqlInExceptionsTest()
     {
-      var domainConfig = GetDomainConfiguration("IncludeSqlInExceptionsTrue");
+      var domainConfig = LoadDomainConfiguration("IncludeSqlInExceptionsTrue");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.IncludeSqlInExceptions, true));
     }
@@ -481,7 +491,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void DontIncludeSqlInExceptionsTest()
     {
-      var domainConfig = GetDomainConfiguration("IncludeSqlInExceptionsFalse");
+      var domainConfig = LoadDomainConfiguration("IncludeSqlInExceptionsFalse");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.IncludeSqlInExceptions, false));
     }
@@ -489,7 +499,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void AllowCyclicDatabaseDependanciesTest()
     {
-      var domainConfig = GetDomainConfiguration("AllowCyclicDatabaseDependenciesTrue");
+      var domainConfig = LoadDomainConfiguration("AllowCyclicDatabaseDependenciesTrue");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.AllowCyclicDatabaseDependencies, true));
     }
@@ -497,7 +507,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void DisallowCyclicDatabaseDependanciesTest()
     {
-      var domainConfig = GetDomainConfiguration("AllowCyclicDatabaseDependenciesFalse");
+      var domainConfig = LoadDomainConfiguration("AllowCyclicDatabaseDependenciesFalse");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.AllowCyclicDatabaseDependencies, false));
     }
@@ -505,35 +515,35 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void BuildInParallelTest()
     {
-      var domainConfig = GetDomainConfiguration("BuildInParallelTrue");
+      var domainConfig = LoadDomainConfiguration("BuildInParallelTrue");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.BuildInParallel, true));
     }
 
     [Test]
     public void DontBuildInParallelTest()
     {
-      var domainConfig = GetDomainConfiguration("BuildInParallelFalse");
+      var domainConfig = LoadDomainConfiguration("BuildInParallelFalse");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.BuildInParallel, false));
     }
 
     [Test]
     public void AllowMultidatabaseKeysTest()
     {
-      var domainConfig = GetDomainConfiguration("MultidatabaseKeysTrue");
+      var domainConfig = LoadDomainConfiguration("MultidatabaseKeysTrue");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.MultidatabaseKeys, true));
     }
 
     [Test]
     public void DisallowMultidatabaseKeysTest()
     {
-      var domainConfig = GetDomainConfiguration("MultidatabaseKeysFalse");
+      var domainConfig = LoadDomainConfiguration("MultidatabaseKeysFalse");
       ValidateAllDefaultExcept(domainConfig, ((d) => d.MultidatabaseKeys, false));
     }
 
     [Test]
     public void ShareStorageSchemaOverNodesTest()
     {
-      var domainConfig = GetDomainConfiguration("SharedStorageSchemaOn");
+      var domainConfig = LoadDomainConfiguration("SharedStorageSchemaOn");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.ShareStorageSchemaOverNodes, true));
     }
@@ -541,7 +551,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void DontShareStorageSchemaOverNodesTest()
     {
-      var domainConfig = GetDomainConfiguration("SharedStorageSchemaOff");
+      var domainConfig = LoadDomainConfiguration("SharedStorageSchemaOff");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.ShareStorageSchemaOverNodes, false));
     }
@@ -549,7 +559,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void EnsureConnectionIsAliveTest()
     {
-      var domainConfig = GetDomainConfiguration("EnableConnectionIsAliveTrue");
+      var domainConfig = LoadDomainConfiguration("EnableConnectionIsAliveTrue");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.EnsureConnectionIsAlive, true));
     }
@@ -557,7 +567,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void DontCheckConnectionIsAliveTest()
     {
-      var domainConfig = GetDomainConfiguration("EnableConnectionIsAliveFalse");
+      var domainConfig = LoadDomainConfiguration("EnableConnectionIsAliveFalse");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.EnsureConnectionIsAlive, false));
     }
@@ -565,7 +575,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void PreferTypeIdAsQueryParameterTest()
     {
-      var domainConfig = GetDomainConfiguration("PreferTypeIdsAsQueryParametersTrue");
+      var domainConfig = LoadDomainConfiguration("PreferTypeIdsAsQueryParametersTrue");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.PreferTypeIdsAsQueryParameters, true));
     }
@@ -573,7 +583,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void DontPreferTypeIdAsQueryParameterTest()
     {
-      var domainConfig = GetDomainConfiguration("PreferTypeIdsAsQueryParametersFalse");
+      var domainConfig = LoadDomainConfiguration("PreferTypeIdsAsQueryParametersFalse");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.PreferTypeIdsAsQueryParameters, false));
     }
@@ -584,7 +594,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest01()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention1");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention1");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -600,7 +610,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest02()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention2");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention2");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Lowercase));
@@ -616,7 +626,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest03()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention3");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention3");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.AsIs));
@@ -632,7 +642,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest04()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention4");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention4");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Default));
@@ -648,7 +658,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest05()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention5");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention5");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -659,7 +669,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest06()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention6");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention6");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -670,7 +680,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest07()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention7");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention7");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -681,7 +691,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest08()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention8");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention8");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -692,7 +702,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest09()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention9");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention9");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -703,7 +713,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest10()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention10");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention10");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -715,7 +725,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionSettingsTest11()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithNamingConvention11");
+      var domainConfig = LoadDomainConfiguration("DomainWithNamingConvention11");
       ValidateAllDefault(domainConfig);
       var namingConvention = domainConfig.NamingConvention;
       Assert.That(namingConvention.LetterCasePolicy, Is.EqualTo(LetterCasePolicy.Uppercase));
@@ -726,19 +736,19 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void NamingConventionInvalidSettingsTest1()
     {
-      _ = Assert.Throws<InvalidOperationException> (()=> GetDomainConfiguration("DomainWithInvalidNamingConvention1"));
+      _ = Assert.Throws<InvalidOperationException> (()=> LoadDomainConfiguration("DomainWithInvalidNamingConvention1"));
     }
 
     [Test]
     public void NamingConventionInvalidSettingsTest2()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidNamingConvention2"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidNamingConvention2"));
     }
 
     [Test]
     public void NamingConventionInvalidSettingsTest3()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidNamingConvention3"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidNamingConvention3"));
     }
 
     #endregion
@@ -748,7 +758,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void VersioningConventionPessimisticTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention1");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention1");
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Pessimistic));
       Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
@@ -757,7 +767,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void VersioningConventionOptimisticTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention2");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention2");
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Optimistic));
       Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
@@ -766,7 +776,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void VersioningConventionDefaultTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention3");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention3");
       ValidateAllDefault(domainConfig);
 
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Default));
@@ -776,7 +786,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void VersioningConventionDenyEntitySetChangeVersionTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention4");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention4");
       ValidateAllDefault(domainConfig);
 
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Optimistic));
@@ -786,7 +796,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void VersioningConventionAllowEntitySetChangeVersionTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithVersioningConvention5");
+      var domainConfig = LoadDomainConfiguration("DomainWithVersioningConvention5");
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.VersioningConvention.EntityVersioningPolicy, Is.EqualTo(EntityVersioningPolicy.Optimistic));
       Assert.That(domainConfig.VersioningConvention.DenyEntitySetOwnerVersionChange, Is.EqualTo(false));
@@ -795,7 +805,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void VersioningConventionInvalidTest()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithInvalidVersioningConvention1"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithInvalidVersioningConvention1"));
     }
 
     #endregion
@@ -804,7 +814,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void TypesRegistrationAsTypesTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithTypes");
+      var domainConfig = LoadDomainConfiguration("DomainWithTypes");
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity1)), Is.True);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity2)), Is.True);
@@ -814,7 +824,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void TypesRegistrationAsAssembliesTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithAssemblies");
+      var domainConfig = LoadDomainConfiguration("DomainWithAssemblies");
       ValidateAllDefault(domainConfig);
       var ormAssembly = typeof(DomainConfiguration).Assembly;
       Assert.That(domainConfig.Types.Count, Is.GreaterThan(0));
@@ -824,7 +834,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void TypesRegistrationAsAssembliesWithNamespace()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithAssembliesAndNamespaces");
+      var domainConfig = LoadDomainConfiguration("DomainWithAssembliesAndNamespaces");
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity1)), Is.True);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity2)), Is.True);
@@ -833,7 +843,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void MixedTypeRegistration()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithMixedRegistrations");
+      var domainConfig = LoadDomainConfiguration("DomainWithMixedRegistrations");
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity1)), Is.True);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity2)), Is.True);
@@ -847,7 +857,7 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       // same type twice
 
-      var domainConfig = GetDomainConfiguration("DomainWithInvalidRegistrations1");
+      var domainConfig = LoadDomainConfiguration("DomainWithInvalidRegistrations1");
 
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.DummyEntity1)), Is.True);
@@ -859,7 +869,7 @@ namespace Xtensive.Orm.Tests.Configuration
     public void InvalidTypeRegistration2()
     {
       // same Assembly
-      var domainConfig = GetDomainConfiguration("DomainWithInvalidRegistrations2");
+      var domainConfig = LoadDomainConfiguration("DomainWithInvalidRegistrations2");
 
       ValidateAllDefault(domainConfig);
       var ormAssembly = typeof(DomainConfiguration).Assembly;
@@ -871,7 +881,7 @@ namespace Xtensive.Orm.Tests.Configuration
     public void InvalidTypeRegistration3()
     {
       // same assembly and namespace
-      var domainConfig = GetDomainConfiguration("DomainWithInvalidRegistrations3");
+      var domainConfig = LoadDomainConfiguration("DomainWithInvalidRegistrations3");
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity1)), Is.True);
       Assert.That(domainConfig.Types.Contains(typeof(TypesToUseInTests.NestedNamespace.DummyNestedEntity2)), Is.True);
@@ -880,25 +890,25 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void InvalidTypeRegistration4()
     {
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidRegistrations4"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations4"));
     }
 
     [Test]
     public void InvalidTypeRegistration5()
     {
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidRegistrations5"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations5"));
     }
 
     [Test]
     public void InvalidTypeRegistration6()
     {
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidRegistrations6"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations6"));
     }
 
     [Test]
     public void InvalidTypeRegistration7()
     {
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidRegistrations7"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidRegistrations7"));
     }
 
     #endregion
@@ -908,7 +918,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void MultipleSessionsTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithMultipleSessionConfigurations");
+      var domainConfig = LoadDomainConfiguration("DomainWithMultipleSessionConfigurations");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -932,7 +942,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionWithEmptyNameTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionEmptyName");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionEmptyName");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -945,7 +955,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionWithCustomNameTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomName");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomName");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -960,7 +970,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionWithCustomUserNameTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomUser");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomUser");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -974,7 +984,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionWithOptionsTest1()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionDefaultOptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionDefaultOptions");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -988,7 +998,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionWithOptionsTest2()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionServerProfile");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionServerProfile");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1002,7 +1012,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionWithOptionsTest3()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionClientProfile");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionClientProfile");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1016,7 +1026,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionWithOptionsTest4()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomOptions");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomOptions");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1030,7 +1040,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionWithCollectionSizesTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionWithCollectionSizes");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionWithCollectionSizes");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1046,7 +1056,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionCustomCacheTypeTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomCacheType");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomCacheType");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1060,7 +1070,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionCustomIsolationLevelTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomIsolationLevel");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomIsolationLevel");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1074,7 +1084,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionCustomCommandTimeoutTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomCommandTimeout");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomCommandTimeout");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1088,7 +1098,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionCustomPreloadingPolicyTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomPreloadingPolicy");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomPreloadingPolicy");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1102,7 +1112,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionCustomConnectionStringTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomConnectionString");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomConnectionString");
       ValidateAllDefault(domainConfig);
 
       var sessions = domainConfig.Sessions;
@@ -1115,7 +1125,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionCustomConnectionUrlTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithSessionCustomConnectionUrl");
+      var domainConfig = LoadDomainConfiguration("DomainWithSessionCustomConnectionUrl");
       ValidateAllDefault(domainConfig);
       var sessions = domainConfig.Sessions;
       Assert.That(sessions.Count, Is.EqualTo(1));
@@ -1127,55 +1137,55 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void SessionWithInvalidOptions()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithSessionInvalidOptions"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithSessionInvalidOptions"));
     }
 
     [Test]
     public void SessionWithInvalidCacheSizeTest1()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidCacheSize1"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheSize1"));
     }
 
     [Test]
     public void SessionWithInvalidCacheSizeTest2()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidCacheSize2"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheSize2"));
     }
 
     [Test]
     public void SessionWithInvalidCacheSizeTest3()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidCacheSize3"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheSize3"));
     }
 
     [Test]
     public void SessionWithInvalidBatchSizeTest1()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidBatchSize1"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidBatchSize1"));
     }
 
     [Test]
     public void SessionWithInvalidBatchSizeTest2()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidBatchSize2"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidBatchSize2"));
     }
 
     [Test]
     public void SessionWithInvalidEntityChangeRegistryTest1()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry1"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry1"));
     }
 
     [Test]
     public void SessionWithInvalidEntityChangeRegistryTest2()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry2"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithSessionInvalidEntityChangeRegistry2"));
     }
 
     [Test]
     public void SessionWithInvalidCacheType1()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => GetDomainConfiguration("DomainWithSessionInvalidCacheType"));
+      _ = Assert.Throws<InvalidOperationException>(() => LoadDomainConfiguration("DomainWithSessionInvalidCacheType"));
     }
 
     #endregion
@@ -1185,7 +1195,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void DatabaseConfigurationOnlyAliasTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithDatabases1");
+      var domainConfig = LoadDomainConfiguration("DomainWithDatabases1");
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Databases.Count, Is.EqualTo(2));
       var db1 = domainConfig.Databases[0];
@@ -1203,7 +1213,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void DatabaseConfigurationWithTypeIdsTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithDatabases2");
+      var domainConfig = LoadDomainConfiguration("DomainWithDatabases2");
       ValidateAllDefault(domainConfig);
       Assert.That(domainConfig.Databases.Count, Is.EqualTo(2));
       var db1 = domainConfig.Databases[0];
@@ -1221,25 +1231,25 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void DatabaseConfigurationNegativeMinTypeIdTest()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithInvalidDatabases1"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases1"));
     }
 
     [Test]
     public void DatabaseConfigurationInvalidMinTypeIdTest()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithInvalidDatabases2"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases2"));
     }
 
     [Test]
     public void DatabaseConfigurationNegativeMaxTypeIdTest()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithInvalidDatabases3"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases3"));
     }
 
     [Test]
     public void DatabaseConfigurationInvalidMaxTypeIdTest()
     {
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithInvalidDatabases4"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithInvalidDatabases4"));
     }
 
     #endregion
@@ -1251,7 +1261,7 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      var domainConfig = GetDomainConfiguration("DomainWithCustomGenerator");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomGenerator");
       ValidateAllDefault(domainConfig);
     }
 
@@ -1260,7 +1270,7 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      var domainConfig = GetDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNames");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNames");
       ValidateAllDefault(domainConfig);
     }
 
@@ -1269,7 +1279,7 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      var domainConfig = GetDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNamesAndKeyParams");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomGeneratorsWithDatabaseNamesAndKeyParams");
       ValidateAllDefault(domainConfig);
     }
 
@@ -1278,7 +1288,7 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      var domainConfig = GetDomainConfiguration("DomainWithCustomGeneratorsWithDatabasesAliases");
+      var domainConfig = LoadDomainConfiguration("DomainWithCustomGeneratorsWithDatabasesAliases");
       ValidateAllDefault(domainConfig);
     }
 
@@ -1287,7 +1297,7 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithCustomGeneratorsConflict1"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorsConflict1"));
     }
 
     [Test]
@@ -1295,7 +1305,7 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithCustomGeneratorsConflict2"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorsConflict2"));
     }
 
     [Test]
@@ -1303,7 +1313,7 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomGeneratorNegativeSeed"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorNegativeSeed"));
     }
 
     [Test]
@@ -1311,7 +1321,7 @@ namespace Xtensive.Orm.Tests.Configuration
     {
       if (!NameAttributeUnique)
         throw new IgnoreException("");
-      _ = Assert.Throws<ArgumentOutOfRangeException>(() => GetDomainConfiguration("DomainWithCustomGeneratorNegativeCache"));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => LoadDomainConfiguration("DomainWithCustomGeneratorNegativeCache"));
     }
 
     #endregion
@@ -1321,7 +1331,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void IgnoreRulesTest()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithIgnoreRules");
+      var domainConfig = LoadDomainConfiguration("DomainWithIgnoreRules");
       ValidateAllDefault(domainConfig);
       ValidateIgnoreRules(domainConfig.IgnoreRules);
     }
@@ -1329,25 +1339,25 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void IgnoreColumnAndIndexAtTheSameTimeTest()
     {
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidIgnoreRules1"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules1"));
     }
 
     [Test]
     public void IgnoreTableAndColumnAndIndexAtTheSameTimeTest()
     {
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidIgnoreRules2"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules2"));
     }
 
     [Test]
     public void IgnoreDatabaseOnlyTest()
     {
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidIgnoreRules3"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules3"));
     }
 
     [Test]
     public void IgnoreDatabaseAndSchemaOnlyTest()
     {
-      _ = Assert.Throws<ArgumentException>(() => GetDomainConfiguration("DomainWithInvalidIgnoreRules4"));
+      _ = Assert.Throws<ArgumentException>(() => LoadDomainConfiguration("DomainWithInvalidIgnoreRules4"));
     }
 
     private void ValidateIgnoreRules(IgnoreRuleCollection rules)
@@ -1488,7 +1498,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void MappingRulesTest1()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithMappingRules1");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules1");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1507,7 +1517,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void MappingRulesTest2()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithMappingRules2");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules2");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1528,7 +1538,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void MappingRulesTest3()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithMappingRules3");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules3");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1548,7 +1558,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void MappingRulesTest4()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithMappingRules4");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules4");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1568,7 +1578,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void MappingRulesTest5()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithMappingRules5");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules5");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1588,7 +1598,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void MappingRulesTest6()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithMappingRules6");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules6");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1607,7 +1617,7 @@ namespace Xtensive.Orm.Tests.Configuration
     [Test]
     public void MappingRulesTest7()
     {
-      var domainConfig = GetDomainConfiguration("DomainWithMappingRules7");
+      var domainConfig = LoadDomainConfiguration("DomainWithMappingRules7");
       ValidateAllDefaultExcept(domainConfig,
         ((d) => d.DefaultDatabase, "main"),
         ((d) => d.DefaultSchema, "dbo"),
@@ -1627,54 +1637,101 @@ namespace Xtensive.Orm.Tests.Configuration
     public void MappingRuleWithConflictByAssemblyTest()
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => GetDomainConfiguration("DomainWithConflictMappingRules1"));
+        () => LoadDomainConfiguration("DomainWithConflictMappingRules1"));
     }
 
     [Test]
     public void MappingRuleWithConflictByNamespaceTest()
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => GetDomainConfiguration("DomainWithConflictMappingRules2"));
+        () => LoadDomainConfiguration("DomainWithConflictMappingRules2"));
     }
 
     [Test]
     public void MappingRulesInvalidTest1()
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => GetDomainConfiguration("DomainWithInvalidMappingRules1"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules1"));
     }
 
     [Test]
     public void MappingRulesInvalidTest2()
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => GetDomainConfiguration("DomainWithInvalidMappingRules2"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules2"));
     }
 
     [Test]
     public void MappingRulesInvalidTest3()
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => GetDomainConfiguration("DomainWithInvalidMappingRules3"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules3"));
     }
 
     [Test]
     public void MappingRulesInvalidTest4()
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => GetDomainConfiguration("DomainWithInvalidMappingRules4"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules4"));
     }
 
     [Test]
     public void MappingRulesInvalidTest5()
     {
       var exception = Assert.Throws<System.ArgumentException>(
-        () => GetDomainConfiguration("DomainWithInvalidMappingRules5"));
+        () => LoadDomainConfiguration("DomainWithInvalidMappingRules5"));
     }
 
     #endregion
 
+    #region Logging
 
+    [Test]
+    public void LoggingConfigurationTest()
+    {
+      var configuration = LoadLoggingConfiguration();
+      ValidateLoggingConfiguration(configuration);
+    }
+
+    [Test]
+    public void LoggingEmptyLoggingSectionTest()
+    {
+      var section = configuration.GetSection($"Xtensive.Orm.EmptyLogging.{Postfix}");
+      _ = Assert.Throws<InvalidOperationException>(() => LoadLoggingConfiguration(section));
+    }
+
+    [Test]
+    public void LoggingEmptyLogsTest()
+    {
+      if (Postfix == "AppConfig")
+        throw new IgnoreException("");
+
+      var section = configuration.GetSection($"Xtensive.Orm.EmptyLogs.{Postfix}");
+      _ = Assert.Throws<InvalidOperationException>(() => LoadLoggingConfiguration(section));
+    }
+
+    [Test]
+    public void LoggingOnlyProviderDeclaredTest()
+    {
+      var section = configuration.GetSection($"Xtensive.Orm.OnlyLogProvider.{Postfix}");
+      var loggingConfig = LoadLoggingConfiguration(section);
+      Assert.That(loggingConfig.Logs.Count, Is.EqualTo(0));
+      Assert.That(loggingConfig.Provider, Is.EqualTo("Xtensive.Orm.Logging.log4net.LogProvider"));
+    }
+
+    [Test]
+    public void LoggingProviderAndEmptyLogsTest()
+    {
+      if (Postfix == "AppConfig")
+        throw new IgnoreException("");
+
+      var section = configuration.GetSection($"Xtensive.Orm.LogProviderAndEmptyLogs.{Postfix}");
+      var loggingConfig = LoadLoggingConfiguration(section);
+      Assert.That(loggingConfig.Logs.Count, Is.EqualTo(0));
+      Assert.That(loggingConfig.Provider, Is.EqualTo("Xtensive.Orm.Logging.log4net.LogProvider"));
+    }
+
+    #endregion
 
     private void ValidateAllDefault(DomainConfiguration domainConfiguration)
     {
@@ -1865,7 +1922,7 @@ namespace Xtensive.Orm.Tests.Configuration
         throw new ArgumentOutOfRangeException(nameof(configuration));
     }
 
-    public bool TryExtractPropertyFormLambda<TConfiguration, T>(Expression<Func<TConfiguration, T>> lambda,
+    private bool TryExtractPropertyFormLambda<TConfiguration, T>(Expression<Func<TConfiguration, T>> lambda,
       out System.Reflection.PropertyInfo property)
     {
       if (lambda.Body.StripCasts() is MemberExpression mExpression && mExpression.Member is System.Reflection.PropertyInfo prop) {
@@ -1988,6 +2045,33 @@ namespace Xtensive.Orm.Tests.Configuration
 
       if (!nameof(sessionConfiguration.ConnectionInfo).In(excludedProperties))
         Assert.That(sessionConfiguration.ConnectionInfo, Is.Null);
+    }
+
+    private void ValidateLoggingConfiguration(LoggingConfiguration configuration)
+    {
+      Assert.That(configuration.Provider, Is.Not.Null.Or.Empty);
+      Assert.That(configuration.Provider, Is.EqualTo("Xtensive.Orm.Logging.log4net.LogProvider"));
+
+      Assert.That(configuration.Logs[0].Source, Is.EqualTo("*"));
+      Assert.That(configuration.Logs[0].Target, Is.EqualTo("Console"));
+
+      Assert.That(configuration.Logs[1].Source, Is.EqualTo("SomeLogName"));
+      Assert.That(configuration.Logs[1].Target, Is.EqualTo("DebugOnlyConsole"));
+
+      Assert.That(configuration.Logs[2].Source, Is.EqualTo("FirstLogName,SecondLogName"));
+      Assert.That(configuration.Logs[2].Target, Is.EqualTo(@"d:\log.txt"));
+
+      Assert.That(configuration.Logs[3].Source, Is.EqualTo("LogName, AnotherLogName"));
+      Assert.That(configuration.Logs[3].Target, Is.EqualTo("Console"));
+
+      Assert.That(configuration.Logs[4].Source, Is.EqualTo("FileLog"));
+      Assert.That(configuration.Logs[4].Target, Is.EqualTo("log.txt"));
+
+      Assert.That(configuration.Logs[5].Source, Is.EqualTo("NullLog"));
+      Assert.That(configuration.Logs[5].Target, Is.EqualTo("None"));
+
+      Assert.That(configuration.Logs[6].Source, Is.EqualTo("Trash"));
+      Assert.That(configuration.Logs[6].Target, Is.EqualTo("skjdhfjsdf sdfsdfksjdghj fgdfg"));
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
+++ b/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
@@ -14,9 +14,15 @@
   <Import Project="$(SolutionDir)MSBuild\DataObjects.Net.InternalBuild.targets" />
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" /> -->
@@ -35,6 +41,12 @@
     <ProjectReference Include="..\Xtensive.Orm\Xtensive.Orm.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="domainSettings.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="domainSettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Northwind.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -96,4 +108,5 @@
       <DependentUpon>TwoPartsModel.tt</DependentUpon>
     </Compile>
   </ItemGroup>
+  <ProjectExtensions><VisualStudio><UserProperties /></VisualStudio></ProjectExtensions>
 </Project>

--- a/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
+++ b/Orm/Xtensive.Orm.Tests/Xtensive.Orm.Tests.csproj
@@ -14,18 +14,11 @@
   <Import Project="$(SolutionDir)MSBuild\DataObjects.Net.InternalBuild.targets" />
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <!-- <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" /> -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
@@ -34,7 +27,9 @@
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Spatial" Version="5.8.3" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0.0" />
-    <!-- <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />-->
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xtensive.Orm.Tests.Framework\Xtensive.Orm.Tests.Framework.csproj" />

--- a/Orm/Xtensive.Orm.Tests/domainSettings.config
+++ b/Orm/Xtensive.Orm.Tests/domainSettings.config
@@ -1,0 +1,2378 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+   <configSections>
+    <section name="Xtensive.Orm.AppConfig" type="Xtensive.Orm.Configuration.Elements.ConfigurationSection, Xtensive.Orm"/>
+  </configSections>
+  <Xtensive.Orm.AppConfig>
+    <domains>
+      <domain name="DomainWithProviderAndConnectionString"
+              provider ="sqlite" connectionString="Data Source=DO-Testsaaa.db3"/>
+      <domain name="DomainWithConnectionUrl" connectionUrl="sqlite:///DO-Tests.db3" />
+
+      <domain name="DomainWithCustomValidKeyCacheSize"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              keyCacheSize="192" />
+      <domain name="DomainWithCustomInvalidKeyCacheSize"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              keyCacheSize="-256" />
+
+      <domain name="DomainWithCustomValidKeyGeneratorCacheSize"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              keyGeneratorCacheSize="192" />
+      <domain name="DomainWithCustomInvalidKeyGeneratorCacheSize"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              keyGeneratorCacheSize="-256" />
+
+      <domain name="DomainWithCustomValidQueryCacheSize"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              queryCacheSize="192" />
+      <domain name="DomainWithCustomInvalidQueryCacheSize"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              queryCacheSize="-256" />
+
+      <domain name="DomainWithCustomValidRecordSetMappingCacheSize"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              recordSetMappingCacheSize="192" />
+      <domain name="DomainWithCustomInvalidRecordSetMappingCacheSize"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              recordSetMappingCacheSize="-256" />
+
+      <domain name="DomainWithCustomDatabase"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              defaultDatabase="MyFancyDatabase" />
+      <domain name="DomainWithCustomSchema"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              defaultSchema="MyFancySchema" />
+
+      <domain name="DomainWithWrongConnectionInfo"
+              upgradeMode="Recreate"
+              connectionString="Data Source=localhost;Initial Catalog=DO40-Tests;Integrated Security=True;MultipleActiveResultSets=True" />
+
+      <domain name="DomainWithUpgradeMode1"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              upgradeMode="Default" />
+      <domain name="DomainWithUpgradeMode2"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              upgradeMode="Recreate" />
+      <domain name="DomainWithUpgradeMode3"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              upgradeMode="Perform" />
+      <domain name="DomainWithUpgradeMode4"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              upgradeMode="PerformSafely" />
+      <domain name="DomainWithUpgradeMode5"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              upgradeMode="Validate" />
+      <domain name="DomainWithUpgradeMode6"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              upgradeMode="LegacyValidate" />
+      <domain name="DomainWithUpgradeMode7"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              upgradeMode="Skip" />
+      <domain name="DomainWithUpgradeMode8"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              upgradeMode="LegacySkip" />
+
+      <domain name="DomainWithWrongUpgradeMode"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              upgradeMode="Defailt" />
+
+      <domain name="DomainWithForeignKeyMode1"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              foreignKeyMode="None" />
+      <domain name="DomainWithForeignKeyMode2"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              foreignKeyMode="Hierarchy" />
+      <domain name="DomainWithForeignKeyMode3"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              foreignKeyMode="Reference" />
+      <domain name="DomainWithForeignKeyMode4"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              foreignKeyMode="All" />
+      <domain name="DomainWithForeignKeyMode5"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              foreignKeyMode="Default" />
+      <domain name="DomainWithForeignKeyMode6"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              foreignKeyMode="Hierarchy,Reference" />
+
+      <domain name="DomainWithInvalidForeignKeyMode"
+              connectionUrl="sqlserver://localhost/DO40-Tests"
+              foreignKeyMode="Defailt" />
+
+      <domain name="DomainWithChangeTrackingMode1"
+              connectionUrl="sqlserver://localhost/"
+              fullTextChangeTrackingMode="Off" />
+      <domain name="DomainWithChangeTrackingMode2"
+              connectionUrl="sqlserver://localhost/"
+              fullTextChangeTrackingMode="Auto" />
+      <domain name="DomainWithChangeTrackingMode3"
+              connectionUrl="sqlserver://localhost/"
+              fullTextChangeTrackingMode="Manual" />
+      <domain name="DomainWithChangeTrackingMode4"
+              connectionUrl="sqlserver://localhost/"
+              fullTextChangeTrackingMode="OffWithNoPopulation" />
+      <domain name="DomainWithChangeTrackingMode5"
+              connectionUrl="sqlserver://localhost/"
+              fullTextChangeTrackingMode="Default" />
+
+      <domain name="DomainWithInvalidChangeTrackingMode"
+              connectionUrl="sqlserver://localhost/"
+              fullTextChangeTrackingMode="Defailt" />
+
+      <domain name="DomainWithDomainOptionsValid1"
+              connectionUrl="sqlserver://localhost/"
+              options="Default" />
+      <domain name="DomainWithDomainOptionsValid2"
+              connectionUrl="sqlserver://localhost/"
+              options="None" />
+
+      <domain name="DomainWithDomainOptionsInvalid"
+              connectionUrl="sqlserver://localhost/"
+              options="Defailt" />
+
+      <domain name="DomainWithColation"
+              connectionUrl="sqlserver://localhost/"
+              collation="generalci" />
+
+      <domain name="DomainWithBriefSchemaSyncExceptions"
+              connectionUrl="sqlserver://localhost/"
+              schemaSyncExceptionFormat="Brief" />
+      <domain name="DomainWithDetailedSchemaSyncExceptions"
+              connectionUrl="sqlserver://localhost/"
+              schemaSyncExceptionFormat="Detailed" />
+      <domain name="DomainWithDefaultSchemaSyncExceptions"
+              connectionUrl="sqlserver://localhost/"
+              schemaSyncExceptionFormat="Default" />
+      <domain name="DomainWithInvalidSchemaSyncExceptions"
+              connectionUrl="sqlserver://localhost/"
+              schemaSyncExceptionFormat="Defailt" />
+
+      <domain name="DomainWithTagsLocationNowhere"
+              connectionUrl="sqlserver://localhost/"
+              tagsLocation="Nowhere" />
+      <domain name="DomainWithTagsLocationBefore"
+              connectionUrl="sqlserver://localhost/"
+              tagsLocation="BeforeStatement" />
+      <domain name="DomainWithTagsLocationWithin"
+              connectionUrl="sqlserver://localhost/"
+              tagsLocation="WithinStatement" />
+      <domain name="DomainWithTagsLocationAfter"
+              connectionUrl="sqlserver://localhost/"
+              tagsLocation="AfterStatement" />
+      <domain name="DomainWithTagsLocationDefault"
+              connectionUrl="sqlserver://localhost/"
+              tagsLocation="Default" />
+      <domain name="DomainWithTagsLocationInvalid"
+              connectionUrl="sqlserver://localhost/"
+              tagsLocation="Defailt" />
+
+      <domain name="DomainWithForcedServerVersion"
+              connectionUrl="sqlserver://localhost/"
+              forcedServerVersion="10.0.0.0" />
+
+      <domain name="DomainWithInitSql"
+              connectionUrl="sqlserver://localhost/"
+              connectionInitializationSql="use [OtherDb]" />
+
+      <domain name="IncludeSqlInExceptionsTrue"
+              connectionUrl="sqlserver://localhost/"
+              includeSqlInExceptions="true" />
+      <domain name="IncludeSqlInExceptionsFalse"
+              connectionUrl="sqlserver://localhost/"
+              includeSqlInExceptions="false" />
+
+      <domain name="AllowCyclicDatabaseDependenciesTrue"
+              connectionUrl="sqlserver://localhost/"
+              allowCyclicDatabaseDependencies="true" />
+      <domain name="AllowCyclicDatabaseDependenciesFalse"
+              connectionUrl="sqlserver://localhost/"
+              allowCyclicDatabaseDependencies="false" />
+
+      <domain name="BuildInParallelTrue"
+              connectionUrl="sqlserver://localhost/"
+              buildInParallel="true" />
+      <domain name="BuildInParallelFalse"
+              connectionUrl="sqlserver://localhost/"
+              buildInParallel="false" />
+
+      <domain name="MultidatabaseKeysTrue"
+              connectionUrl="sqlserver://localhost/"
+              multidatabaseKeys="true" />
+      <domain name="MultidatabaseKeysFalse"
+              connectionUrl="sqlserver://localhost/"
+              multidatabaseKeys="false" />
+
+      <domain name="SharedStorageSchemaOn"
+              connectionUrl="sqlserver://localhost/"
+              shareStorageSchemaOverNodes="true" />
+      <domain name="SharedStorageSchemaOff"
+              connectionUrl="sqlserver://localhost/"
+              shareStorageSchemaOverNodes="false" />
+
+      <domain name="EnableConnectionIsAliveTrue"
+              connectionUrl="sqlserver://localhost/"
+              ensureConnectionIsAlive="true" />
+      <domain name="EnableConnectionIsAliveFalse"
+              connectionUrl="sqlserver://localhost/"
+              ensureConnectionIsAlive="false" />
+
+      <domain name="PreferTypeIdsAsQueryParametersTrue"
+              connectionUrl="sqlserver://localhost/"
+              preferTypeIdsAsQueryParameters="true" />
+      <domain name="PreferTypeIdsAsQueryParametersFalse"
+              connectionUrl="sqlserver://localhost/"
+              preferTypeIdsAsQueryParameters="false" />
+
+      <domain name="DomainWithNamingConvention1"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Uppercase" namespacePolicy="Synonymize" namingRules="UnderscoreHyphens,RemoveDots">
+          <namespaceSynonyms>
+            <synonym namespace="Xtensive.Orm" synonym="system"/>
+            <synonym namespace="Xtensive.Orm.Tests" synonym="theRest" />
+          </namespaceSynonyms>
+        </namingConvention>
+      </domain>
+
+      <domain name="DomainWithNamingConvention2"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Lowercase" namespacePolicy="Synonymize" namingRules="UnderscoreHyphens,RemoveDots">
+          <namespaceSynonyms>
+            <synonym namespace="Xtensive.Orm" synonym="system"/>
+            <synonym namespace="Xtensive.Orm.Tests" synonym="theRest" />
+          </namespaceSynonyms>
+        </namingConvention>
+      </domain>
+
+      <domain name="DomainWithNamingConvention3"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="AsIs" namespacePolicy="Synonymize" namingRules="UnderscoreHyphens,RemoveDots">
+          <namespaceSynonyms>
+            <synonym namespace="Xtensive.Orm" synonym="system"/>
+            <synonym namespace="Xtensive.Orm.Tests" synonym="theRest" />
+          </namespaceSynonyms>
+        </namingConvention>
+      </domain>
+
+      <domain name="DomainWithNamingConvention4"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Default" namespacePolicy="Synonymize" namingRules="UnderscoreHyphens,RemoveDots">
+          <namespaceSynonyms>
+            <synonym namespace="Xtensive.Orm" synonym="system"/>
+            <synonym namespace="Xtensive.Orm.Tests" synonym="theRest" />
+          </namespaceSynonyms>
+        </namingConvention>
+      </domain>
+
+      <domain name="DomainWithNamingConvention5"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Uppercase" namespacePolicy="AsIs" namingRules="UnderscoreHyphens,RemoveDots" />
+      </domain>
+
+      <domain name="DomainWithNamingConvention6"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Uppercase" namespacePolicy="Hash" namingRules="UnderscoreHyphens,RemoveDots" />
+      </domain>
+
+      <domain name="DomainWithNamingConvention7"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Uppercase" namespacePolicy="Omit" namingRules="UnderscoreHyphens,RemoveDots" />
+      </domain>
+
+      <domain name="DomainWithNamingConvention8"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Uppercase" namespacePolicy="Default" namingRules="UnderscoreHyphens,RemoveDots" />
+      </domain>
+
+      <domain name="DomainWithNamingConvention9"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Uppercase" namespacePolicy="Hash" namingRules="UnderscoreDots,RemoveHyphens" />
+      </domain>
+
+      <domain name="DomainWithNamingConvention10"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Uppercase" namespacePolicy="Hash" namingRules="None" />
+      </domain>
+
+      <domain name="DomainWithNamingConvention11"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Uppercase" namespacePolicy="Hash" namingRules="Default" />
+      </domain>
+
+      <domain name="DomainWithInvalidNamingConvention1"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Defailt" namespacePolicy="Default" namingRules="Default" />
+      </domain>
+
+      <domain name="DomainWithInvalidNamingConvention2"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Default" namespacePolicy="Defailt" namingRules="Default" />
+      </domain>
+
+      <domain name="DomainWithInvalidNamingConvention3"
+              connectionUrl="sqlserver://localhost/">
+        <namingConvention letterCasePolicy="Default" namespacePolicy="Default" namingRules="Defailt" />
+      </domain>
+
+
+      <domain name="DomainWithVersioningConvention1"
+              connectionUrl="sqlserver://localhost/">
+        <versioningConvention entityVersioningPolicy="Pessimistic" />
+      </domain>
+
+      <domain name="DomainWithVersioningConvention2"
+              connectionUrl="sqlserver://localhost/">
+        <versioningConvention entityVersioningPolicy="Optimistic" />
+      </domain>
+
+      <domain name="DomainWithVersioningConvention3"
+              connectionUrl="sqlserver://localhost/">
+        <versioningConvention entityVersioningPolicy="Default" />
+      </domain>
+
+      <domain name="DomainWithVersioningConvention4"
+              connectionUrl="sqlserver://localhost/">
+        <versioningConvention entityVersioningPolicy="Optimistic" denyEntitySetOwnerVersionChange="true" />
+      </domain>
+
+      <domain name="DomainWithVersioningConvention5"
+              connectionUrl="sqlserver://localhost/">
+        <versioningConvention entityVersioningPolicy="Optimistic" denyEntitySetOwnerVersionChange="false" />
+      </domain>
+
+      <domain name="DomainWithInvalidVersioningConvention1"
+              connectionUrl="sqlserver://localhost/">
+        <versioningConvention entityVersioningPolicy="Defauit" />
+      </domain>
+
+      <domain name="DomainWithTypes"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add type="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests" />
+          <add type="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity2, Xtensive.Orm.Tests" />
+        </types>
+      </domain>
+
+      <domain name="DomainWithAssemblies"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add assembly="Xtensive.Orm" />
+        </types>
+      </domain>
+
+      <domain name="DomainWithAssembliesAndNamespaces"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add assembly="Xtensive.Orm.Tests" namespace="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace" />
+        </types>
+      </domain>
+
+      <domain name="DomainWithMixedRegistrations"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add type="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests" />
+          <add type="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity2, Xtensive.Orm.Tests" />
+          <add assembly="Xtensive.Orm" />
+          <add assembly="Xtensive.Orm.Tests" namespace="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace" />
+        </types>
+      </domain>
+
+      <domain name="DomainWithInvalidRegistrations1"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add type="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests" />
+          <add type="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests" />
+        </types>
+      </domain>
+
+      <domain name="DomainWithInvalidRegistrations2"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add assembly="Xtensive.Orm" />
+          <add assembly="Xtensive.Orm" />
+        </types>
+      </domain>
+
+      <domain name="DomainWithInvalidRegistrations3"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add assembly="Xtensive.Orm.Tests" namespace="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace" />
+          <add assembly="Xtensive.Orm.Tests" namespace="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace" />
+        </types>
+      </domain>
+
+      <domain name="DomainWithInvalidRegistrations4"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add type="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests"
+               assembly="Xtensive.Orm"
+               namespace="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"/>
+        </types>
+      </domain>
+
+      <domain name="DomainWithInvalidRegistrations5"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add type="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests"
+               assembly="Xtensive.Orm"/>
+        </types>
+      </domain>
+
+      <domain name="DomainWithInvalidRegistrations6"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add type="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests"
+               namespace="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"/>
+        </types>
+      </domain>
+
+      <domain name="DomainWithInvalidRegistrations7"
+              connectionUrl="sqlserver://localhost/">
+        <types>
+          <add namespace="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace" />
+        </types>
+      </domain>
+
+
+      <domain name="DomainWithDatabases1"
+              connectionUrl="sqlserver://localhost/">
+        <databases>
+          <database name="main" realName="DO-Tests-1" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+      <domain name="DomainWithDatabases2"
+              connectionUrl="sqlserver://localhost/">
+        <databases>
+          <database name="main" realName="DO-Tests-1" minTypeId="100" maxTypeId="1000"/>
+          <database name="other" realName="DO-Tests-2" minTypeId="2000" maxTypeId="3000" />
+        </databases>
+      </domain>
+
+
+      <domain name="DomainWithInvalidDatabases1"
+              connectionUrl="sqlserver://localhost/">
+        <databases>
+          <database name="main" realName="DO-Tests-1" minTypeId="-10" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithInvalidDatabases2"
+              connectionUrl="sqlserver://localhost/">
+        <databases>
+          <database name="main" realName="DO-Tests-1" minTypeId="50" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithInvalidDatabases3"
+              connectionUrl="sqlserver://localhost/">
+        <databases>
+          <database name="main" realName="DO-Tests-1" maxTypeId="-10" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithInvalidDatabases4"
+              connectionUrl="sqlserver://localhost/">
+        <databases>
+          <database name="main" realName="DO-Tests-1" maxTypeId="50" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithCustomGenerator"
+              connectionUrl="sqlserver://localhost/">
+        <keyGenerators>
+          <keyGenerator name="Int32" seed="12" cacheSize="127" />
+        </keyGenerators>
+      </domain>
+
+      <domain name="DomainWithCustomGeneratorsWithDatabaseNames"
+              connectionUrl="sqlserver://localhost/">
+        <keyGenerators>
+          <keyGenerator name="Int32" database="DO-Tests-1" />
+          <keyGenerator name="Int32" database="DO-Tests-2" />
+        </keyGenerators>
+      </domain>
+
+      <domain name="DomainWithCustomGeneratorsWithDatabaseNamesAndKeyParams"
+              connectionUrl="sqlserver://localhost/">
+        <keyGenerators>
+          <keyGenerator name="Int32" database="DO-Tests-1" seed="12" cacheSize="127" />
+          <keyGenerator name="Int32" database="DO-Tests-2" seed="13" cacheSize="129" />
+        </keyGenerators>
+      </domain>
+
+      <domain name="DomainWithCustomGeneratorsWithDatabasesAliases"
+              connectionUrl="sqlserver://localhost/">
+        <keyGenerators>
+          <keyGenerator name="Int32" database="main" seed="12" cacheSize="127" />
+          <keyGenerator name="Int32" database="other" seed="13" cacheSize="129" />
+        </keyGenerators>
+        <databases>
+          <database name="main" realName="DO-Tests-1" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithCustomGeneratorsConflict1"
+              connectionUrl="sqlserver://localhost/">
+        <keyGenerators>
+          <keyGenerator name="Int32" database="DO-Tests-1" />
+          <keyGenerator name="Int32" database="DO-Tests-1" />
+        </keyGenerators>
+      </domain>
+      <domain name="DomainWithCustomGeneratorsConflict2"
+              connectionUrl="sqlserver://localhost/">
+        <keyGenerators>
+          <keyGenerator name="Int32" database="DO-Tests-1" />
+          <keyGenerator name="Int32" database="main" />
+        </keyGenerators>
+        <databases>
+          <database name="main" realName="DO-Tests-1" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+      <domain name="DomainWithCustomGeneratorNegativeSeed"
+              connectionUrl="sqlserver://localhost/">
+        <keyGenerators>
+          <keyGenerator name="Int32" database="DO-Tests-1" seed="-12"/>
+        </keyGenerators>
+      </domain>
+      <domain name="DomainWithCustomGeneratorNegativeCache"
+              connectionUrl="sqlserver://localhost/">
+        <keyGenerators>
+          <keyGenerator name="Int32" database="DO-Tests-1" cacheSize="-127" />
+        </keyGenerators>
+      </domain>
+
+      <!-- Ignore rules -->
+      <domain name="DomainWithIgnoreRules" connectionUrl="sqlserver://localhost/">
+        <ignoreRules>
+          <rule database="Other-DO40-Tests" schema="some-schema1" table="table1"/>
+          <rule database="some-database" schema="some-schema2" column="column2"/>
+          <rule database="some-database" schema="some-schema2" index="index2"/>
+          <rule database="some-database" schema="some-schema3" table="table2" column="col3"/>
+          <rule database="some-database" schema="some-schema3" table="table2" index="index3"/>
+          <rule database="another-some-database" table="some-table" />
+          <rule database="database1" column ="some-column"/>
+          <rule database="database1" index ="some-index"/>
+          <rule schema="schema1" table="table1"/>
+          <rule schema="schema1" column="column2"/>
+          <rule schema="schema1" index="index2" />
+          <rule schema="schema1" table="table2" column="column3"/>
+          <rule schema="schema1" table="table2" index="index3"/>
+          <rule table="table4" column="column3"/>
+          <rule table="table4" index ="index2" />
+          <rule table="single-table"/>
+          <rule column="single-column"/>
+          <rule index ="single-index" />
+        </ignoreRules>
+      </domain>
+
+      <domain name="DomainWithInvalidIgnoreRules1" connectionUrl="sqlserver://localhost/">
+        <ignoreRules>
+          <rule column="column1" index="index1" />
+        </ignoreRules>
+      </domain>
+      <domain name="DomainWithInvalidIgnoreRules2" connectionUrl="sqlserver://localhost/">
+        <ignoreRules>
+          <rule table="table1" column="column1" index="index1" />
+        </ignoreRules>
+      </domain>
+      <domain name="DomainWithInvalidIgnoreRules3" connectionUrl="sqlserver://localhost/">
+        <ignoreRules>
+          <rule database="database1" />
+        </ignoreRules>
+      </domain>
+      <domain name="DomainWithInvalidIgnoreRules4" connectionUrl="sqlserver://localhost/">
+        <ignoreRules>
+          <rule database="Other-DO40-Tests" schema="some-schema1"/>
+        </ignoreRules>
+      </domain>
+
+      <!-- Mapping Rules -->
+      <domain name="DomainWithMappingRules1" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule assembly="Xtensive.Orm.Tests" database="DO-Tests-1" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithMappingRules2" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule assembly="Xtensive.Orm.Tests" schema="Model1" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithMappingRules3" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule namespace="Xtensive.Orm.Configuration.Options" database="DO-Tests-2" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithMappingRules4" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule namespace="Xtensive.Orm.Tests.Configuration" schema="Model2" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithMappingRules5" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule assembly="Xtensive.Orm.Tests" namespace="Xtensive.Orm.Tests.Configuration.TypesToUseInTests" database ="DO-Tests-3"/>
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithMappingRules6" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule assembly="Xtensive.Orm.Tests" namespace="Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace" schema="Model3" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithMappingRules7" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule assembly="Xtensive.Orm.Tests" namespace="Xtensive.Orm.Tests.Indexing" database="main" schema="Model4" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithConflictMappingRules1" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule assembly="Xtensive.Orm.Tests" database="DO-Tests-1" />
+          <rule assembly="Xtensive.Orm.Tests" schema="Model1" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithConflictMappingRules2" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule namespace="Xtensive.Orm.Tests.Configuration" database="DO-Tests-1" />
+          <rule namespace="Xtensive.Orm.Tests.Configuration" schema="Model2" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithInvalidMappingRules1" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule database="DO-Tests-1" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithInvalidMappingRules2" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule schema="Model4" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithInvalidMappingRules3" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule assembly="Xtensive.Orm.Tests" namespace="Xtensive.Orm.Tests.Configuration"/>
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithInvalidMappingRules4" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule assembly="Xtensive.Orm.Tests"/>
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <domain name="DomainWithInvalidMappingRules5" connectionUrl="sqlserver://localhost/" defaultDatabase="main" defaultSchema="dbo">
+        <mappingRules>
+          <rule namespace="Xtensive.Orm.Tests.Indexing" />
+        </mappingRules>
+        <databases>
+          <database name="main" realName="DO-Tests" />
+          <database name="other" realName="DO-Tests-2" />
+        </databases>
+      </domain>
+
+      <!-- Session configuration -->
+
+      <domain name="DomainWithSessionEmptyName" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session options="ClientProfile" />
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionCustomName" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="UserCreated" options="ClientProfile" />
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionCustomUser" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" userName="User" password="126654" />
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionDefaultOptions" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" options="Default" />
+        </sessions>
+      </domain>
+      <domain name="DomainWithSessionServerProfile" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" options="ServerProfile" />
+        </sessions>
+      </domain>
+      <domain name="DomainWithSessionClientProfile" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" options="ClientProfile" />
+        </sessions>
+      </domain>
+      <domain name="DomainWithSessionCustomOptions" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" options="AllowSwitching, AutoActivation, ReadRemovedObjects, ValidateEntityVersions" />
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionWithCollectionSizes" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" cacheSize="399" batchSize="20" entityChangeRegistrySize="255" />
+        </sessions>
+      </domain>
+      <domain name="DomainWithSessionCustomCacheType" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" cacheType="Infinite" />
+        </sessions>
+      </domain>
+      <domain name="DomainWithSessionCustomIsolationLevel" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" defaultIsolationLevel="ReadCommitted" />
+        </sessions>
+      </domain>
+      <domain name="DomainWithSessionCustomCommandTimeout" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" defaultCommandTimeout="300" />
+        </sessions>
+      </domain>
+      <domain name="DomainWithSessionCustomPreloadingPolicy" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" readerPreloading="Always" />
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionCustomConnectionString" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" connectionString="Data Source=localhost;Initial Catalog=DO-Tests;Integrated Security=True;MultipleActiveResultSets=True" />
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionCustomConnectionUrl" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" connectionUrl="sqlserver://localhost/DO-Tests" />
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithMultipleSessionConfigurations" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default"
+                   cacheType="Infinite"
+                   batchSize="20"
+                   entityChangeRegistrySize="255"
+                   options="AllowSwitching, AutoActivation, ReadRemovedObjects, ValidateEntityVersions"/>
+          <session name="System"
+                   cacheType="Infinite"
+                   batchSize="30"
+                   options="ServerProfile"/>
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionInvalidOptions" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" options="Defailt"/>
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionInvalidCacheSize1" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" cacheSize="-5"/>
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionInvalidCacheSize2" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" cacheSize="0"/>
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionInvalidCacheSize3" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" cacheSize="1"/>
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionInvalidBatchSize1" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" batchSize="-5"/>
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionInvalidBatchSize2" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" batchSize="0"/>
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionInvalidEntityChangeRegistry1" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" entityChangeRegistrySize="-5"/>
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionInvalidEntityChangeRegistry2" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" entityChangeRegistrySize="0"/>
+        </sessions>
+      </domain>
+
+      <domain name="DomainWithSessionInvalidCacheType" connectionUrl="sqlserver://localhost/">
+        <sessions>
+          <session name="Default" cacheType="Defailt"/>
+        </sessions>
+      </domain>
+    </domains>
+  </Xtensive.Orm.AppConfig>
+  <Xtensive.Orm.Xml>
+    <Domains>
+      <Domain name="DomainWithProviderAndConnectionString">
+        <Provider>sqlite</Provider>
+        <ConnectionString>Data Source=DO-Testsaaa.db3</ConnectionString>
+      </Domain>
+      <Domain name="DomainWithConnectionUrl">
+        <ConnectionUrl>sqlite:///DO-Tests.db3</ConnectionUrl>
+      </Domain>
+
+      <Domain name="DomainWithCustomValidKeyCacheSize">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <KeyCacheSize>192</KeyCacheSize>
+      </Domain>
+      <Domain name="DomainWithCustomInvalidKeyCacheSize" >
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <KeyCacheSize>-256</KeyCacheSize>
+      </Domain>
+
+      <Domain name="DomainWithCustomValidKeyGeneratorCacheSize">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <KeyGeneratorCacheSize>192</KeyGeneratorCacheSize>
+      </Domain>
+      <Domain name="DomainWithCustomInvalidKeyGeneratorCacheSize">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <KeyGeneratorCacheSize>-256</KeyGeneratorCacheSize>
+      </Domain>
+
+      <Domain name="DomainWithCustomValidQueryCacheSize">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <QueryCacheSize>192</QueryCacheSize>
+      </Domain>
+      <Domain name="DomainWithCustomInvalidQueryCacheSize">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <QueryCacheSize>-256</QueryCacheSize>
+      </Domain>
+
+      <Domain name="DomainWithCustomValidRecordSetMappingCacheSize">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <RecordSetMappingCacheSize>192</RecordSetMappingCacheSize>
+      </Domain>
+      <Domain name="DomainWithCustomInvalidRecordSetMappingCacheSize">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <RecordSetMappingCacheSize>-256</RecordSetMappingCacheSize>
+      </Domain>
+
+      <Domain name="DomainWithCustomDatabase">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <DefaultDatabase>MyFancyDatabase</DefaultDatabase>
+      </Domain>
+        
+      <Domain name="DomainWithCustomSchema">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <DefaultSchema>MyFancySchema</DefaultSchema>
+      </Domain>
+      
+      <Domain name="DomainWithWrongConnectionInfo"
+              upgradeMode="Recreate"
+              connectionString="Data Source=localhost;Initial Catalog=DO40-Tests;Integrated Security=True;MultipleActiveResultSets=True">
+        
+      </Domain>
+
+      <Domain name="DomainWithUpgradeMode1">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <UpgradeMode>Default</UpgradeMode>
+      </Domain>
+      <Domain name="DomainWithUpgradeMode2">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <UpgradeMode>Recreate</UpgradeMode>
+      </Domain>
+      <Domain name="DomainWithUpgradeMode3">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <UpgradeMode>Perform</UpgradeMode>
+      </Domain>
+      <Domain name="DomainWithUpgradeMode4">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <UpgradeMode>PerformSafely</UpgradeMode>
+      </Domain>
+      <Domain name="DomainWithUpgradeMode5">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <UpgradeMode>Validate</UpgradeMode>
+      </Domain>
+      <Domain name="DomainWithUpgradeMode6">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <UpgradeMode>LegacyValidate</UpgradeMode>
+      </Domain>
+      <Domain name="DomainWithUpgradeMode7">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <UpgradeMode>Skip</UpgradeMode>
+      </Domain>
+      <Domain name="DomainWithUpgradeMode8">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <UpgradeMode>LegacySkip</UpgradeMode>
+      </Domain>
+
+      <Domain name="DomainWithWrongUpgradeMode">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <UpgradeMode>Defailt</UpgradeMode>
+      </Domain>
+
+      <Domain name="DomainWithForeignKeyMode1">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <ForeignKeyMode>None</ForeignKeyMode>
+      </Domain>
+      <Domain name="DomainWithForeignKeyMode2">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <ForeignKeyMode>Hierarchy</ForeignKeyMode>
+      </Domain>
+      <Domain name="DomainWithForeignKeyMode3">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <ForeignKeyMode>Reference</ForeignKeyMode>
+      </Domain>
+      <Domain name="DomainWithForeignKeyMode4">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <ForeignKeyMode>All</ForeignKeyMode>
+      </Domain>
+      <Domain name="DomainWithForeignKeyMode5">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <ForeignKeyMode>Default</ForeignKeyMode>
+      </Domain>
+      <Domain name="DomainWithForeignKeyMode6">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <ForeignKeyMode>Hierarchy,Reference</ForeignKeyMode>
+      </Domain>
+
+      <Domain name="DomainWithInvalidForeignKeyMode">
+        <ConnectionUrl>sqlserver://localhost/DO40-Tests</ConnectionUrl>
+        <ForeignKeyMode>Defailt</ForeignKeyMode>
+      </Domain>
+
+      <Domain name="DomainWithChangeTrackingMode1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <FullTextChangeTrackingMode>Off</FullTextChangeTrackingMode>
+      </Domain>
+      <Domain name="DomainWithChangeTrackingMode2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <FullTextChangeTrackingMode>Auto</FullTextChangeTrackingMode>
+      </Domain>
+      <Domain name="DomainWithChangeTrackingMode3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <FullTextChangeTrackingMode>Manual</FullTextChangeTrackingMode>
+      </Domain>
+      <Domain name="DomainWithChangeTrackingMode4">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <FullTextChangeTrackingMode>OffWithNoPopulation</FullTextChangeTrackingMode>
+      </Domain>
+      <Domain name="DomainWithChangeTrackingMode5">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <FullTextChangeTrackingMode>Default</FullTextChangeTrackingMode>
+      </Domain>
+
+      <Domain name="DomainWithInvalidChangeTrackingMode">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <FullTextChangeTrackingMode>Defailt</FullTextChangeTrackingMode>
+      </Domain>
+
+      <Domain name="DomainWithDomainOptionsValid1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Options>Default</Options>
+      </Domain>
+      <Domain name="DomainWithDomainOptionsValid2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Options>None</Options>
+      </Domain>
+
+      <Domain name="DomainWithDomainOptionsInvalid">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Options>Defailt</Options>
+      </Domain>
+
+      <Domain name="DomainWithColation">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Collation>generalci</Collation>
+      </Domain>
+
+      <Domain name="DomainWithBriefSchemaSyncExceptions">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <SchemaSyncExceptionFormat>Brief</SchemaSyncExceptionFormat>
+      </Domain>
+      <Domain name="DomainWithDetailedSchemaSyncExceptions">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <SchemaSyncExceptionFormat>Detailed</SchemaSyncExceptionFormat>
+      </Domain>
+      <Domain name="DomainWithDefaultSchemaSyncExceptions">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <SchemaSyncExceptionFormat>Default</SchemaSyncExceptionFormat>
+      </Domain>
+      <Domain name="DomainWithInvalidSchemaSyncExceptions">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <SchemaSyncExceptionFormat>Defailt</SchemaSyncExceptionFormat>
+      </Domain>
+
+      <Domain name="DomainWithTagsLocationNowhere">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <TagsLocation>Nowhere</TagsLocation>
+      </Domain>
+      <Domain name="DomainWithTagsLocationBefore">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <TagsLocation>BeforeStatement</TagsLocation>
+      </Domain>
+      <Domain name="DomainWithTagsLocationWithin">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <TagsLocation>WithinStatement</TagsLocation>
+      </Domain>
+      <Domain name="DomainWithTagsLocationAfter">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <TagsLocation>AfterStatement</TagsLocation>
+      </Domain>
+      <Domain name="DomainWithTagsLocationDefault">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <TagsLocation>Default</TagsLocation>
+      </Domain>
+      <Domain name="DomainWithTagsLocationInvalid">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <TagsLocation>Defailt</TagsLocation>
+      </Domain>
+
+      <Domain name="DomainWithForcedServerVersion">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <ForcedServerVersion>10.0.0.0</ForcedServerVersion>
+      </Domain>
+
+      <Domain name="DomainWithInitSql">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <ConnectionInitializationSql>use [OtherDb]</ConnectionInitializationSql>
+      </Domain>
+
+      <Domain name="IncludeSqlInExceptionsTrue">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <IncludeSqlInExceptions>true</IncludeSqlInExceptions>
+      </Domain>
+      <Domain name="IncludeSqlInExceptionsFalse">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <IncludeSqlInExceptions>false</IncludeSqlInExceptions>
+      </Domain>
+      <Domain name="AllowCyclicDatabaseDependenciesTrue">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <AllowCyclicDatabaseDependencies>true</AllowCyclicDatabaseDependencies>
+      </Domain>
+      <Domain name="AllowCyclicDatabaseDependenciesFalse">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <AllowCyclicDatabaseDependencies>false</AllowCyclicDatabaseDependencies>
+      </Domain>
+
+      <Domain name="BuildInParallelTrue">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <BuildInParallel>true</BuildInParallel>
+      </Domain>
+      <Domain name="BuildInParallelFalse">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <BuildInParallel>false</BuildInParallel>
+      </Domain>
+
+      <Domain name="MultidatabaseKeysTrue">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <MultidatabaseKeys>true</MultidatabaseKeys>
+      </Domain>
+      <Domain name="MultidatabaseKeysFalse">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <MultidatabaseKeys>false</MultidatabaseKeys>
+      </Domain>
+
+      <Domain name="SharedStorageSchemaOn">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <ShareStorageSchemaOverNodes>true</ShareStorageSchemaOverNodes>
+      </Domain>
+      <Domain name="SharedStorageSchemaOff">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <ShareStorageSchemaOverNodes>false</ShareStorageSchemaOverNodes>
+      </Domain>
+
+      <Domain name="EnableConnectionIsAliveTrue">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <EnsureConnectionIsAlive>true</EnsureConnectionIsAlive>
+      </Domain>
+      <Domain name="EnableConnectionIsAliveFalse">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <EnsureConnectionIsAlive>false</EnsureConnectionIsAlive>
+      </Domain>
+
+      <Domain name="PreferTypeIdsAsQueryParametersTrue">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <PreferTypeIdsAsQueryParameters>true</PreferTypeIdsAsQueryParameters>
+      </Domain>
+      <Domain name="PreferTypeIdsAsQueryParametersFalse">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <PreferTypeIdsAsQueryParameters>false</PreferTypeIdsAsQueryParameters>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Uppercase</LetterCasePolicy>
+          <NamespacePolicy>Synonymize</NamespacePolicy>
+          <NamingRules>UnderscoreHyphens,RemoveDots</NamingRules>
+          <NamespaceSynonyms>
+            <Synonym>
+              <Namespace>Xtensive.Orm</Namespace>
+              <Synonym>system</Synonym>
+            </Synonym>
+            <Synonym>
+              <Namespace>Xtensive.Orm.Tests</Namespace>
+              <Synonym>theRest</Synonym>
+            </Synonym>
+          </NamespaceSynonyms>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Lowercase</LetterCasePolicy>
+          <NamespacePolicy>Synonymize</NamespacePolicy>
+          <NamingRules>UnderscoreHyphens,RemoveDots</NamingRules>
+          <NamespaceSynonyms>
+            <Synonym>
+              <Namespace>Xtensive.Orm</Namespace>
+              <Synonym>system</Synonym>
+            </Synonym>
+            <Synonym>
+              <Namespace>Xtensive.Orm.Tests</Namespace>
+              <Synonym>theRest</Synonym>
+            </Synonym>
+          </NamespaceSynonyms>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>AsIs</LetterCasePolicy>
+          <NamespacePolicy>Synonymize</NamespacePolicy>
+          <NamingRules>UnderscoreHyphens,RemoveDots</NamingRules>
+          <NamespaceSynonyms>
+            <Synonym>
+              <Namespace>Xtensive.Orm</Namespace>
+              <Synonym>system</Synonym>
+            </Synonym>
+            <Synonym>
+              <Namespace>Xtensive.Orm.Tests</Namespace>
+              <Synonym>theRest</Synonym>
+            </Synonym>
+          </NamespaceSynonyms>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention4">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Default</LetterCasePolicy>
+          <NamespacePolicy>Synonymize</NamespacePolicy>
+          <NamingRules>UnderscoreHyphens,RemoveDots</NamingRules>
+          <NamespaceSynonyms>
+            <Synonym>
+              <Namespace>Xtensive.Orm</Namespace>
+              <Synonym>system</Synonym>
+            </Synonym>
+            <Synonym>
+              <Namespace>Xtensive.Orm.Tests</Namespace>
+              <Synonym>theRest</Synonym>
+            </Synonym>
+          </NamespaceSynonyms>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention5">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Uppercase</LetterCasePolicy>
+          <NamespacePolicy>AsIs</NamespacePolicy>
+          <NamingRules>UnderscoreHyphens,RemoveDots</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention6">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Uppercase</LetterCasePolicy>
+          <NamespacePolicy>Hash</NamespacePolicy>
+          <NamingRules>UnderscoreHyphens,RemoveDots</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention7">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Uppercase</LetterCasePolicy>
+          <NamespacePolicy>Omit</NamespacePolicy>
+          <NamingRules>UnderscoreHyphens,RemoveDots</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention8">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Uppercase</LetterCasePolicy>
+          <NamespacePolicy>Default</NamespacePolicy>
+          <NamingRules>UnderscoreHyphens,RemoveDots</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention9">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Uppercase</LetterCasePolicy>
+          <NamespacePolicy>Hash</NamespacePolicy>
+          <NamingRules>UnderscoreDots,RemoveHyphens</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention10">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Uppercase</LetterCasePolicy>
+          <NamespacePolicy>Hash</NamespacePolicy>
+          <NamingRules>None</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithNamingConvention11">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Uppercase</LetterCasePolicy>
+          <NamespacePolicy>Hash</NamespacePolicy>
+          <NamingRules>Default</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithInvalidNamingConvention1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Defailt</LetterCasePolicy>
+          <NamespacePolicy>Default</NamespacePolicy>
+          <NamingRules>Default</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithInvalidNamingConvention2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Default</LetterCasePolicy>
+          <NamespacePolicy>Defailt</NamespacePolicy>
+          <NamingRules>Default</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+      <Domain name="DomainWithInvalidNamingConvention3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <NamingConvention>
+          <LetterCasePolicy>Default</LetterCasePolicy>
+          <NamespacePolicy>Default</NamespacePolicy>
+          <NamingRules>Defailt</NamingRules>
+        </NamingConvention>
+      </Domain>
+
+
+      <Domain name="DomainWithVersioningConvention1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <VersioningConvention>
+          <EntityVersioningPolicy>Pessimistic</EntityVersioningPolicy>
+        </VersioningConvention>
+      </Domain>
+
+      <Domain name="DomainWithVersioningConvention2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <VersioningConvention>
+          <EntityVersioningPolicy>Optimistic</EntityVersioningPolicy>
+        </VersioningConvention>
+      </Domain>
+
+      <Domain name="DomainWithVersioningConvention3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <VersioningConvention>
+          <EntityVersioningPolicy>Default</EntityVersioningPolicy>
+        </VersioningConvention>
+      </Domain>
+
+      <Domain name="DomainWithVersioningConvention4">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <VersioningConvention>
+          <EntityVersioningPolicy>Optimistic</EntityVersioningPolicy>
+          <DenyEntitySetOwnerVersionChange>true</DenyEntitySetOwnerVersionChange>
+        </VersioningConvention>
+      </Domain>
+
+      <Domain name="DomainWithVersioningConvention5">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <VersioningConvention>
+          <EntityVersioningPolicy>Optimistic</EntityVersioningPolicy>
+          <DenyEntitySetOwnerVersionChange>false</DenyEntitySetOwnerVersionChange>
+        </VersioningConvention> 
+      </Domain>
+
+      <Domain name="DomainWithInvalidVersioningConvention1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <VersioningConvention>
+          <EntityVersioningPolicy>Defauit</EntityVersioningPolicy>
+        </VersioningConvention>
+      </Domain>
+
+      <Domain name="DomainWithTypes">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Types>
+          <Registration>
+            <Type>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests</Type>
+          </Registration>
+          <Registration>
+            <Type>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity2, Xtensive.Orm.Tests</Type>
+          </Registration>
+        </Types>
+      </Domain>
+
+      <Domain name="DomainWithAssemblies">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+          <Registration>
+            <Assembly>Xtensive.Orm</Assembly>
+          </Registration>
+        </types>
+      </Domain>
+
+      <Domain name="DomainWithAssembliesAndNamespaces">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+          <Registration>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Namespace>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace</Namespace>
+          </Registration>
+        </types>
+      </Domain>
+
+      <Domain name="DomainWithMixedRegistrations">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+          <Registration>
+            <Type>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests</Type>
+          </Registration>
+          <Registration>
+            <Type>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity2, Xtensive.Orm.Tests</Type>
+          </Registration>
+          <Registration>
+            <Assembly>Xtensive.Orm</Assembly>
+          </Registration>
+          <Registration>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Namespace>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace</Namespace>
+          </Registration>
+        </types>
+      </Domain>
+
+      <Domain name="DomainWithInvalidRegistrations1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+          <Registration>
+            <Type>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests</Type>
+          </Registration>
+          <Registration>
+            <Type>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests</Type>
+          </Registration>
+        </types>
+      </Domain>
+
+      <Domain name="DomainWithInvalidRegistrations2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+          <Registration>
+            <Assembly>Xtensive.Orm</Assembly>
+          </Registration>
+          <Registration>
+            <Assembly>Xtensive.Orm</Assembly>
+          </Registration>
+        </types>
+      </Domain>
+
+      <Domain name="DomainWithInvalidRegistrations3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+          <Registration>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Namespace>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace</Namespace>
+          </Registration>
+          <Registration>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Namespace>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace</Namespace>
+          </Registration>
+        </types>
+      </Domain>
+
+      <Domain name="DomainWithInvalidRegistrations4">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+          <Registration>
+            <Type>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests</Type>
+            <Assembly>Xtensive.Orm</Assembly>
+            <Namespace>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace</Namespace>
+          </Registration>
+        </types>
+      </Domain>
+
+      <Domain name="DomainWithInvalidRegistrations5">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+          <Registration>
+            <Type>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests</Type>
+            <Assembly>Xtensive.Orm</Assembly>
+          </Registration>
+        </types>
+      </Domain>
+
+      <Domain name="DomainWithInvalidRegistrations6">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+          <Registration>
+            <Type>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests</Type>
+            <Namespace>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace</Namespace>
+          </Registration>
+        </types>
+      </Domain>
+
+      <Domain name="DomainWithInvalidRegistrations7">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <types>
+           <Registration>
+            <Namespace>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace</Namespace>
+          </Registration>
+        </types>
+      </Domain>
+
+
+      <Domain name="DomainWithDatabases1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests-1</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+      <Domain name="DomainWithDatabases2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests-1</RealName>
+            <MinTypeId>100</MinTypeId>
+            <MaxTypeId>1000</MaxTypeId>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+            <MinTypeId>2000</MinTypeId>
+            <MaxTypeId>3000</MaxTypeId>
+          </Database>
+        </Databases>
+      </Domain>
+
+
+      <Domain name="DomainWithInvalidDatabases1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests-1</RealName>
+            <MinTypeId>-10</MinTypeId>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithInvalidDatabases2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests-1</RealName>
+            <MinTypeId>50</MinTypeId>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithInvalidDatabases3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests-1</RealName>
+            <MaxTypeId>-10</MaxTypeId>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithInvalidDatabases4">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests-1</RealName>
+            <MaxTypeId>50</MaxTypeId>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithCustomGenerator">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <KeyGenerators>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Seed>12</Seed>
+            <CacheSize>127</CacheSize>
+          </KeyGenerator>
+        </KeyGenerators>
+      </Domain>
+
+      <Domain name="DomainWithCustomGeneratorsWithDatabaseNames">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <KeyGenerators>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>DO-Tests-1</Database>
+          </KeyGenerator>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>DO-Tests-2</Database>
+          </KeyGenerator>  
+        </KeyGenerators>
+      </Domain>
+
+      <Domain name="DomainWithCustomGeneratorsWithDatabaseNamesAndKeyParams">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <KeyGenerators>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>DO-Tests-1</Database>
+            <Seed>12</Seed>
+            <CacheSize>127</CacheSize>
+          </KeyGenerator>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>DO-Tests-2</Database>
+            <Seed>13</Seed>
+            <CacheSize>129</CacheSize>
+          </KeyGenerator>
+        </KeyGenerators>
+      </Domain>
+
+      <Domain name="DomainWithCustomGeneratorsWithDatabasesAliases">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <KeyGenerators>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>main</Database>
+            <Seed>12</Seed>
+            <CacheSize>127</CacheSize>
+          </KeyGenerator>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>other</Database>
+            <Seed>13</Seed>
+            <CacheSize>129</CacheSize>
+          </KeyGenerator>
+        </KeyGenerators>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests-1</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithCustomGeneratorsConflict1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <KeyGenerators>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>DO-Tests-1</Database>
+          </KeyGenerator>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>DO-Tests-1</Database>
+          </KeyGenerator>
+        </KeyGenerators>
+      </Domain>
+      <Domain name="DomainWithCustomGeneratorsConflict2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <KeyGenerators>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>DO-Tests-1</Database>
+          </KeyGenerator>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>main</Database>
+          </KeyGenerator>
+        </KeyGenerators>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests-1</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+      <Domain name="DomainWithCustomGeneratorNegativeSeed">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <KeyGenerators>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>DO-Tests-1</Database>
+            <Seed>-12</Seed>
+          </KeyGenerator>
+        </KeyGenerators>
+      </Domain>
+      <Domain name="DomainWithCustomGeneratorNegativeCache">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <KeyGenerators>
+          <KeyGenerator>
+            <Name>Int32</Name>
+            <Database>DO-Tests-1</Database>
+            <CacheSize>-127</CacheSize>
+          </KeyGenerator>
+        </KeyGenerators>
+      </Domain>
+
+      <!-- Ignore rules -->
+      <Domain name="DomainWithIgnoreRules">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <IgnoreRules>
+          <Rule>
+            <Database>Other-DO40-Tests</Database>
+            <Schema>some-schema1</Schema>
+            <Table>table1</Table>
+          </Rule>
+          <Rule>
+            <Database>some-database</Database>
+            <Schema>some-schema2</Schema>
+            <Column>column2</Column>
+          </Rule>
+          <Rule>
+            <Database>some-database</Database>
+            <Schema>some-schema2</Schema>
+            <Index>index2</Index>
+          </Rule>
+          <Rule>
+            <Database>some-database</Database>
+            <Schema>some-schema3</Schema>
+            <Table>table2</Table>
+            <Column>col3</Column>
+          </Rule>
+          <Rule>
+            <Database>some-database</Database>
+            <Schema>some-schema3</Schema>
+            <Table>table2</Table>
+            <Index>index3</Index>
+          </Rule>
+          <Rule>
+            <Database>another-some-database</Database>
+            <Table>some-table</Table>
+          </Rule>
+          <Rule>
+            <Database>database1</Database>
+            <Column>some-column</Column>
+          </Rule>
+          <Rule>
+            <Database>database1</Database>
+            <Index>some-index</Index>
+          </Rule>
+          <rule>
+            <Schema>schema1</Schema>
+            <Table>table1</Table>
+          </rule>
+          <rule>
+            <Schema>schema1</Schema>
+            <Column>column2</Column>
+          </rule>
+          <rule>
+            <Schema>schema1</Schema>
+            <Index>index2</Index>
+          </rule>
+          <rule>
+            <Schema>schema1</Schema>
+            <Table>table2</Table>
+            <Column>column3</Column>
+          </rule>
+          <rule>
+            <Schema>schema1</Schema>
+            <Table>table2</Table>
+            <Index>index3</Index>
+          </rule>
+          <rule>
+            <Table>table4</Table>
+            <Column>column3</Column>
+          </rule>
+          <rule>
+            <Table>table4</Table>
+            <Index>index2</Index>
+          </rule>
+          <rule>
+            <Table>single-table</Table>
+          </rule>
+          <rule>
+            <Column>single-column</Column>
+          </rule>
+          <rule>
+            <Index>single-index</Index>
+          </rule>
+        </IgnoreRules>
+      </Domain>
+
+      <Domain name="DomainWithInvalidIgnoreRules1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <IgnoreRules>
+          <Rule>
+            <Column>column1</Column>
+            <Index>index1</Index>
+          </Rule>
+        </IgnoreRules>
+      </Domain>
+      <Domain name="DomainWithInvalidIgnoreRules2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <IgnoreRules>
+          <Rule>
+            <Table>table1</Table>
+            <Column>column1</Column>
+            <Index>index1</Index>
+          </Rule>
+        </IgnoreRules>
+      </Domain>
+      <Domain name="DomainWithInvalidIgnoreRules3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <IgnoreRules>
+          <Rule>
+            <Database>database1</Database>
+          </Rule>
+        </IgnoreRules>
+      </Domain>
+      <Domain name="DomainWithInvalidIgnoreRules4">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <IgnoreRules>
+          <Rule>
+            <Database>Other-DO40-Tests</Database>
+            <Schema>some-schema1</Schema>
+          </Rule>
+        </IgnoreRules>
+      </Domain>
+
+      <!-- Mapping Rules -->
+      <Domain name="DomainWithMappingRules1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Database>DO-Tests-1</Database>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithMappingRules2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Schema>Model1</Schema>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithMappingRules3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Namespace>Xtensive.Orm.Configuration.Options</Namespace>
+            <Database>DO-Tests-2</Database>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithMappingRules4">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Namespace>Xtensive.Orm.Tests.Configuration</Namespace>
+            <Schema>Model2</Schema>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithMappingRules5">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Namespace>Xtensive.Orm.Tests.Configuration.TypesToUseInTests</Namespace>
+            <Database>DO-Tests-3</Database>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithMappingRules6">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Namespace>Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace</Namespace>
+            <Schema>Model3</Schema>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithMappingRules7">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Namespace>Xtensive.Orm.Tests.Indexing</Namespace>
+            <Database>main</Database>
+            <Schema>Model4</Schema>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithConflictMappingRules1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Database>DO-Tests-1</Database>
+          </Rule>
+          <Rule>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Schema>Model1</Schema>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithConflictMappingRules2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Namespace>Xtensive.Orm.Tests.Configuration</Namespace>
+            <Database>DO-Tests-1</Database>
+          </Rule>
+          <Rule>
+            <Namespace>Xtensive.Orm.Tests.Configuration</Namespace>
+            <Schema>Model2</Schema>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithInvalidMappingRules1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Database>DO-Tests-1</Database>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithInvalidMappingRules2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Schema>Model4</Schema>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithInvalidMappingRules3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+            <Namespace>Xtensive.Orm.Tests.Configuration</Namespace>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithInvalidMappingRules4">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Assembly>Xtensive.Orm.Tests</Assembly>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <Domain name="DomainWithInvalidMappingRules5">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <DefaultDatabase>main</DefaultDatabase>
+        <DefaultSchema>dbo</DefaultSchema>
+        <MappingRules>
+          <Rule>
+            <Namespace>Xtensive.Orm.Tests.Indexing</Namespace>
+          </Rule>
+        </MappingRules>
+        <Databases>
+          <Database>
+            <Name>main</Name>
+            <RealName>DO-Tests</RealName>
+          </Database>
+          <Database>
+            <Name>other</Name>
+            <RealName>DO-Tests-2</RealName>
+          </Database>
+        </Databases>
+      </Domain>
+
+      <!-- Session configuration -->
+
+      <Domain name="DomainWithSessionEmptyName">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session>
+            <Options>ClientProfile</Options>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionCustomName">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="UserCreated">
+            <Options>ClientProfile</Options>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionCustomUser">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <UserName>User</UserName>
+            <Password>126654</Password>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionDefaultOptions">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <Options>Default</Options>
+          </Session>
+        </Sessions>
+      </Domain>
+      <Domain name="DomainWithSessionServerProfile">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <Options>ServerProfile</Options>
+          </Session>
+        </Sessions>
+      </Domain>
+      <Domain name="DomainWithSessionClientProfile">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default" options="ClientProfile"></Session>
+        </Sessions>
+      </Domain>
+      <Domain name="DomainWithSessionCustomOptions">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <Options>AllowSwitching, AutoActivation, ReadRemovedObjects, ValidateEntityVersions</Options>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionWithCollectionSizes">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <CacheSize>399</CacheSize>
+            <BatchSize>20</BatchSize>
+            <EntityChangeRegistrySize>255</EntityChangeRegistrySize>
+          </Session>
+        </Sessions>
+      </Domain>
+      <Domain name="DomainWithSessionCustomCacheType">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <CacheType>Infinite</CacheType>
+          </Session>
+        </Sessions>
+      </Domain>
+      <Domain name="DomainWithSessionCustomIsolationLevel">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <DefaultIsolationLevel>ReadCommitted</DefaultIsolationLevel>
+          </Session>
+        </Sessions>
+      </Domain>
+      <Domain name="DomainWithSessionCustomCommandTimeout">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <DefaultCommandTimeout>300</DefaultCommandTimeout>
+          </Session>
+        </Sessions>
+      </Domain>
+      <Domain name="DomainWithSessionCustomPreloadingPolicy">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <session name="Default">
+            <ReaderPreloading>Always</ReaderPreloading>
+          </session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionCustomConnectionString">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <ConnectionString>Data Source=localhost;Initial Catalog=DO-Tests;Integrated Security=True;MultipleActiveResultSets=True</ConnectionString>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionCustomConnectionUrl">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <ConnectionUrl>sqlserver://localhost/DO-Tests</ConnectionUrl>
+          </Session>
+        </Sessions>
+      </Domain>
+    
+  
+
+      <Domain name="DomainWithMultipleSessionConfigurations">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <CacheType>Infinite</CacheType>
+            <BatchSize>20</BatchSize>
+            <EntityChangeRegistrySize>255</EntityChangeRegistrySize>
+            <Options>AllowSwitching, AutoActivation, ReadRemovedObjects, ValidateEntityVersions</Options>
+          </Session>
+          <Session name="System">
+            <CacheType>Infinite</CacheType>
+            <BatchSize>30</BatchSize>
+            <Options>ServerProfile</Options>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionInvalidOptions">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <Options>Defailt</Options>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionInvalidCacheSize1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <CacheSize>-5</CacheSize>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionInvalidCacheSize2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <CacheSize>0</CacheSize>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionInvalidCacheSize3">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <CacheSize>1</CacheSize>
+          </Session>
+        </Sessions>
+      </Domain>
+      
+      <Domain name="DomainWithSessionInvalidBatchSize1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <BatchSize>-5</BatchSize>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionInvalidBatchSize2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <BatchSize>0</BatchSize>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionInvalidEntityChangeRegistry1">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <EntityChangeRegistrySize>-5</EntityChangeRegistrySize>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <Domain name="DomainWithSessionInvalidEntityChangeRegistry2">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <EntityChangeRegistrySize>0</EntityChangeRegistrySize>
+          </Session>
+        </Sessions>
+      </Domain>
+
+      <domain name="DomainWithSessionInvalidCacheType">
+        <ConnectionUrl>sqlserver://localhost/</ConnectionUrl>
+        <Sessions>
+          <Session name="Default">
+            <CacheType>Defailt</CacheType>
+          </Session>
+        </Sessions>
+      </domain>
+    </Domains>
+  </Xtensive.Orm.Xml>
+</configuration>

--- a/Orm/Xtensive.Orm.Tests/domainSettings.config
+++ b/Orm/Xtensive.Orm.Tests/domainSettings.config
@@ -879,7 +879,27 @@
         </sessions>
       </domain>
     </domains>
+
+    <logging provider="Xtensive.Orm.Logging.log4net.LogProvider">
+      <log source="*" target="Console"/>
+      <log source="SomeLogName" target="DebugOnlyConsole"/>
+      <log source="FirstLogName,SecondLogName" target="d:\log.txt"/>
+      <log source="LogName, AnotherLogName" target ="Console"/>
+      <log source="FileLog" target="log.txt"/>
+      <log source="NullLog" target="None"/>
+      <log source="Trash" target="skjdhfjsdf sdfsdfksjdghj fgdfg"/>
+    </logging>
   </Xtensive.Orm.AppConfig>
+
+  <Xtensive.Orm.EmptyLogging.AppConfig>
+    <logging>
+    </logging>
+  </Xtensive.Orm.EmptyLogging.AppConfig>
+  <Xtensive.Orm.OnlyLogProvider.AppConfig>
+    <logging provider="Xtensive.Orm.Logging.log4net.LogProvider">
+    </logging>
+  </Xtensive.Orm.OnlyLogProvider.AppConfig>
+
   <Xtensive.Orm.Xml>
     <Domains>
       <Domain name="DomainWithProviderAndConnectionString">
@@ -2374,5 +2394,60 @@
         </Sessions>
       </domain>
     </Domains>
+    <Logging>
+      <Provider>Xtensive.Orm.Logging.log4net.LogProvider</Provider>
+      <Logs>
+        <Log>
+          <Source>*</Source>
+          <Target>Console</Target>
+        </Log>
+        <Log>
+          <Source>SomeLogName</Source>
+          <Target>DebugOnlyConsole</Target>
+        </Log>
+        <Log>
+          <Source>FirstLogName,SecondLogName</Source>
+          <Target>d:\log.txt</Target>
+        </Log>
+        <Log>
+          <Source>LogName, AnotherLogName</Source>
+          <Target>Console</Target>
+        </Log>
+        <Log>
+          <Source>FileLog</Source>
+          <Target>log.txt</Target>
+        </Log>
+        <Log>
+          <Source>NullLog</Source>
+          <Target>None</Target>
+        </Log>
+        <Log>
+          <Source>Trash</Source>
+          <Target>skjdhfjsdf sdfsdfksjdghj fgdfg</Target>
+        </Log>
+      </Logs>
+    </Logging>
   </Xtensive.Orm.Xml>
+  <Xtensive.Orm.EmptyLogging.Xml>
+    <Logging>
+    </Logging>
+  </Xtensive.Orm.EmptyLogging.Xml>
+  <Xtensive.Orm.EmptyLogs.Xml>
+    <Logging>
+      <Logs>
+      </Logs>
+    </Logging>
+  </Xtensive.Orm.EmptyLogs.Xml>
+  <Xtensive.Orm.OnlyLogProvider.Xml>
+    <Logging>
+      <Provider>Xtensive.Orm.Logging.log4net.LogProvider</Provider>
+    </Logging>
+  </Xtensive.Orm.OnlyLogProvider.Xml>
+  <Xtensive.Orm.LogProviderAndEmptyLogs.Xml>
+    <Logging>
+      <Provider>Xtensive.Orm.Logging.log4net.LogProvider</Provider>
+      <Logs>
+      </Logs>
+    </Logging>
+  </Xtensive.Orm.LogProviderAndEmptyLogs.Xml>
 </configuration>

--- a/Orm/Xtensive.Orm.Tests/domainSettings.json
+++ b/Orm/Xtensive.Orm.Tests/domainSettings.json
@@ -1,0 +1,1414 @@
+{
+  "Xtensive.Orm.Json": {
+    "Domains": {
+      "DomainWithProviderAndConnectionString": {
+        "Provider": "sqlite",
+        "ConnectionString": "Data Source=DO-Testsaaa.db3"
+      },
+
+      "DomainWithConnectionUrl": {
+        "ConnectionUrl": "sqlite:///DO-Tests.db3"
+      },
+
+      "DomainWithCustomValidKeyCacheSize": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "KeyCacheSize": 192
+      },
+      "DomainWithCustomInvalidKeyCacheSize": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "KeyCacheSize": -256
+      },
+
+      "DomainWithCustomValidKeyGeneratorCacheSize": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "KeyGeneratorCacheSize": 192
+      },
+      "DomainWithCustomInvalidKeyGeneratorCacheSize": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "KeyGeneratorCacheSize": -256
+      },
+
+      "DomainWithCustomValidQueryCacheSize": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "QueryCacheSize": 192
+      },
+      "DomainWithCustomInvalidQueryCacheSize": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "QueryCacheSize": -256
+      },
+
+      "DomainWithCustomValidRecordSetMappingCacheSize": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "RecordSetMappingCacheSize": 192
+      },
+      "DomainWithCustomInvalidRecordSetMappingCacheSize": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "RecordSetMappingCacheSize": -256
+      },
+
+      "DomainWithCustomDatabase": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "DefaultDatabase": "MyFancyDatabase"
+      },
+
+      "DomainWithCustomSchema": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "DefaultSchema": "MyFancySchema"
+      },
+
+      "DomainWithWrongConnectionInfo": {
+        "UpgradeMode": "Recreate",
+        "ConnectionString": "Data Source=localhost;Initial Catalog=DO40-Tests;Integrated Security=True;MultipleActiveResultSets=True"
+      },
+
+      "DomainWithUpgradeMode1": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "UpgradeMode": "Default"
+      },
+      "DomainWithUpgradeMode2": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "UpgradeMode": "Recreate"
+      },
+      "DomainWithUpgradeMode3": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "UpgradeMode": "Perform"
+      },
+      "DomainWithUpgradeMode4": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "UpgradeMode": "PerformSafely"
+      },
+      "DomainWithUpgradeMode5": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "UpgradeMode": "Validate"
+      },
+      "DomainWithUpgradeMode6": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "UpgradeMode": "LegacyValidate"
+      },
+      "DomainWithUpgradeMode7": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "UpgradeMode": "Skip"
+      },
+      "DomainWithUpgradeMode8": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "UpgradeMode": "LegacySkip"
+      },
+
+      "DomainWithWrongUpgradeMode": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "UpgradeMode": "Defailt"
+      },
+
+      "DomainWithForeignKeyMode1": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "ForeignKeyMode": "None"
+      },
+      "DomainWithForeignKeyMode2": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "ForeignKeyMode": "Hierarchy"
+      },
+      "DomainWithForeignKeyMode3": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "ForeignKeyMode": "Reference"
+      },
+      "DomainWithForeignKeyMode4": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "ForeignKeyMode": "All"
+      },
+      "DomainWithForeignKeyMode5": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "ForeignKeyMode": "Default"
+      },
+      "DomainWithForeignKeyMode6": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "ForeignKeyMode": "Hierarchy,Reference"
+      },
+      "DomainWithInvalidForeignKeyMode": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "ForeignKeyMode": "Defauit"
+      },
+
+      "DomainWithChangeTrackingMode1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "FullTextChangeTrackingMode": "Off"
+      },
+      "DomainWithChangeTrackingMode2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "FullTextChangeTrackingMode": "Auto"
+      },
+      "DomainWithChangeTrackingMode3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "FullTextChangeTrackingMode": "Manual"
+      },
+      "DomainWithChangeTrackingMode4": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "FullTextChangeTrackingMode": "OffWithNoPopulation"
+      },
+      "DomainWithChangeTrackingMode5": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "FullTextChangeTrackingMode": "Default"
+      },
+      "DomainWithInvalidChangeTrackingMode": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "FullTextChangeTrackingMode": "Defauit"
+      },
+
+      "DomainWithDomainOptionsValid1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Options": "Default"
+      },
+      "DomainWithDomainOptionsValid2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Options": "None"
+      },
+      "DomainWithDomainOptionsInvalid": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Options": "Defauit"
+      },
+
+      "DomainWithColation": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Collation": "generalci"
+      },
+
+      "DomainWithBriefSchemaSyncExceptions": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "SchemaSyncExceptionFormat": "Brief"
+      },
+      "DomainWithDetailedSchemaSyncExceptions": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "SchemaSyncExceptionFormat": "Detailed"
+      },
+      "DomainWithDefaultSchemaSyncExceptions": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "SchemaSyncExceptionFormat": "Default"
+      },
+      "DomainWithInvalidSchemaSyncExceptions": {
+        "ConnectionUrl": "sqlserver://localhost/DO40-Tests",
+        "SchemaSyncExceptionFormat": "Defailt"
+      },
+
+      "DomainWithTagsLocationNowhere": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "TagsLocation": "Nowhere"
+      },
+      "DomainWithTagsLocationBefore": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "TagsLocation": "BeforeStatement"
+      },
+      "DomainWithTagsLocationWithin": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "TagsLocation": "WithinStatement"
+      },
+      "DomainWithTagsLocationAfter": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "TagsLocation": "AfterStatement"
+      },
+      "DomainWithTagsLocationDefault": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "TagsLocation": "Default"
+      },
+      "DomainWithTagsLocationInvalid": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "TagsLocation": "Defauit"
+      },
+
+      "DomainWithForcedServerVersion": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "ForcedServerVersion": "10.0.0.0"
+      },
+      "DomainWithInitSql": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "ConnectionInitializationSql": "use [OtherDb]"
+      },
+
+      "IncludeSqlInExceptionsTrue": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "IncludeSqlInExceptions": true
+      },
+      "IncludeSqlInExceptionsFalse": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "IncludeSqlInExceptions": false
+      },
+
+      "AllowCyclicDatabaseDependenciesTrue": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "AllowCyclicDatabaseDependencies": true
+      },
+      "AllowCyclicDatabaseDependenciesFalse": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "AllowCyclicDatabaseDependencies": false
+      },
+
+      "BuildInParallelTrue": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "BuildInParallel": true
+      },
+      "BuildInParallelFalse": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "BuildInParallel": false
+      },
+
+      "MultidatabaseKeysTrue": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "MultidatabaseKeys": true
+      },
+      "MultidatabaseKeysFalse": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "MultidatabaseKeys": false
+      },
+
+      "SharedStorageSchemaOn": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "ShareStorageSchemaOverNodes": true
+      },
+      "SharedStorageSchemaOff": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "ShareStorageSchemaOverNodes": false
+      },
+
+      "EnableConnectionIsAliveTrue": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "EnsureConnectionIsAlive": true
+      },
+      "EnableConnectionIsAliveFalse": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "EnsureConnectionIsAlive": false
+      },
+
+      "PreferTypeIdsAsQueryParametersTrue": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "PreferTypeIdsAsQueryParameters": true
+      },
+      "PreferTypeIdsAsQueryParametersFalse": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "PreferTypeIdsAsQueryParameters": false
+      },
+
+      "DomainWithNamingConvention1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Uppercase",
+          "NamespacePolicy": "Synonymize",
+          "NamingRules": "UnderscoreHyphens,RemoveDots",
+          "NamespaceSynonyms": [
+            {
+              "Namespace": "Xtensive.Orm",
+              "Synonym": "system"
+            },
+            {
+              "Namespace": "Xtensive.Orm.Tests",
+              "Synonym": "theRest"
+            }
+          ]
+        }
+      },
+      "DomainWithNamingConvention2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Lowercase",
+          "NamespacePolicy": "Synonymize",
+          "NamingRules": "UnderscoreHyphens,RemoveDots",
+          "NamespaceSynonyms": [
+            {
+              "Namespace": "Xtensive.Orm",
+              "Synonym": "system"
+            },
+            {
+              "Namespace": "Xtensive.Orm.Tests",
+              "Synonym": "theRest"
+            }
+          ]
+        }
+      },
+      "DomainWithNamingConvention3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "AsIs",
+          "NamespacePolicy": "Synonymize",
+          "NamingRules": "UnderscoreHyphens,RemoveDots",
+          "NamespaceSynonyms": [
+            {
+              "Namespace": "Xtensive.Orm",
+              "Synonym": "system"
+            },
+            {
+              "Namespace": "Xtensive.Orm.Tests",
+              "Synonym": "theRest"
+            }
+          ]
+        }
+      },
+      "DomainWithNamingConvention4": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Default",
+          "NamespacePolicy": "Synonymize",
+          "NamingRules": "UnderscoreHyphens,RemoveDots",
+          "NamespaceSynonyms": [
+            {
+              "Namespace": "Xtensive.Orm",
+              "Synonym": "system"
+            },
+            {
+              "Namespace": "Xtensive.Orm.Tests",
+              "Synonym": "theRest"
+            }
+          ]
+        }
+      },
+      "DomainWithNamingConvention5": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Uppercase",
+          "NamespacePolicy": "AsIs",
+          "NamingRules": "UnderscoreHyphens,RemoveDots"
+        }
+      },
+      "DomainWithNamingConvention6": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Uppercase",
+          "NamespacePolicy": "Hash",
+          "NamingRules": "UnderscoreHyphens,RemoveDots"
+        }
+      },
+      "DomainWithNamingConvention7": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Uppercase",
+          "NamespacePolicy": "Omit",
+          "NamingRules": "UnderscoreHyphens,RemoveDots"
+        }
+      },
+      "DomainWithNamingConvention8": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Uppercase",
+          "NamespacePolicy": "Default",
+          "NamingRules": "UnderscoreHyphens,RemoveDots"
+        }
+      },
+      "DomainWithNamingConvention9": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Uppercase",
+          "NamespacePolicy": "Hash",
+          "NamingRules": "UnderscoreDots,RemoveHyphens"
+        }
+      },
+      "DomainWithNamingConvention10": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Uppercase",
+          "NamespacePolicy": "Hash",
+          "NamingRules": "None"
+        }
+      },
+      "DomainWithNamingConvention11": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Uppercase",
+          "NamespacePolicy": "Hash",
+          "NamingRules": "Default"
+        }
+      },
+
+      "DomainWithInvalidNamingConvention1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Defailt",
+          "NamespacePolicy": "Default",
+          "NamingRules": "Default"
+        }
+      },
+      "DomainWithInvalidNamingConvention2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Default",
+          "NamespacePolicy": "Defailt",
+          "NamingRules": "Default"
+        }
+      },
+      "DomainWithInvalidNamingConvention3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "NamingConvention": {
+          "LetterCasePolicy": "Default",
+          "NamespacePolicy": "Default",
+          "NamingRules": "Defailt"
+        }
+      },
+
+      "DomainWithVersioningConvention1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "VersioningConvention": {
+          "EntityVersioningPolicy": "Pessimistic"
+        }
+      },
+      "DomainWithVersioningConvention2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "VersioningConvention": {
+          "EntityVersioningPolicy": "Optimistic"
+        }
+      },
+      "DomainWithVersioningConvention3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "VersioningConvention": {
+          "EntityVersioningPolicy": "Default"
+        }
+      },
+      "DomainWithVersioningConvention4": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "VersioningConvention": {
+          "EntityVersioningPolicy": "Optimistic",
+          "DenyEntitySetOwnerVersionChange": true
+        }
+      },
+      "DomainWithVersioningConvention5": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "VersioningConvention": {
+          "EntityVersioningPolicy": "Optimistic",
+          "DenyEntitySetOwnerVersionChange": false
+        }
+      },
+
+      "DomainWithInvalidVersioningConvention1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "VersioningConvention": {
+          "EntityVersioningPolicy": "Defauit"
+        }
+      },
+
+      "DomainWithTypes": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Type": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests"
+          },
+          {
+            "Type": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity2, Xtensive.Orm.Tests"
+          }
+        ]
+      },
+      "DomainWithAssemblies": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Assembly": "Xtensive.Orm"
+          }
+        ]
+      },
+      "DomainWithAssembliesAndNamespaces": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Namespace": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"
+          }
+        ]
+      },
+
+      "DomainWithMixedRegistrations": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Type": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests"
+          },
+          {
+            "Type": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity2, Xtensive.Orm.Tests"
+          },
+          {
+            "Assembly": "Xtensive.Orm"
+          },
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Namespace": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"
+          }
+        ]
+      },
+
+      "DomainWithInvalidRegistrations1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Type": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests"
+          },
+          {
+            "Type": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests"
+          }
+        ]
+      },
+      "DomainWithInvalidRegistrations2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Assembly": "Xtensive.Orm"
+          },
+          {
+            "Assembly": "Xtensive.Orm"
+          }
+        ]
+      },
+      "DomainWithInvalidRegistrations3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Namespace": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"
+          },
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Namespace": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"
+          }
+        ]
+      },
+      "DomainWithInvalidRegistrations4": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Type": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests",
+            "Assembly": "Xtensive.Orm",
+            "Namespace": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"
+          }
+        ]
+      },
+      "DomainWithInvalidRegistrations5": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Type": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests",
+            "Assembly": "Xtensive.Orm"
+          }
+        ]
+      },
+      "DomainWithInvalidRegistrations6": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Type": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.DummyEntity1, Xtensive.Orm.Tests",
+            "Namespace": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"
+          }
+        ]
+      },
+      "DomainWithInvalidRegistrations7": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Types": [
+          {
+            "Namespace": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace"
+          }
+        ]
+      },
+
+      "DomainWithDatabases1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests-1"
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithDatabases2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests-1",
+            "MinTypeId": 100,
+            "MaxTypeId": 1000
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2",
+            "MinTypeId": 2000,
+            "MaxTypeId": 3000
+          }
+        }
+      },
+
+      "DomainWithInvalidDatabases1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests-1",
+            "MinTypeId": -10
+          }
+        }
+      },
+      "DomainWithInvalidDatabases2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests-1",
+            "MinTypeId": 50
+          }
+        }
+      },
+      "DomainWithInvalidDatabases3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests-1",
+            "MaxTypeId": -10
+          }
+        }
+      },
+      "DomainWithInvalidDatabases4": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests-1",
+            "MaxTypeId": 50
+          }
+        }
+      },
+
+      "DomainWithCustomGenerator": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "KeyGenerators": [
+          {
+            "Name": "Int32",
+            "Seed": 12,
+            "CacheSize": 127
+          }
+        ]
+      },
+      "DomainWithCustomGeneratorsWithDatabaseNames": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "KeyGenerators": [
+          {
+            "Name": "Int32",
+            "Database": "DO-Tests-1"
+          },
+          {
+            "Name": "Int32",
+            "Database": "DO-Tests-2"
+          }
+        ]
+      },
+      "DomainWithCustomGeneratorsWithDatabaseNamesAndKeyParams": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "KeyGenerators": [
+          {
+            "Name": "Int32",
+            "Database": "DO-Tests-1",
+            "Seed": 12,
+            "CacheSize": 127
+          },
+          {
+            "Name": "Int32",
+            "Database": "DO-Tests-2",
+            "Seed": 13,
+            "CacheSize": 129
+          }
+        ]
+      },
+      "DomainWithCustomGeneratorsWithDatabasesAliases": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "KeyGenerators": [
+          {
+            "Name": "Int32",
+            "Database": "main",
+            "Seed": 12,
+            "CacheSize": 127
+          },
+          {
+            "Name": "Int32",
+            "Database": "Other",
+            "Seed": 13,
+            "CacheSize": 129
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests-1"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+
+      "DomainWithCustomGeneratorsConflict1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "KeyGenerators": [
+          {
+            "Name": "Int32",
+            "Database": "DO-Tests-1"
+          },
+          {
+            "Name": "Int32",
+            "Database": "DO-Tests-1"
+          }
+        ]
+      },
+      "DomainWithCustomGeneratorsConflict2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "KeyGenerators": [
+          {
+            "Name": "Int32",
+            "Database": "DO-Tests-1"
+          },
+          {
+            "Name": "Int32",
+            "Database": "main"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests-1"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithCustomGeneratorNegativeSeed": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "KeyGenerators": [
+          {
+            "Name": "Int32",
+            "Database": "DO-Tests-1",
+            "Seed": -12
+          }
+        ]
+      },
+      "DomainWithCustomGeneratorNegativeCache": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "KeyGenerators": [
+          {
+            "Name": "Int32",
+            "Database": "DO-Tests-1",
+            "CacheSize": -127
+          }
+        ]
+      },
+
+      "DomainWithIgnoreRules": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "IgnoreRules": [
+          {
+            "Database": "Other-DO40-Tests",
+            "Schema": "some-schema1",
+            "Table": "table1"
+          },
+          {
+            "Database": "some-database",
+            "Schema": "some-schema2",
+            "Column": "column2"
+          },
+          {
+            "Database": "some-database",
+            "Schema": "some-schema2",
+            "Index": "index2"
+          },
+          {
+            "Database": "some-database",
+            "Schema": "some-schema3",
+            "Table": "table2",
+            "Column": "col3"
+          },
+          {
+            "Database": "some-database",
+            "Schema": "some-schema3",
+            "Table": "table2",
+            "Index": "index3"
+          },
+          {
+            "Database": "another-some-database",
+            "Table": "some-table"
+          },
+          {
+            "Database": "database1",
+            "Column": "some-column"
+          },
+          {
+            "Database": "database1",
+            "Index": "some-index"
+          },
+          {
+            "Schema": "schema1",
+            "Table": "table1"
+          },
+          {
+            "Schema": "schema1",
+            "Column": "column2"
+          },
+          {
+            "Schema": "schema1",
+            "Index": "index2"
+          },
+          {
+            "Schema": "schema1",
+            "Table": "table2",
+            "Column": "column3"
+          },
+          {
+            "Schema": "schema1",
+            "Table": "table2",
+            "Index": "index3"
+          },
+          {
+            "Table": "table4",
+            "Column": "column3"
+          },
+          {
+            "Table": "table4",
+            "Index": "index2"
+          },
+          {
+            "Table": "single-table"
+          },
+          {
+            "Column": "single-column"
+          },
+          {
+            "Index": "single-index"
+          }
+        ]
+      },
+      "DomainWithInvalidIgnoreRules1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "IgnoreRules": [
+          {
+            "Column": "column1",
+            "Index": "index1"
+          }
+        ]
+      },
+      "DomainWithInvalidIgnoreRules2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "IgnoreRules": [
+          {
+            "Table": "table1",
+            "Column": "column1",
+            "Index": "index1"
+          }
+        ]
+      },
+      "DomainWithInvalidIgnoreRules3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "IgnoreRules": [
+          {
+            "Database": "database1"
+          }
+        ]
+      },
+      "DomainWithInvalidIgnoreRules4": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "IgnoreRules": [
+          {
+            "Database": "database1",
+            "Schema": "schema1"
+          }
+        ]
+      },
+
+      "DomainWithMappingRules1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Database": "DO-Tests-1"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithMappingRules2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Schema": "Model1"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithMappingRules3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Namespace": "Xtensive.Orm.Configuration.Options",
+            "Database": "DO-Tests-2"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithMappingRules4": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Namespace": "Xtensive.Orm.Tests.Configuration",
+            "Schema": "Model2"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithMappingRules5": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Namespace": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests",
+            "Database": "DO-Tests-3"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithMappingRules6": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Namespace": "Xtensive.Orm.Tests.Configuration.TypesToUseInTests.NestedNamespace",
+            "Schema": "Model3"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithMappingRules7": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Namespace": "Xtensive.Orm.Tests.Indexing",
+            "Database": "main",
+            "Schema": "Model4"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+
+      "DomainWithConflictMappingRules1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Database": "DO-Tests-1"
+          },
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Schema": "Model1"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithConflictMappingRules2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Namespace": "Xtensive.Orm.Tests.Configuration",
+            "Database": "DO-Tests-2"
+          },
+          {
+            "Namespace": "Xtensive.Orm.Tests.Configuration",
+            "Schema": "Model2"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+
+      "DomainWithInvalidMappingRules1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Database": "main"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithInvalidMappingRules2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Schema": "Model4"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithInvalidMappingRules3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Assembly": "Xtensive.Orm.Tests",
+            "Namespace": "Xtensive.Orm.Tests.Indexing"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithInvalidMappingRules4": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Assembly": "Xtensive.Orm.Tests"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+      "DomainWithInvalidMappingRules5": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "DefaultDatabase": "main",
+        "DefaultSchema": "dbo",
+        "MappingRules": [
+          {
+            "Namespace": "Xtensive.Orm.Tests.Indexing"
+          }
+        ],
+        "Databases": {
+          "main": {
+            "RealName": "DO-Tests"
+
+          },
+          "other": {
+            "RealName": "DO-Tests-2"
+          }
+        }
+      },
+
+      "DomainWithSessionEmptyName": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "": {
+            "Options": "ClientProfile"
+          }
+        }
+      },
+      "DomainWithSessionCustomName": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "UserCreated": {
+            "Options": "ClientProfile"
+          }
+        }
+      },
+      "DomainWithSessionCustomUser": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "UserName": "User",
+            "Password": "126654"
+          }
+        }
+      },
+      "DomainWithSessionDefaultOptions": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "Options": "Default"
+          }
+        }
+      },
+      "DomainWithSessionServerProfile": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "Options": "ServerProfile"
+          }
+        }
+      },
+      "DomainWithSessionClientProfile": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "Options": "ClientProfile"
+          }
+        }
+      },
+      "DomainWithSessionCustomOptions": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "Options": "AllowSwitching, AutoActivation, ReadRemovedObjects, ValidateEntityVersions"
+          }
+        }
+      },
+
+      "DomainWithSessionWithCollectionSizes": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "CacheSize": 399,
+            "BatchSize": 20,
+            "EntityChangeRegistrySize": 255
+          }
+        }
+      },
+
+      "DomainWithSessionCustomCacheType": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "CacheType": "Infinite"
+          }
+        }
+      },
+
+      "DomainWithSessionCustomIsolationLevel": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "DefaultIsolationLevel": "ReadCommitted"
+          }
+        }
+      },
+
+      "DomainWithSessionCustomCommandTimeout": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "DefaultCommandTimeout": 300
+          }
+        }
+      },
+
+      "DomainWithSessionCustomPreloadingPolicy": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "ReaderPreloading": "Always"
+          }
+        }
+      },
+
+      "DomainWithSessionCustomConnectionString": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "ConnectionString": "Data Source=localhost;Initial Catalog=DO-Tests;Integrated Security=True;MultipleActiveResultSets=True"
+          }
+        }
+      },
+      "DomainWithSessionCustomConnectionUrl": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "ConnectionUrl": "sqlserver://localhost/DO-Tests"
+          }
+        }
+      },
+
+      "DomainWithMultipleSessionConfigurations": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "CacheType": "Infinite",
+            "BatchSize": 20,
+            "EntityChangeRegistrySize": 255,
+            "Options": "AllowSwitching, AutoActivation, ReadRemovedObjects, ValidateEntityVersions"
+          },
+          "System": {
+            "CacheType": "Infinite",
+            "BatchSize": 30,
+            "Options": "ServerProfile"
+          }
+        }
+      },
+
+      "DomainWithSessionInvalidOptions": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "Options": "Defailt"
+          }
+        }
+      },
+      "DomainWithSessionInvalidCacheSize1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "CacheSize": -5
+          }
+        }
+      },
+      "DomainWithSessionInvalidCacheSize2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "CacheSize": 0
+          }
+        }
+      },
+      "DomainWithSessionInvalidCacheSize3": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "CacheSize": 1
+          }
+        }
+      },
+      "DomainWithSessionInvalidBatchSize1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "BatchSize": -5
+          }
+        }
+      },
+      "DomainWithSessionInvalidBatchSize2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "BatchSize": 0
+          }
+        }
+      },
+      "DomainWithSessionInvalidEntityChangeRegistry1": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "EntityChangeRegistrySize": -5
+          }
+        }
+      },
+      "DomainWithSessionInvalidEntityChangeRegistry2": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "EntityChangeRegistrySize": 0
+          }
+        }
+      },
+      "DomainWithSessionInvalidCacheType": {
+        "ConnectionUrl": "sqlserver://localhost/",
+        "Sessions": {
+          "Default": {
+            "CacheType": "Defailt"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/domainSettings.json
+++ b/Orm/Xtensive.Orm.Tests/domainSettings.json
@@ -1409,6 +1409,60 @@
           }
         }
       }
+    },
+    "Logging": {
+      "Provider": "Xtensive.Orm.Logging.log4net.LogProvider",
+      "Logs": [
+        {
+          "Source": "*",
+          "Target": "Console"
+        },
+        {
+          "Source": "SomeLogName",
+          "Target": "DebugOnlyConsole"
+        },
+        {
+          "Source": "FirstLogName,SecondLogName",
+          "Target": "d:\\log.txt"
+        },
+        {
+          "Source": "LogName, AnotherLogName",
+          "Target": "Console"
+        },
+        {
+          "Source": "FileLog",
+          "Target": "log.txt"
+        },
+        {
+          "Source": "NullLog",
+          "Target": "None"
+        },
+        {
+          "Source": "Trash",
+          "Target": "skjdhfjsdf sdfsdfksjdghj fgdfg"
+        }
+      ]
+    }
+  },
+  "Xtensive.Orm.EmptyLogging.Json": {
+    "Logging": {
+
+    }
+  },
+  "Xtensive.Orm.EmptyLogs.Json": {
+    "Logging": {
+      "Logs": []
+    }
+  },
+  "Xtensive.Orm.OnlyLogProvider.Json": {
+    "Logging": {
+      "Provider": "Xtensive.Orm.Logging.log4net.LogProvider"
+    }
+  },
+  "Xtensive.Orm.LogProviderAndEmptyLogs.Json": {
+    "Logging": {
+      "Provider": "Xtensive.Orm.Logging.log4net.LogProvider",
+      "Logs": []
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Configuration/ConfigurationBase.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/ConfigurationBase.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Configuration
     /// <inheritdoc/>
     public virtual object Clone()
     {
-      ConfigurationBase clone = CreateClone();
+      var clone = CreateClone();
       clone.CopyFrom(this);
       return clone;
     }

--- a/Orm/Xtensive.Orm/Orm/Configuration/DatabaseConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DatabaseConfiguration.cs
@@ -52,7 +52,7 @@ namespace Xtensive.Orm.Configuration
     /// <summary>
     /// Gets or sets type ID minimal value
     /// for types mapped to this database.
-    /// Default value is 100.
+    /// Default value is <see cref="TypeInfo.MinTypeId"/>.
     /// </summary>
     public int MinTypeId
     {

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -68,7 +68,7 @@ namespace Xtensive.Orm.Configuration
 
     /// <summary>
     /// Default <see cref="ShareStorageSchemaOverNodes"/> value:
-    /// <see langword="false"/>
+    /// <see langword="false"/>.
     /// </summary>
     public const bool DefaultShareStorageSchemaOverNodes = false;
 
@@ -354,6 +354,7 @@ namespace Xtensive.Orm.Configuration
     /// <summary>
     /// Gets or sets a value indicating change tracking mode of full-text indexes.
     /// The property may have no effect for certain storages where there is no support for such option.
+    /// Default value is <see cref="DomainConfiguration.DefaultFullTextChangeTrackingMode"/>.
     /// </summary>
     public FullTextChangeTrackingMode FullTextChangeTrackingMode
     {
@@ -590,7 +591,7 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <summary>
-    /// Gets or sets versioning convention.
+    /// Gets or sets rules of entity versioning.
     /// </summary>
     public VersioningConvention VersioningConvention
     {
@@ -603,6 +604,13 @@ namespace Xtensive.Orm.Configuration
 
     /// <summary>
     /// Enables extra check if connection is not broken on its opening.
+    /// For some RDBMSs physical connection may become broken but connection pool, which
+    /// is in charge of logical connections, is not aware of it.
+    /// In such cases connection pool provides connection
+    /// which is dead on arrival and causes exception on first use of it.
+    /// Such connection should be re-created and re-opened. The extra check
+    /// tests connection by making "first use" of it, if check failed connection
+    /// will be restored automatically.
     /// </summary>
     public bool EnsureConnectionIsAlive
     {

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -8,6 +8,7 @@ using System;
 using System.Configuration;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration.Internals;
 using Xtensive.Orm.Internals;
@@ -646,6 +647,9 @@ namespace Xtensive.Orm.Configuration
     /// </summary>
     public bool IsMultischema => isMultischema ?? GetIsMultischema();
 
+    internal bool Supports(DomainOptions optionsToCheck) => (options & optionsToCheck) == optionsToCheck;
+
+    internal bool Supports(ForeignKeyMode modeToCheck) => (foreignKeyMode & modeToCheck) == modeToCheck;
 
     private bool GetIsMultidatabase()
     {
@@ -768,6 +772,8 @@ namespace Xtensive.Orm.Configuration
     /// <returns>The clone of this configuration.</returns>
     public new DomainConfiguration Clone() => (DomainConfiguration) base.Clone();
 
+    #region Static DomainConfiguration.Load() methods
+
     /// <summary>
     /// Loads the <see cref="DomainConfiguration"/> for <see cref="Domain"/>
     /// with the specified <paramref name="name"/>
@@ -847,11 +853,6 @@ namespace Xtensive.Orm.Configuration
       return LoadConfigurationFromSection(section, name);
     }
 
-    internal bool Supports(DomainOptions optionsToCheck) => (options & optionsToCheck) == optionsToCheck;
-
-    internal bool Supports(ForeignKeyMode modeToCheck) => (foreignKeyMode & modeToCheck) == modeToCheck;
-
-
     private static DomainConfiguration LoadConfigurationFromSection(ConfigurationSection section, string name)
     {
       var domainElement = section.Domains[name];
@@ -861,6 +862,20 @@ namespace Xtensive.Orm.Configuration
       }
       return domainElement.ToNative();
     }
+
+    /// <summary>
+    /// Loads the <see cref="DomainConfiguration"/> for <see cref="Domain"/>
+    /// with the specified <paramref name="name"/>.
+    /// </summary>
+    /// <param name="configurationSection">Root configuration section where domain configurations are placed</param>
+    /// <param name="name">Name of the <see cref="Domain"/>.</param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">The "domains" section is not found or domain with requested name is not found.</exception>
+    public static DomainConfiguration Load(IConfigurationSection configurationSection, string name)
+    {
+      throw new NotImplementedException();
+    }
+    #endregion
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2022 Xtensive LLC.
+// Copyright (C) 2007-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -73,7 +73,7 @@ namespace Xtensive.Orm.Configuration
     public const bool DefaultShareStorageSchemaOverNodes = false;
 
     /// <summary>
-    /// Default <see cref="AllowCyclicDatabaseDependencies" /> value: <see langword="false" />
+    /// Default <see cref="AllowCyclicDatabaseDependencies" /> value: <see langword="false" />.
     /// </summary>
     public const bool DefaultAllowCyclicDatabaseDependencies = false;
 
@@ -881,8 +881,25 @@ namespace Xtensive.Orm.Configuration
     /// <exception cref="InvalidOperationException">The "domains" section is not found or domain with requested name is not found.</exception>
     public static DomainConfiguration Load(IConfigurationSection configurationSection, string name)
     {
-      throw new NotImplementedException();
+      var allDomainsSection = configurationSection.GetSection("Domains");
+      if (allDomainsSection != null && allDomainsSection.GetChildren().Any()) {
+        var domainSection = allDomainsSection.GetSection(name);
+        if (domainSection.GetChildren().Any()) {
+          var parseResult = new FromJsonToDomainConfigurationParser().Parse(domainSection);
+          if (parseResult != null)
+            return parseResult;
+        }
+        else if ((domainSection = allDomainsSection.GetSection($"Domain:{name}")).GetChildren().Any()) {
+          var parseResult = new XmlDomainConfigParser().Parse(domainSection);
+          if (parseResult != null)
+            return parseResult;
+        }
+      }
+
+      throw new InvalidOperationException(string.Format(
+          Strings.ExConfigurationForDomainIsNotFoundInApplicationConfigurationFile, name, sectionName));
     }
+
     #endregion
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -9,6 +9,7 @@ using System.Configuration;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
+using Xtensive.Collections;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration.Internals;
 using Xtensive.Orm.Internals;
@@ -145,6 +146,7 @@ namespace Xtensive.Orm.Configuration
     private DatabaseConfigurationCollection databases = new();
     private KeyGeneratorConfigurationCollection keyGenerators = new();
     private IgnoreRuleCollection ignoreRules = new();
+    private ExtensionConfigurationCollection extensionConfigurations = new();
     private NamingConvention namingConvention = new();
     private VersioningConvention versioningConvention = new();
     private int keyCacheSize = DefaultKeyCacheSize;
@@ -445,6 +447,18 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <summary>
+    /// Gets collection of additional configurations (configurations of extensions)
+    /// that might be required during domain build process.
+    /// </summary>
+    public ExtensionConfigurationCollection ExtensionConfigurations {
+      get => extensionConfigurations;
+      set {
+        EnsureNotLocked();
+        extensionConfigurations = value;
+      }
+    }
+
+    /// <summary>
     /// Gets or sets value indicating whether SQL text of a query
     /// that caused error should be included in exception message.
     /// </summary>
@@ -694,6 +708,7 @@ namespace Xtensive.Orm.Configuration
       keyGenerators.Lock(true);
       ignoreRules.Lock(true);
       versioningConvention.Lock(true);
+      extensionConfigurations.Lock(true);
 
       base.Lock(recursive);
 
@@ -772,6 +787,7 @@ namespace Xtensive.Orm.Configuration
       shareStorageSchemaOverNodes = configuration.ShareStorageSchemaOverNodes;
       versioningConvention = (VersioningConvention) configuration.VersioningConvention.Clone();
       preferTypeIdsAsQueryParameters = configuration.PreferTypeIdsAsQueryParameters;
+      ExtensionConfigurations = (ExtensionConfigurationCollection) configuration.ExtensionConfigurations.Clone();
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -881,20 +881,21 @@ namespace Xtensive.Orm.Configuration
     /// <exception cref="InvalidOperationException">The "domains" section is not found or domain with requested name is not found.</exception>
     public static DomainConfiguration Load(IConfigurationSection configurationSection, string name)
     {
-      var allDomainsSection = configurationSection.GetSection("Domains");
-      if (allDomainsSection != null && allDomainsSection.GetChildren().Any()) {
-        var domainSection = allDomainsSection.GetSection(name);
-        if (domainSection.GetChildren().Any()) {
-          var parseResult = new FromJsonToDomainConfigurationParser().Parse(domainSection);
-          if (parseResult != null)
-            return parseResult;
-        }
-        else if ((domainSection = allDomainsSection.GetSection($"Domain:{name}")).GetChildren().Any()) {
-          var parseResult = new XmlDomainConfigParser().Parse(domainSection);
-          if (parseResult != null)
-            return parseResult;
-        }
-      }
+      ArgumentValidator.EnsureArgumentNotNull(configurationSection, nameof(configurationSection));
+
+      var jsonParser = new JsonToDomainConfigurationReader();
+      var xmlParser = new XmlToDomainConfigurationReader();
+
+      var parseResult = jsonParser.Read(configurationSection, name);
+      if (parseResult != null)
+        return parseResult;
+      parseResult = xmlParser.Read(configurationSection, name);
+      if (parseResult != null)
+        return parseResult;
+
+      throw new InvalidOperationException(string.Format(
+          Strings.ExConfigurationForDomainIsNotFoundInApplicationConfigurationFile, name, sectionName));
+    }
 
       throw new InvalidOperationException(string.Format(
           Strings.ExConfigurationForDomainIsNotFoundInApplicationConfigurationFile, name, sectionName));

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -877,7 +877,7 @@ namespace Xtensive.Orm.Configuration
     /// </summary>
     /// <param name="configurationSection">Root configuration section where domain configurations are placed</param>
     /// <param name="name">Name of the <see cref="Domain"/>.</param>
-    /// <returns></returns>
+    /// <returns>Domain configuration.</returns>
     /// <exception cref="InvalidOperationException">The "domains" section is not found or domain with requested name is not found.</exception>
     public static DomainConfiguration Load(IConfigurationSection configurationSection, string name)
     {

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -9,9 +9,7 @@ using System.Configuration;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
-using Xtensive.Collections;
 using Xtensive.Core;
-using Xtensive.Orm.Configuration.Internals;
 using Xtensive.Orm.Internals;
 using ConfigurationSection = Xtensive.Orm.Configuration.Elements.ConfigurationSection;
 
@@ -19,7 +17,7 @@ namespace Xtensive.Orm.Configuration
 {
   /// <summary>
   /// The configuration of the <see cref="Domain"/>.
-  /// </summary> 
+  /// </summary>
   [Serializable]
   public class DomainConfiguration : ConfigurationBase
   {

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -897,6 +897,38 @@ namespace Xtensive.Orm.Configuration
           Strings.ExConfigurationForDomainIsNotFoundInApplicationConfigurationFile, name, sectionName));
     }
 
+    public static DomainConfiguration Load(IConfigurationRoot configurationRoot, string name)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(configurationRoot, nameof(configurationRoot));
+
+      var jsonParser = new JsonToDomainConfigurationReader();
+      var xmlParser = new XmlToDomainConfigurationReader();
+
+      var parseResult = jsonParser.Read(configurationRoot, name);
+      if (parseResult != null)
+        return parseResult;
+      parseResult = xmlParser.Read(configurationRoot, name);
+      if (parseResult != null)
+        return parseResult;
+
+      throw new InvalidOperationException(string.Format(
+          Strings.ExConfigurationForDomainIsNotFoundInApplicationConfigurationFile, name, sectionName));
+    }
+
+    public static DomainConfiguration Load(IConfigurationRoot configurationRoot, string sectionName, string name)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(configurationRoot, nameof(configurationRoot));
+
+      var jsonParser = new JsonToDomainConfigurationReader();
+      var xmlParser = new XmlToDomainConfigurationReader();
+
+      var parseResult = jsonParser.Read(configurationRoot, sectionName, name);
+      if (parseResult != null)
+        return parseResult;
+      parseResult = xmlParser.Read(configurationRoot, sectionName, name);
+      if (parseResult != null)
+        return parseResult;
+
       throw new InvalidOperationException(string.Format(
           Strings.ExConfigurationForDomainIsNotFoundInApplicationConfigurationFile, name, sectionName));
     }

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -9,9 +9,9 @@ using System.Configuration;
 using System.Linq;
 using JetBrains.Annotations;
 using Xtensive.Core;
-using Xtensive.Orm.Configuration.Elements;
+using Xtensive.Orm.Configuration.Internals;
 using Xtensive.Orm.Internals;
-using ConfigurationSection=Xtensive.Orm.Configuration.Elements.ConfigurationSection;
+using ConfigurationSection = Xtensive.Orm.Configuration.Elements.ConfigurationSection;
 
 namespace Xtensive.Orm.Configuration
 {
@@ -95,7 +95,13 @@ namespace Xtensive.Orm.Configuration
     /// <summary>
     /// Default <see cref="ForeignKeyMode"/> value.
     /// </summary>
+    [Obsolete ("User DefaultForeignKeyMode")]
     public const ForeignKeyMode DefauktForeignKeyMode = ForeignKeyMode.Default;
+
+    /// <summary>
+    /// Default <see cref="ForeignKeyMode"/> value.
+    /// </summary>
+    public const ForeignKeyMode DefaultForeignKeyMode = ForeignKeyMode.Default;
 
     /// <summary>
     /// Default <see cref="FullTextChangeTrackingMode"/> value.
@@ -154,7 +160,7 @@ namespace Xtensive.Orm.Configuration
     private bool ensureConnectionIsAlive = DefaultEnsureConnectionIsAlive;
     private bool preferTypeIdsAsQueryParameters = DefaultPreferTypeIdsAsQueryParameters;
     private DomainUpgradeMode upgradeMode = DefaultUpgradeMode;
-    private ForeignKeyMode foreignKeyMode = DefauktForeignKeyMode;
+    private ForeignKeyMode foreignKeyMode = DefaultForeignKeyMode;
     private FullTextChangeTrackingMode fullTextChangeTrackingMode = DefaultFullTextChangeTrackingMode;
     private DomainOptions options = DefaultDomainOptions;
     private SchemaSyncExceptionFormat schemaSyncExceptionFormat = DefaultSchemaSyncExceptionFormat;

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/DatabaseConfigurationElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/DatabaseConfigurationElement.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.02.08
 
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Configuration.Elements
     public override object Identifier { get { return Name; } }
 
     /// <summary>
-    /// <see cref="DatabaseConfiguration.Name" copy="true"/>
+    /// <see cref="DatabaseConfiguration.Name" />
     /// </summary>
     [ConfigurationProperty(NameElementName, IsKey = true)]
     public string Name
@@ -34,7 +34,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DatabaseConfiguration.RealName" copy="true"/>
+    /// <see cref="DatabaseConfiguration.RealName" />
     /// </summary>
     [ConfigurationProperty(RealNameElementName)]
     public string RealName
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DatabaseConfiguration.MinTypeId" copy="true"/>
+    /// <see cref="DatabaseConfiguration.MinTypeId" />
     /// </summary>
     [ConfigurationProperty(MinTypeIdElementName, DefaultValue = TypeInfo.MinTypeId)]
     public int MinTypeId
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DatabaseConfiguration.MaxTypeId" copy="true"/>
+    /// <see cref="DatabaseConfiguration.MaxTypeId" />
     /// </summary>
     [ConfigurationProperty(MaxTypeIdElementName, DefaultValue = int.MaxValue)]
     public int MaxTypeId

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/DomainConfigurationElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/DomainConfigurationElement.cs
@@ -245,7 +245,7 @@ namespace Xtensive.Orm.Configuration.Elements
     /// <see cref="DomainConfiguration.KeyGenerators" copy="true"/>
     /// </summary>
     [ConfigurationProperty(KeyGeneratorsElementName, IsDefaultCollection = false)]
-    [ConfigurationCollection(typeof (ConfigurationCollection<DatabaseConfigurationElement>), AddItemName = "keyGenerator")]
+    [ConfigurationCollection(typeof (ConfigurationCollection<KeyGeneratorConfigurationElement>), AddItemName = "keyGenerator")]
     public ConfigurationCollection<KeyGeneratorConfigurationElement> KeyGenerators
     {
       get { return (ConfigurationCollection<KeyGeneratorConfigurationElement>) this[KeyGeneratorsElementName]; }
@@ -295,7 +295,8 @@ namespace Xtensive.Orm.Configuration.Elements
     /// <summary>
     /// <see cref="DomainConfiguration.AllowCyclicDatabaseDependencies" copy="true"/>
     /// </summary>
-    [ConfigurationProperty(AllowCyclicDatabaseDependenciesElementName, DefaultValue = false)]
+    [ConfigurationProperty(AllowCyclicDatabaseDependenciesElementName,
+      DefaultValue = DomainConfiguration.DefaultAllowCyclicDatabaseDependencies)]
     public bool AllowCyclicDatabaseDependencies
     {
       get { return (bool) this[AllowCyclicDatabaseDependenciesElementName]; }

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/DomainConfigurationElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/DomainConfigurationElement.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2023 Xtensive LLC.
+// Copyright (C) 2008-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Aleksey Gamzov
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Configuration.Elements
     public override object Identifier { get { return Name; } }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.Name" copy="true"/>
+    /// <see cref="DomainConfiguration.Name" />
     /// </summary>
     [ConfigurationProperty(NameElementName, IsKey = true, DefaultValue = "")]
     public string Name
@@ -68,7 +68,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.ConnectionInfo" copy="true"/>
+    /// <see cref="DomainConfiguration.ConnectionInfo" />
     /// </summary>
     [ConfigurationProperty(ConnectionUrlElementName, DefaultValue = null)]
     public string ConnectionUrl
@@ -78,7 +78,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.ConnectionInfo" copy="true"/>
+    /// <see cref="DomainConfiguration.ConnectionInfo" />
     /// </summary>
     [ConfigurationProperty(ConnectionStringElementName, DefaultValue = null)]
     public string ConnectionString
@@ -88,7 +88,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.ConnectionInfo" copy="true"/>
+    /// <see cref="DomainConfiguration.ConnectionInfo" />
     /// </summary>
     [ConfigurationProperty(ProviderElementName, DefaultValue = WellKnown.Provider.SqlServer)]
     public string Provider
@@ -98,7 +98,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.Types" copy="true"/>
+    /// <see cref="DomainConfiguration.Types" />
     /// </summary>
     [ConfigurationProperty(TypesElementName, IsDefaultCollection = false)]
     [ConfigurationCollection(typeof (ConfigurationCollection<TypeRegistrationElement>), AddItemName = "add")]
@@ -108,7 +108,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.NamingConvention" copy="true"/>
+    /// <see cref="DomainConfiguration.NamingConvention" />
     /// </summary>
     [ConfigurationProperty(NamingConventionElementName)]
     public NamingConventionElement NamingConvention
@@ -118,7 +118,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.KeyCacheSize" copy="true"/>
+    /// <see cref="DomainConfiguration.KeyCacheSize" />
     /// </summary>
     [ConfigurationProperty(KeyCacheSizeElementName, DefaultValue = DomainConfiguration.DefaultKeyCacheSize)]
     [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
@@ -129,7 +129,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.KeyGeneratorCacheSize" copy="true"/>
+    /// <see cref="DomainConfiguration.KeyGeneratorCacheSize" />
     /// </summary>
     [ConfigurationProperty(KeyGeneratorCacheSizeElementName, DefaultValue = DomainConfiguration.DefaultKeyGeneratorCacheSize)]
     [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
@@ -140,7 +140,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.QueryCacheSize" copy="true"/>
+    /// <see cref="DomainConfiguration.QueryCacheSize" />
     /// </summary>
     [ConfigurationProperty(QueryCacheSizeElementName, DefaultValue = DomainConfiguration.DefaultQueryCacheSize)]
     [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
@@ -151,7 +151,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.RecordSetMappingCacheSize" copy="true"/>
+    /// <see cref="DomainConfiguration.RecordSetMappingCacheSize" />
     /// </summary>
     [ConfigurationProperty(RecordSetMappingCacheSizeElementName, DefaultValue = DomainConfiguration.DefaultRecordSetMappingCacheSize)]
     [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
@@ -162,7 +162,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.UpgradeMode" copy="true"/>
+    /// <see cref="DomainConfiguration.UpgradeMode" />
     /// </summary>
     [ConfigurationProperty(UpgradeModeElementName, DefaultValue = "Default")]
     public string UpgradeMode
@@ -172,7 +172,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.SchemaSyncExceptionFormat" copy="true"/>
+    /// <see cref="DomainConfiguration.SchemaSyncExceptionFormat" />
     /// </summary>
     [ConfigurationProperty(SchemaSyncExceptionFormatElementName, DefaultValue = "Default")]
     public string SchemaSyncExceptionFormat
@@ -182,7 +182,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.ForeignKeyMode" copy="true"/>
+    /// <see cref="DomainConfiguration.ForeignKeyMode" />
     /// </summary>
     [ConfigurationProperty(ForeignKeyModeElementName, DefaultValue = "Default")]
     public string ForeignKeyMode
@@ -192,7 +192,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.FullTextChangeTrackingMode" copy="true"/>
+    /// <see cref="DomainConfiguration.FullTextChangeTrackingMode" />
     /// </summary>
     [ConfigurationProperty(FullTextChangeTrackingModeElementName, DefaultValue = "Default")]
     public string FullTextChangeTrackingMode
@@ -202,7 +202,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.Collation" copy="true"/>
+    /// <see cref="DomainConfiguration.Collation" />
     /// </summary>
     [ConfigurationProperty(CollationElementName)]
     public string Collation
@@ -212,7 +212,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.Sessions" copy="true"/>
+    /// <see cref="DomainConfiguration.Sessions" />
     /// </summary>
     [ConfigurationProperty(SessionsElementName, IsDefaultCollection = false)]
     [ConfigurationCollection(typeof (ConfigurationCollection<SessionConfigurationElement>), AddItemName = "session")]
@@ -222,7 +222,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.MappingRules" copy="true"/>
+    /// <see cref="DomainConfiguration.MappingRules" />
     /// </summary>
     [ConfigurationProperty(MappingRulesElementName, IsDefaultCollection = false)]
     [ConfigurationCollection(typeof (ConfigurationCollection<MappingRuleElement>), AddItemName = "rule")]
@@ -232,7 +232,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.Databases" copy="true"/>
+    /// <see cref="DomainConfiguration.Databases" />
     /// </summary>
     [ConfigurationProperty(DatabasesElementName, IsDefaultCollection = false)]
     [ConfigurationCollection(typeof (ConfigurationCollection<DatabaseConfigurationElement>), AddItemName = "database")]
@@ -242,7 +242,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.KeyGenerators" copy="true"/>
+    /// <see cref="DomainConfiguration.KeyGenerators" />
     /// </summary>
     [ConfigurationProperty(KeyGeneratorsElementName, IsDefaultCollection = false)]
     [ConfigurationCollection(typeof (ConfigurationCollection<KeyGeneratorConfigurationElement>), AddItemName = "keyGenerator")]
@@ -252,7 +252,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.ServiceContainerType" copy="true"/>
+    /// <see cref="DomainConfiguration.ServiceContainerType" />
     /// </summary>
     [ConfigurationProperty(ServiceContainerTypeElementName, DefaultValue = null)]
     public string ServiceContainerType
@@ -262,7 +262,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.DefaultSchema" copy="true"/>
+    /// <see cref="DomainConfiguration.DefaultSchema" />
     /// </summary>
     [ConfigurationProperty(DefaultSchemaElementName)]
     public string DefaultSchema
@@ -272,7 +272,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.DefaultDatabase" copy="true"/>
+    /// <see cref="DomainConfiguration.DefaultDatabase" />
     /// </summary>
     [ConfigurationProperty(DefaultDatabaseElementName)]
     public string DefaultDatabase
@@ -282,7 +282,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.IncludeSqlInExceptions" copy="true"/>
+    /// <see cref="DomainConfiguration.IncludeSqlInExceptions" />
     /// </summary>
     [ConfigurationProperty(IncludeSqlInExceptionsElementName,
       DefaultValue = DomainConfiguration.DefaultIncludeSqlInExceptions)]
@@ -293,7 +293,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.AllowCyclicDatabaseDependencies" copy="true"/>
+    /// <see cref="DomainConfiguration.AllowCyclicDatabaseDependencies" />
     /// </summary>
     [ConfigurationProperty(AllowCyclicDatabaseDependenciesElementName,
       DefaultValue = DomainConfiguration.DefaultAllowCyclicDatabaseDependencies)]
@@ -304,7 +304,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.BuildInParallel" copy="true"/>
+    /// <see cref="DomainConfiguration.BuildInParallel" />
     /// </summary>
     [ConfigurationProperty(BuildInParallelElementName,
       DefaultValue = DomainConfiguration.DefaultBuildInParallel)]
@@ -315,7 +315,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.ForcedServerVersion" copy="true" />
+    /// <see cref="DomainConfiguration.ForcedServerVersion" />
     /// </summary>
     [ConfigurationProperty(ForcedServerVersionElementName)]
     public string ForcedServerVersion
@@ -325,7 +325,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.ConnectionInitializationSql" copy="true" />
+    /// <see cref="DomainConfiguration.ConnectionInitializationSql" />
     /// </summary>
     [ConfigurationProperty(ConnectionInitializationSqlElementName)]
     public string ConnectionInitializationSql
@@ -335,7 +335,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.IgnoreRules" copy="true"/>
+    /// <see cref="DomainConfiguration.IgnoreRules" />
     /// </summary>
     [ConfigurationProperty(IgnoreRulesElementName, IsDefaultCollection = false)]
     [ConfigurationCollection(typeof (ConfigurationCollection<IgnoreRuleElement>), AddItemName = "rule")]
@@ -345,7 +345,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.MultidatabaseKeys" copy="true"/>
+    /// <see cref="DomainConfiguration.MultidatabaseKeys"/>
     /// </summary>
     [ConfigurationProperty(MultidatabaseKeysElementName,
       DefaultValue = DomainConfiguration.DefaultMultidatabaseKeys)]
@@ -356,7 +356,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.Options" copy="true"/>
+    /// <see cref="DomainConfiguration.Options"/>
     /// </summary>
     [ConfigurationProperty(OptionsElementName, DefaultValue = "Default")]
     public string Options
@@ -366,7 +366,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.ShareStorageSchemaOverNodes" copy="true"/>
+    /// <see cref="DomainConfiguration.ShareStorageSchemaOverNodes"/>
     /// </summary>
     [ConfigurationProperty(ShareStorageSchemaOverNodesElementName, DefaultValue = false)]
     public bool ShareStorageSchemaOverNodes
@@ -376,7 +376,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.NamingConvention" copy="true"/>
+    /// <see cref="DomainConfiguration.NamingConvention"/>
     /// </summary>
     [ConfigurationProperty(VersioningConventionElementName)]
     public VersioningConventionElement VersioningConvention
@@ -386,7 +386,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.EnsureConnectionIsAlive" copy="true"/>
+    /// <see cref="DomainConfiguration.EnsureConnectionIsAlive"/>
     /// </summary>
     [ConfigurationProperty(EnsureConnectionIsAliveElementName, DefaultValue = true)]
     public bool EnsureConnectionIsAlive
@@ -396,7 +396,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.TagsLocation" copy="true"/>.
+    /// <see cref="DomainConfiguration.TagsLocation"/>.
     /// </summary>
     [ConfigurationProperty(TagsLocationElementName, DefaultValue = "Default")]
     public string TagsLocation
@@ -406,7 +406,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.PreferTypeIdsAsQueryParameters" copy="true"/>
+    /// <see cref="DomainConfiguration.PreferTypeIdsAsQueryParameters"/>
     /// </summary>
     [ConfigurationProperty(PreferTypeIdsAsQueryParametersElementName, DefaultValue = true)]
     public bool PreferTypeIdsAsQueryParameters

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/IgnoreRuleElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/IgnoreRuleElement.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
@@ -31,7 +31,7 @@ namespace Xtensive.Orm.Configuration.Elements
         Index ?? string.Empty);
 
     /// <summary>
-    /// <see cref="IgnoreRule.Database" copy="true"/>
+    /// <see cref="IgnoreRule.Database" />
     /// </summary>
     [ConfigurationProperty(DatabaseElementName)]
     public string Database
@@ -41,7 +41,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="IgnoreRule.Schema" copy="true"/>
+    /// <see cref="IgnoreRule.Schema" />
     /// </summary>
     [ConfigurationProperty(SchemaElementName)]
     public string Schema
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="IgnoreRule.Table" copy="true"/>
+    /// <see cref="IgnoreRule.Table" />
     /// </summary>
     [ConfigurationProperty(TableElementName)]
     public string Table

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/KeyGeneratorConfigurationElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/KeyGeneratorConfigurationElement.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.03.28
 
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="KeyGeneratorConfiguration.Name" copy="true"/>
+    /// <see cref="KeyGeneratorConfiguration.Name" />
     /// </summary>
     [ConfigurationProperty(NameElementName, IsKey = true)]
     public string Name
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="KeyGeneratorConfiguration.Database" copy="true"/>
+    /// <see cref="KeyGeneratorConfiguration.Database" />
     /// </summary>
     [ConfigurationProperty(DatabaseElementName, IsKey = true)]
     public string Database
@@ -45,7 +45,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="KeyGeneratorConfiguration.Seed" copy="true"/>
+    /// <see cref="KeyGeneratorConfiguration.Seed" />
     /// </summary>
     [ConfigurationProperty(SeedElementName, DefaultValue = 0L)]
     public long Seed
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="KeyGeneratorConfiguration.CacheSize" copy="true" />
+    /// <see cref="KeyGeneratorConfiguration.CacheSize" />
     /// </summary>
     [ConfigurationProperty(CacheSizeElementName, DefaultValue = (long) DomainConfiguration.DefaultKeyGeneratorCacheSize)]
     public long CacheSize

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/MappingRuleElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/MappingRuleElement.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.02.07
 
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="MappingRule.Assembly" copy="true"/>
+    /// <see cref="MappingRule.Assembly" />
     /// </summary>
     [ConfigurationProperty(AssemblyElementName, IsKey = true)]
     public string Assembly
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="MappingRule.Namespace" copy="true"/>
+    /// <see cref="MappingRule.Namespace" />
     /// </summary>
     [ConfigurationProperty(NamespaceElementName, IsKey = true)]
     public string Namespace
@@ -45,7 +45,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="MappingRule.Database" copy="true"/>
+    /// <see cref="MappingRule.Database" />
     /// </summary>
     [ConfigurationProperty(DatabaseElementName)]
     public string Database
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="MappingRule.Schema" copy="true"/>
+    /// <see cref="MappingRule.Schema" />
     /// </summary>
     [ConfigurationProperty(SchemaElementName)]
     public string Schema

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/NamingConventionElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/NamingConventionElement.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
 // Created:    2008.08.07
 
@@ -21,7 +21,7 @@ namespace Xtensive.Orm.Configuration.Elements
     private const string NamespaceSynonymsElementName = "namespaceSynonyms";
 
     /// <summary>
-    /// <see cref="NamingConvention.LetterCasePolicy" copy="true"/>
+    /// <see cref="NamingConvention.LetterCasePolicy" />
     /// </summary>
     [ConfigurationProperty(LetterCasePolicyElementName, IsRequired = false, IsKey = false, DefaultValue = "Default")]
     public string LetterCasePolicy
@@ -31,7 +31,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="NamingConvention.NamespacePolicy" copy="true"/>
+    /// <see cref="NamingConvention.NamespacePolicy" />
     /// </summary>
     [ConfigurationProperty(NamespacePolicyElementName, IsRequired = false, IsKey = false, DefaultValue = "Default")]
     public string NamespacePolicy
@@ -41,7 +41,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="NamingConvention.NamingRules" copy="true"/>
+    /// <see cref="NamingConvention.NamingRules" />
     /// </summary>
     [ConfigurationProperty(NamingRulesElementName, IsRequired = false, IsKey = false, DefaultValue = "Default")]
     public string NamingRules
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="NamingConvention.NamespaceSynonyms" copy="true"/>
+    /// <see cref="NamingConvention.NamespaceSynonyms" />
     /// </summary>
     [ConfigurationProperty(NamespaceSynonymsElementName, IsRequired = false, IsKey = false)]
     [ConfigurationCollection(typeof (ConfigurationCollection<NamespaceSynonymElement>), AddItemName = "synonym")]

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/SessionConfigurationElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/SessionConfigurationElement.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2008-2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Aleksey Gamzov
 // Created:    2008.08.11
 
@@ -37,7 +37,7 @@ namespace Xtensive.Orm.Configuration.Elements
     public override object Identifier { get { return Name; } }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.Name" copy="true"/>
+    /// <see cref="SessionConfiguration.Name" />
     /// </summary>
     [ConfigurationProperty(NameElementName, IsKey = true, DefaultValue = "Default")]
     public string Name {
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.UserName" copy="true"/>
+    /// <see cref="SessionConfiguration.UserName" />
     /// </summary>
     [ConfigurationProperty(UserNameElementName)]
     public string UserName {
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.Password" copy="true"/>
+    /// <see cref="SessionConfiguration.Password" />
     /// </summary>
     [ConfigurationProperty(PasswordElementName)]
     public string Password {
@@ -64,7 +64,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.CacheSize" copy="true"/>
+    /// <see cref="SessionConfiguration.CacheSize" />
     /// </summary>
     [ConfigurationProperty(CacheSizeElementName,
       DefaultValue = SessionConfiguration.DefaultCacheSize)]
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.CacheType" copy="true"/>
+    /// <see cref="SessionConfiguration.CacheType" />
     /// </summary>
     [ConfigurationProperty(CacheTypeElementName, DefaultValue = "Default")]
     public string CacheType {
@@ -84,7 +84,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.Options" copy="true"/>
+    /// <see cref="SessionConfiguration.Options" />
     /// </summary>
     [ConfigurationProperty(OptionsElementName, DefaultValue = "Default")]
     public string Options {
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.DefaultIsolationLevel" copy="true" />
+    /// <see cref="SessionConfiguration.DefaultIsolationLevel" />
     /// </summary>
     [ConfigurationProperty(IsolationLevelElementName, DefaultValue = "RepeatableRead")]
     public string DefaultIsolationLevel {
@@ -102,7 +102,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.DefaultCommandTimeout" copy="true" />
+    /// <see cref="SessionConfiguration.DefaultCommandTimeout" />
     /// </summary>
     [ConfigurationProperty(CommandTimeoutElementName, DefaultValue = null)]
     public int? DefaultCommandTimeout {
@@ -111,7 +111,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.BatchSize" copy="true"/>
+    /// <see cref="SessionConfiguration.BatchSize" />
     /// </summary>
     [ConfigurationProperty(BatchSizeElementName,
       DefaultValue = SessionConfiguration.DefaultBatchSize)]
@@ -122,7 +122,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.ReaderPreloading" copy="true"/>
+    /// <see cref="SessionConfiguration.ReaderPreloading" />
     /// </summary>
     [ConfigurationProperty(ReaderPreloadingElementName, DefaultValue = "Default")]
     public string ReaderPreloading {
@@ -131,7 +131,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="DomainConfiguration.ServiceContainerType" copy="true"/>
+    /// <see cref="DomainConfiguration.ServiceContainerType" />
     /// </summary>
     [ConfigurationProperty(ServiceContainerTypeElementName, DefaultValue = null)]
     public string ServiceContainerType {
@@ -140,7 +140,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="SessionConfiguration.EntityChangeRegistrySize" copy="true"/>.
+    /// <see cref="SessionConfiguration.EntityChangeRegistrySize" />.
     /// </summary>
     [ConfigurationProperty(EntityChangeRegistrySizeElementName,
       DefaultValue = SessionConfiguration.DefaultEntityChangeRegistrySize)]

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/SessionConfigurationElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/SessionConfigurationElement.cs
@@ -68,6 +68,7 @@ namespace Xtensive.Orm.Configuration.Elements
     /// </summary>
     [ConfigurationProperty(CacheSizeElementName,
       DefaultValue = SessionConfiguration.DefaultCacheSize)]
+    [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
     public int CacheSize {
       get { return (int) this[CacheSizeElementName]; }
       set { this[CacheSizeElementName] = value; }
@@ -114,6 +115,7 @@ namespace Xtensive.Orm.Configuration.Elements
     /// </summary>
     [ConfigurationProperty(BatchSizeElementName,
       DefaultValue = SessionConfiguration.DefaultBatchSize)]
+    [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
     public int BatchSize {
       get { return (int) this[BatchSizeElementName]; }
       set { this[BatchSizeElementName] = value; }
@@ -142,6 +144,7 @@ namespace Xtensive.Orm.Configuration.Elements
     /// </summary>
     [ConfigurationProperty(EntityChangeRegistrySizeElementName,
       DefaultValue = SessionConfiguration.DefaultEntityChangeRegistrySize)]
+    [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
     public int EntityChangeRegistrySize {
       get { return (int) this[EntityChangeRegistrySizeElementName]; }
       set { this[EntityChangeRegistrySizeElementName] = value; }

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/VersioningConventionElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/VersioningConventionElement.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2018 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2018-2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
 // Created:    2018.03.14
 
@@ -15,7 +15,7 @@ namespace Xtensive.Orm.Configuration.Elements
     private const string DenyEntitySetOwnerVersionChangeElementName = "denyEntitySetOwnerVersionChange";
 
     /// <summary>
-    /// <see cref="VersioningConvention.EntityVersioningPolicy" copy="true"/>
+    /// <see cref="VersioningConvention.EntityVersioningPolicy" />
     /// </summary>
     [ConfigurationProperty(EntityVersioningPolicyElementName, IsRequired = false, IsKey = false, DefaultValue = "Default")]
     public string EntityVersioningPolicy
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Configuration.Elements
     }
 
     /// <summary>
-    /// <see cref="VersioningConvention.DenyEntitySetOwnerVersionChange" copy="true"/>
+    /// <see cref="VersioningConvention.DenyEntitySetOwnerVersionChange" />
     /// </summary>
     [ConfigurationProperty(DenyEntitySetOwnerVersionChangeElementName, IsRequired = false, IsKey = false, DefaultValue = false)]
     public bool DenyEntitySetOwnerVersionChange

--- a/Orm/Xtensive.Orm/Orm/Configuration/ExtensionConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/ExtensionConfigurationCollection.cs
@@ -1,16 +1,18 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xtensive.Core;
 
 namespace Xtensive.Orm.Configuration
 {
   /// <summary>
-  /// Default <see cref="IExtensionConfigurationCollection"/> implementation (<see cref="ILockable">lockable</see>).
+  /// Collection of configurations of extensions.
   /// </summary>
   [Serializable]
   public sealed class ExtensionConfigurationCollection : LockableBase,

--- a/Orm/Xtensive.Orm/Orm/Configuration/Interfaces/IConfigurationSectionReader{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Interfaces/IConfigurationSectionReader{T}.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+
+using Microsoft.Extensions.Configuration;
+
+namespace Xtensive.Orm.Configuration
+{
+  /// <summary>
+  /// Reads certain type of configuration (DomainConfiguration, LoggingConfiguration, etc.) from IConfigurationSection API
+  /// </summary>
+  /// <typeparam name="TConfiguration"></typeparam>
+  public interface IConfigurationSectionReader<TConfiguration>
+  {
+    /// <summary>
+    /// Reads configuration from given configuration section.
+    /// </summary>
+    /// <param name="configurationSection">Root configuration section where specific configuration is placed (for domain configuration - where all domain configurations).</param>
+    /// <returns>Instance of configuration.</returns>
+    TConfiguration Read(IConfigurationSection configurationSection);
+
+    /// <summary>
+    /// Reads configuration from given configuration section with specified name (if named configuration supported e.g. doman configuration)
+    /// </summary>
+    /// <param name="configurationSection">Root configuration section where specific configuration is placed (for domain configuration - where all domain configurations).</param>
+    /// <param name="nameOfConfiguration">Name of configuration.</param>
+    /// <returns>Instance of configuration.</returns>
+    TConfiguration Read(IConfigurationSection configurationSection, string nameOfConfiguration);
+
+    /// <summary>
+    /// Reads configuration (with default name if name is required) from default section (and with default name) from given configuration root.
+    /// </summary>
+    /// <param name="configurationRoot">Root of all configuration sections.</param>
+    /// <returns>Instance of configuration.</returns>
+    TConfiguration Read(IConfigurationRoot configurationRoot);
+
+    /// <summary>
+    /// Reads configuration (with default name if name is required) from given section of given configuration root.
+    /// </summary>
+    /// <param name="configurationRoot">Root of all configuration sections.</param>
+    /// <param name="sectionName">Specific section name from which configuration should be read.</param>
+    /// <returns>Instance of configuration.</returns>
+    TConfiguration Read(IConfigurationRoot configurationRoot, string sectionName);
+
+    /// <summary>
+    /// Reads configuration with given name from given section of given configuration root.
+    /// </summary>
+    /// <param name="configurationRoot">Root of all configuration sections.</param>
+    /// <param name="sectionName">Specific section name from which configuration should be read.</param>
+    /// <param name="nameOfConfiguration">Name of configuration.</param>
+    /// <returns>Instance of configuration.</returns>
+    TConfiguration Read(IConfigurationRoot configurationRoot, string sectionName, string nameOfConfiguration);
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/ConfigurationSectionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/ConfigurationSectionExtensions.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Xtensive.Collections;
 
-namespace Xtensive.Orm.Configuration.Internals
+namespace Xtensive.Orm.Configuration
 {
   internal static class ConfigurationSectionExtensions
   {

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/ConfigurationSectionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/ConfigurationSectionExtensions.cs
@@ -1,8 +1,9 @@
-using System;
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Xtensive.Collections;
 

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/ConfigurationSectionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/ConfigurationSectionExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Xtensive.Collections;
+
+namespace Xtensive.Orm.Configuration.Internals
+{
+  internal static class ConfigurationSectionExtensions
+  {
+    public static IEnumerable<IConfigurationSection> GetSelfOrChildren(this IConfigurationSection section, bool requiredName = false)
+    {
+      var children = section.GetChildren().ToList();
+      if (children.Count > 0) {
+        if (requiredName) {
+          var anyItemWithName = children.Any(i => i["name"] != null);
+          if (anyItemWithName) {
+            return children;
+          }
+        }
+        var firstChild = children[0];
+        var isIndexed = firstChild.Key == "0";
+        if (isIndexed)
+          return children;
+        else
+          return EnumerableUtils.One(section);
+      }
+      return children;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/DomainConfigurationParsers.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/DomainConfigurationParsers.cs
@@ -1,0 +1,334 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Xtensive.Collections;
+using Xtensive.Orm.Configuration.Options;
+
+namespace Xtensive.Orm.Configuration.Internals
+{
+  internal interface IConfigurationSectionParser
+  {
+    DomainConfiguration Parse(IConfiguration configuration);
+
+    DomainConfiguration Parse(IConfigurationRoot configuration, string sectionName);
+
+    DomainConfiguration Parse(IConfigurationSection domainConfiguration, Dictionary<string, string> connectionStrings = null);
+
+  }
+
+  internal sealed class XmlDomainConfigParser : DomainConfigurationParser
+  {
+
+    protected override void ProcessNamingConvention(IConfigurationSection namingConventionSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+      if (namingConventionSection == null) {
+        domainConfiguratonOptions.NamingConventionRaw = null;
+        return;
+      }
+
+      if (namingConventionSection.GetChildren().Any()) {
+        var namingConvetion = namingConventionSection.Get<NamingConventionOptions>();
+        if (namingConvetion!= null) {
+          var synonymsSection = namingConventionSection.GetSection(NamespaceSynonymSectionName);
+          var synonyms = synonymsSection != null && synonymsSection.GetChildren().Any()
+            ? GetSelfOrChildren(synonymsSection.GetSection(SynonymElementName))
+              .Select(s => s.Get<NamespaceSynonymOptions>())
+              .Where(ns => ns != null)
+              .ToArray()
+            : Array.Empty<NamespaceSynonymOptions>();
+
+          namingConvetion.NamespaceSynonyms = synonyms;
+          domainConfiguratonOptions.NamingConventionRaw = namingConvetion;
+        }
+        else {
+          domainConfiguratonOptions.NamingConventionRaw = null;
+        }
+      }
+    }
+
+    protected override void ProcessVersioningConvention(IConfigurationSection versioningConventionSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+      if (versioningConventionSection == null) {
+        domainConfiguratonOptions.VersioningConvention = null;
+        return;
+      }
+
+      if (versioningConventionSection.GetChildren().Any()) {
+        var versioningConvention = versioningConventionSection.Get<VersioningConventionOptions>();
+
+        domainConfiguratonOptions.VersioningConvention = versioningConvention != null
+          ? versioningConvention
+          : null;
+      }
+    }
+
+    protected override void ProcessTypes(IConfigurationSection typesSection, DomainConfigurationOptions domainConfigurationOptions)
+    {
+      if (typesSection == null) {
+        domainConfigurationOptions.Types = Array.Empty<TypeRegistrationOptions>();
+        return;
+      }
+      if (TryProcessTypeRegistrationsWithAttributes(typesSection, domainConfigurationOptions)
+        || TryProcessTypeRegistrationsWithNodes(typesSection, domainConfigurationOptions))
+        return;
+      domainConfigurationOptions.Types = Array.Empty<TypeRegistrationOptions>();
+    }
+
+    private bool TryProcessTypeRegistrationsWithAttributes(IConfigurationSection typesSection,
+      DomainConfigurationOptions domainConfigurationOptions)
+    {
+      var registrations = typesSection.GetSection(OldStyleTypeRegistrationElementName);
+      if (registrations != null && registrations.GetChildren().Any()) {
+        domainConfigurationOptions.Types = GetSelfOrChildren(registrations)
+          .Select(s => s.Get<TypeRegistrationOptions>())
+          .Where(tr => tr != null)
+          .ToArray();
+        return true;
+      }
+      return false;
+    }
+
+    private bool TryProcessTypeRegistrationsWithNodes(IConfigurationSection typesSection,
+      DomainConfigurationOptions domainConfigurationOptions)
+    {
+      var registrations = typesSection.GetSection(TypeRegistrationElementName);
+      if (registrations == null)
+        return false;
+
+      domainConfigurationOptions.Types = GetSelfOrChildren(registrations)
+        .Select(s => s.Get<TypeRegistrationOptions>())
+        .Where(tr => tr != null)
+        .ToArray();
+      return true;
+    }
+
+    protected override void ProcessDatabases(IConfigurationSection databasesSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+      domainConfiguratonOptions.Databases.Clear();
+      if (databasesSection == null)
+        return;
+      var databaseElement = databasesSection.GetSection(DatabaseElementName);
+      if (databaseElement == null)
+        return;
+      foreach (var section in GetSelfOrChildren(databaseElement, true)) {
+        var dbItem = section.Get<DatabaseOptions>();
+        if (dbItem == null)
+          continue;
+        domainConfiguratonOptions.Databases.Add(dbItem.Name, dbItem);
+      }
+    }
+
+    protected override void ProcessKeyGenerators(IConfigurationSection keyGeneratorsSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+      domainConfiguratonOptions.KeyGenerators.Clear();
+      ProcessCollectionOfOptions(keyGeneratorsSection, KeyGeneratorElementName, domainConfiguratonOptions.KeyGenerators);
+    }
+
+    protected override void ProcessIgnoreRules(IConfigurationSection ignoreRulesSection, Options.DomainConfigurationOptions domainConfiguratonOptions)
+    {
+      domainConfiguratonOptions.IgnoreRules.Clear();
+      ProcessCollectionOfOptions(ignoreRulesSection, RuleElementName, domainConfiguratonOptions.IgnoreRules);
+    }
+
+    protected override void ProcessMappingRules(IConfigurationSection mappingRulesSection, Options.DomainConfigurationOptions domainConfiguratonOptions)
+    {
+      domainConfiguratonOptions.MappingRules.Clear();
+      ProcessCollectionOfOptions(mappingRulesSection, RuleElementName, domainConfiguratonOptions.MappingRules);
+    }
+
+    protected override void ProcessSessions(IConfigurationSection sessionsSection, Options.DomainConfigurationOptions domainConfiguratonOptions)
+    {
+      domainConfiguratonOptions.Sessions.Clear();
+      if (sessionsSection == null)
+        return;
+      var sessionElement = sessionsSection.GetSection(SessionElementName);
+      if (sessionElement == null)
+        return;
+      foreach (var section in GetSelfOrChildren(sessionElement, true)) {
+        var sessionItem = section.Get<SessionConfigurationOptions>();
+        if (sessionItem == null)
+          continue;
+        domainConfiguratonOptions.Sessions.Add(sessionItem.Name, sessionItem);
+      }
+    }
+
+    private void ProcessCollectionOfOptions<TOption>(IConfigurationSection collectionSection, string itemKey, OptionsCollection<TOption> collection)
+      where TOption : class, IIdentifyableOptions
+    {
+      if (collectionSection == null)
+        return;
+      var collectionElement = collectionSection.GetSection(itemKey);
+      if (collectionElement == null)
+        return;
+      foreach (var item in GetSelfOrChildren(collectionElement)) {
+        var optItem = item.Get<TOption>();
+        collection.Add(optItem);
+      }
+    }
+
+    private IEnumerable<IConfigurationSection> GetSelfOrChildren(IConfigurationSection section, bool requiredName = false)
+    {
+      var children = section.GetChildren().ToList();
+      if (children.Count > 0) {
+        if (requiredName) {
+          var anyItemWithName = children.Any(i => i["name"] != null);
+          if (anyItemWithName) {
+            return children;
+          }
+        }
+        var firstChild = children[0];
+        var isIndexed = firstChild.Key == "0";
+        if (isIndexed)
+          return children;
+        else
+          return EnumerableUtils.One(section);
+      }
+      return children;
+    }
+  }
+
+  internal class FromJsonToDomainConfigurationParser : DomainConfigurationParser
+  {
+
+    protected override void ProcessNamingConvention(IConfigurationSection namingConventionSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+      if (namingConventionSection == null || !namingConventionSection.GetChildren().Any())
+        return;
+      var jsonListVariant = namingConventionSection.Get<NamingConventionOptions>();
+      if (jsonListVariant.NamespaceSynonyms == null)
+        jsonListVariant.NamespaceSynonyms = Array.Empty<NamespaceSynonymOptions>();
+      domainConfiguratonOptions.NamingConventionRaw = jsonListVariant;
+    }
+  }
+
+  internal abstract class DomainConfigurationParser : IConfigurationSectionParser
+  {
+    protected const string RuleElementName = "Rule";
+    protected const string KeyGeneratorElementName = "KeyGenerator";
+    protected const string OldStyleTypeRegistrationElementName = "Add";
+    protected const string TypeRegistrationElementName = "Registration";
+    protected const string SynonymElementName = "Synonym";
+    protected const string DatabaseElementName = "Database";
+    protected const string SessionElementName = "Session";
+
+    protected const string NamingConventionSectionName = "NamingConvention";
+    protected const string VersioningConventionSectionName = "VersioningConvention";
+    protected const string TypesSectionName = "Types";
+    protected const string DatabasesSectionName = "Databases";
+    protected const string KeyGeneratorsSectionName = "KeyGenerators";
+    protected const string IgnoreRulesSectionName = "IgnoreRules";
+    protected const string MappingRulesSectionName = "MappingRules";
+    protected const string SessionsSectionName = "Sessions";
+    protected const string NamespaceSynonymSectionName = "NamespaceSynonyms";
+
+    public DomainConfiguration Parse(IConfiguration configuration)
+    {
+      if (configuration is IConfigurationRoot configurationRoot) {
+        return Parse(configurationRoot, WellKnown.DefaultConfigurationSection);
+      }
+      else if (configuration is IConfigurationSection configurationSection) {
+        return Parse(configurationSection);
+      }
+      throw new InvalidOperationException("");
+    }
+
+    public DomainConfiguration Parse(IConfigurationRoot configuration, string sectionName)
+    {
+      var context = new ConfigurationParserContext(configuration, sectionName);
+      return ParseInternal(context);
+    }
+
+    public DomainConfiguration Parse(IConfigurationSection domainConfiguration, Dictionary<string, string> connectionStrings = null)
+    {
+      var context = new ConfigurationParserContext(domainConfiguration, connectionStrings);
+      return ParseInternal(context);
+    }
+
+    private DomainConfiguration ParseInternal(ConfigurationParserContext context)
+    {
+      var domainByNameSection = context.CurrentSection;
+      if (domainByNameSection == null || !domainByNameSection.GetChildren().Any()) {
+        return null;
+      }
+      // this handles only root properties of domain configuration
+      var domainConfigurationOptions = context.CurrentSection.Get<Options.DomainConfigurationOptions>();
+      if (domainConfigurationOptions == null) {
+        return null;
+      }
+
+      // all sub-items require manual reading;
+      ProcessNamingConvention(domainByNameSection.GetSection(NamingConventionSectionName), domainConfigurationOptions);
+      ProcessVersioningConvention(domainByNameSection.GetSection(VersioningConventionSectionName), domainConfigurationOptions);
+      ProcessTypes(domainByNameSection.GetSection(TypesSectionName), domainConfigurationOptions);
+      ProcessDatabases(domainByNameSection.GetSection(DatabasesSectionName), domainConfigurationOptions);
+      ProcessKeyGenerators(domainByNameSection.GetSection(KeyGeneratorsSectionName), domainConfigurationOptions);
+      ProcessIgnoreRules(domainByNameSection.GetSection(IgnoreRulesSectionName), domainConfigurationOptions);
+      ProcessMappingRules(domainByNameSection.GetSection(MappingRulesSectionName), domainConfigurationOptions);
+      ProcessSessions(domainByNameSection.GetSection(SessionsSectionName), domainConfigurationOptions);
+
+      return domainConfigurationOptions.ToNative(context.ConnectionStrings);
+    }
+
+    protected virtual void ProcessNamingConvention(IConfigurationSection namingConventionSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+    }
+
+    protected virtual void ProcessVersioningConvention(IConfigurationSection versioningConventionSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+    }
+
+    protected virtual void ProcessTypes(IConfigurationSection typesSection, DomainConfigurationOptions domainConfigurationOptions)
+    {
+    }
+
+    protected virtual void ProcessDatabases(IConfigurationSection databasesSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+    }
+
+    protected virtual void ProcessKeyGenerators(IConfigurationSection keyGeneratorsSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+    }
+
+    protected virtual void ProcessIgnoreRules(IConfigurationSection ignoreRulesSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+    }
+
+    protected virtual void ProcessMappingRules(IConfigurationSection mappingRulesSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+    }
+
+    protected virtual void ProcessSessions(IConfigurationSection sessionsSection, DomainConfigurationOptions domainConfiguratonOptions)
+    {
+    }
+  }
+
+  internal sealed class ConfigurationParserContext
+  {
+    public readonly IConfigurationRoot CurrentConfiguration;
+
+    public readonly IConfigurationSection CurrentSection;
+
+    public readonly string SectionName;
+
+    public readonly IDictionary<string, string> ConnectionStrings;
+
+    public ConfigurationParserContext(IConfigurationRoot currentConfiguration, string sectionName)
+    {
+      CurrentConfiguration = currentConfiguration;
+      CurrentSection = currentConfiguration.GetSection(sectionName);
+      ConnectionStrings = currentConfiguration.Get<Dictionary<string, string>>();
+    }
+
+    public ConfigurationParserContext(IConfigurationSection currentSection, IDictionary<string, string> connectionStrings)
+    {
+      CurrentSection = currentSection;
+      ConnectionStrings = connectionStrings;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/ExtensionConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/ExtensionConfigurationCollection.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration
+{
+  /// <summary>
+  /// Default <see cref="IExtensionConfigurationCollection"/> implementation (<see cref="ILockable">lockable</see>).
+  /// </summary>
+  [Serializable]
+  public sealed class ExtensionConfigurationCollection : LockableBase
+    IEnumerable<ConfigurationBase>
+  {
+    private Dictionary<Type, ConfigurationBase> extensionConfigurations;
+
+    /// <summary>
+    /// Number of configurations in collection.
+    /// </summary>
+    public long Count
+    {
+      [DebuggerStepThrough]
+      get => extensionConfigurations != null ? extensionConfigurations.Count : 0;
+    }
+
+    /// <summary>
+    /// Gets configuration of certain type from collection.
+    /// </summary>
+    /// <typeparam name="T">Type of configuration to get.</typeparam>
+    /// <returns>Found configuration or <see langword="null"/>.</returns>
+    [DebuggerStepThrough]
+    public T Get<T>()
+      where T : ConfigurationBase
+    {
+      return extensionConfigurations != null && extensionConfigurations.TryGetValue(typeof(T), out var result)
+        ? (T) result
+        : null;
+    }
+
+    /// <summary>
+    /// Adds or replace configuration of certain type
+    /// </summary>
+    /// <typeparam name="T">Type of configuration.</typeparam>
+    /// <param name="value">Configuration to add or to replace existing one.</param>
+    [DebuggerStepThrough]
+    public void Set<T>(T value)
+      where T : ConfigurationBase
+    {
+      EnsureNotLocked();
+      ArgumentValidator.EnsureArgumentNotNull(value, nameof(value));
+
+      var extensionConfigurationType = typeof(T);
+
+      if (extensionConfigurations == null) {
+        extensionConfigurations = new Dictionary<Type, ConfigurationBase>();
+      }
+
+      extensionConfigurations[extensionConfigurationType] = value;
+    }
+
+    /// <summary>
+    /// Clears the collection.
+    /// </summary>
+    public void Clear()
+    {
+      EnsureNotLocked();
+      extensionConfigurations = null;
+    }
+
+    /// <inheritdoc/>
+    public override void Lock(bool recursive)
+    {
+      base.Lock(recursive);
+      if (extensionConfigurations != null)
+        foreach (var pair in extensionConfigurations) {
+          pair.Value.Lock(recursive);
+        }
+    }
+
+    #region ICloneable methods
+
+    /// <inheritdoc/>
+    public object Clone()
+    {
+      return new ExtensionConfigurationCollection(this);
+    }
+
+    #endregion
+
+    #region IEnumerable methods
+
+    /// <inheritdoc/>
+    [DebuggerStepThrough]
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <inheritdoc/>
+    public IEnumerator<ConfigurationBase> GetEnumerator()
+    {
+      return extensionConfigurations != null
+        ? extensionConfigurations.Values.GetEnumerator()
+        : Enumerable.Empty<ConfigurationBase>().GetEnumerator();
+    }
+
+    #endregion
+
+
+    // Constructors
+
+    /// <summary>
+    /// Initializes new instance of this type.
+    /// </summary>
+    public ExtensionConfigurationCollection()
+    {
+    }
+
+    /// <summary>
+    /// Initializes new instance of this type.
+    /// </summary>
+    /// <param name="source">The source to copy into this collection.</param>
+    public ExtensionConfigurationCollection(ExtensionConfigurationCollection source)
+      : this()
+    {
+      ArgumentValidator.EnsureArgumentNotNull(source, nameof(source));
+      if (source.Count == 0)
+        return;
+      extensionConfigurations = new Dictionary<Type, ConfigurationBase>(source.extensionConfigurations);
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/ExtensionConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/ExtensionConfigurationCollection.cs
@@ -13,7 +13,7 @@ namespace Xtensive.Orm.Configuration
   /// Default <see cref="IExtensionConfigurationCollection"/> implementation (<see cref="ILockable">lockable</see>).
   /// </summary>
   [Serializable]
-  public sealed class ExtensionConfigurationCollection : LockableBase
+  public sealed class ExtensionConfigurationCollection : LockableBase,
     IEnumerable<ConfigurationBase>
   {
     private Dictionary<Type, ConfigurationBase> extensionConfigurations;

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/LoggingConfigurationReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/LoggingConfigurationReader.cs
@@ -1,0 +1,94 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Internals
+{
+  internal sealed class LoggingConfigurationReader : IConfigurationSectionReader<LoggingConfiguration>
+  {
+    private const string LoggingSectionName = "Logging";
+    private const string LogsSectionName = "Logs";
+
+    private const string ProviderElementName = "Provider";
+    private const string LogElementName = "Log";
+    private const string LogSourceElementName = "Source";
+    private const string LogTargerElementName = "Target";
+
+    /// <inheritdoc/>
+    public LoggingConfiguration Read(IConfigurationRoot configurationRoot, string sectionName)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(configurationRoot, nameof(configurationRoot));
+      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sectionName, nameof(sectionName));
+
+      return Read(configurationRoot.GetSection(sectionName));
+    }
+
+    /// <inheritdoc/>
+    public LoggingConfiguration Read(IConfigurationRoot configurationRoot)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(configurationRoot, nameof(configurationRoot));
+      return Read(configurationRoot.GetSection(WellKnown.DefaultConfigurationSection));
+    }
+
+    /// <inheritdoc/>
+    public LoggingConfiguration Read(IConfigurationRoot configurationRoot, string sectionName, string nameOfConfiguration)
+    {
+      throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public LoggingConfiguration Read(IConfigurationSection configurationSection)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(configurationSection, nameof(configurationSection));
+
+      var ormConfigurationSection = configurationSection;
+
+      var loggingSection = ormConfigurationSection.GetSection(LoggingSectionName);
+
+      if (loggingSection != null && loggingSection.GetChildren().Any()) {
+        var provider = loggingSection.GetSection(ProviderElementName)?.Value;
+        var logsSection = loggingSection.GetSection(LogsSectionName);
+        IConfigurationSection logElement;
+
+        if (logsSection != null && logsSection.GetChildren().Any()) {
+          logElement = logsSection.GetSection(LogElementName);
+          if (logElement == null || !logElement.GetChildren().Any()) {
+            logElement = logsSection;
+          }
+        }
+        else {
+          logElement = loggingSection.GetSection(LogElementName);
+        }
+
+        var configuration = new LoggingConfiguration(provider);
+        foreach (var logItem in logElement.GetSelfOrChildren()) {
+          var source = logItem.GetSection(LogSourceElementName).Value;
+          var target = logItem.GetSection(LogTargerElementName).Value;
+          if (source.IsNullOrEmpty() || target.IsNullOrEmpty())
+            throw new InvalidOperationException();
+          configuration.Logs.Add(new LogConfiguration(source, target));
+        }
+
+        if (configuration.Provider ==  null && configuration.Logs.Count==0)
+          throw new InvalidOperationException();
+
+        return configuration;
+      }
+
+      throw new InvalidOperationException(
+        string.Format(Strings.ExSectionIsNotFoundInApplicationConfigurationFile, WellKnown.DefaultConfigurationSection));
+    }
+
+    /// <inheritdoc/>
+    public LoggingConfiguration Read(IConfigurationSection configurationSection, string nameOfConfiguration)
+    {
+      throw new NotSupportedException();
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Internals/LoggingConfigurationReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Internals/LoggingConfigurationReader.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Xtensive.Core;
 
-namespace Xtensive.Orm.Configuration.Internals
+namespace Xtensive.Orm.Configuration
 {
   internal sealed class LoggingConfigurationReader : IConfigurationSectionReader<LoggingConfiguration>
   {
@@ -33,13 +33,17 @@ namespace Xtensive.Orm.Configuration.Internals
     public LoggingConfiguration Read(IConfigurationRoot configurationRoot)
     {
       ArgumentValidator.EnsureArgumentNotNull(configurationRoot, nameof(configurationRoot));
+
       return Read(configurationRoot.GetSection(WellKnown.DefaultConfigurationSection));
     }
 
     /// <inheritdoc/>
     public LoggingConfiguration Read(IConfigurationRoot configurationRoot, string sectionName, string nameOfConfiguration)
     {
-      throw new NotSupportedException();
+      ArgumentValidator.EnsureArgumentNotNull(configurationRoot, nameof(configurationRoot));
+      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sectionName, nameof(sectionName));
+
+      return Read(configurationRoot.GetSection(sectionName));
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Configuration/LogConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/LogConfiguration.cs
@@ -1,25 +1,42 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Kulakov
 // Created:    2013.09.17
+
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Configuration
 {
   /// <summary>
   /// Configuration of log. 
   /// </summary>
-  public class LogConfiguration
+  public class LogConfiguration : LockableBase
   {
+    private string source;
+    private string target;
+
     /// <summary>
     /// Gets or sets source or sources of log separated by comma.
     /// </summary>
-    public string Source { get; set; }
+    public string Source {
+      get => source;
+      set {
+        EnsureNotLocked();
+        source = value;
+      }
+    }
 
     /// <summary>
     /// Gets or sets targer of log.
     /// </summary>
-    public string Target { get; set; }
+    public string Target {
+      get => target;
+      set {
+        EnsureNotLocked();
+        target = value;
+      }
+    }
 
     /// <summary>
     /// Creates new instance of this class
@@ -28,8 +45,8 @@ namespace Xtensive.Orm.Configuration
     /// <param name="target">Targer for new log</param>
     public LogConfiguration(string source, string target)
     {
-      Source = source;
-      Target = target;
+      this.source = source;
+      this.target = target;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2020 Xtensive LLC.
+// Copyright (C) 2013-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
@@ -10,7 +10,6 @@ using System.Configuration;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Xtensive.Core;
-using Xtensive.Orm.Configuration.Internals;
 using ConfigurationSection = Xtensive.Orm.Configuration.Elements.ConfigurationSection;
 
 namespace Xtensive.Orm.Configuration

--- a/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
@@ -80,6 +80,16 @@ namespace Xtensive.Orm.Configuration
       return loggingConfiguration;
     }
 
+    public static LoggingConfiguration Load(IConfigurationSection configurationSection)
+    {
+      throw new NotImplementedException();
+    }
+
+    public static LoggingConfiguration Load(IConfigurationRoot configurationRoot, string sectionName = null)
+    {
+      throw new NotImplementedException();
+    }
+
     /// <summary>
     /// Creates instance of this class.
     /// </summary>

--- a/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
@@ -82,12 +82,12 @@ namespace Xtensive.Orm.Configuration
 
     public static LoggingConfiguration Load(IConfigurationSection configurationSection)
     {
-      return new LoggingConfigurationParser().Parse(configurationSection);
+      return new LoggingConfigurationReader().Read(configurationSection);
     }
 
-    public static LoggingConfiguration Load(IConfigurationRoot configurationRoot, string sectionName = null)
+      return new LoggingConfigurationReader().Read(configurationRoot);
     {
-      return new LoggingConfigurationParser().Parse(configurationRoot, sectionName);
+      return new LoggingConfigurationReader().Read(configurationRoot, sectionName);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
@@ -82,12 +82,12 @@ namespace Xtensive.Orm.Configuration
 
     public static LoggingConfiguration Load(IConfigurationSection configurationSection)
     {
-      throw new NotImplementedException();
+      return new LoggingConfigurationParser().Parse(configurationSection);
     }
 
     public static LoggingConfiguration Load(IConfigurationRoot configurationRoot, string sectionName = null)
     {
-      throw new NotImplementedException();
+      return new LoggingConfigurationParser().Parse(configurationRoot, sectionName);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
@@ -7,7 +7,9 @@
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using Microsoft.Extensions.Configuration;
 using Xtensive.Core;
+using Xtensive.Orm.Configuration.Internals;
 using ConfigurationSection = Xtensive.Orm.Configuration.Elements.ConfigurationSection;
 
 namespace Xtensive.Orm.Configuration
@@ -43,7 +45,7 @@ namespace Xtensive.Orm.Configuration
     /// <returns>Loaded configuration.</returns>
     public static LoggingConfiguration Load(string sectionName)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sectionName, "sectionName");
+      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sectionName, nameof(sectionName));
 
       var section = (ConfigurationSection)ConfigurationManager.GetSection(sectionName);
       if (section==null)
@@ -70,8 +72,8 @@ namespace Xtensive.Orm.Configuration
     /// <returns>Loaded configuration.</returns>
     public static LoggingConfiguration Load(System.Configuration.Configuration configuration, string sectionName)
     {
-      ArgumentValidator.EnsureArgumentNotNull(configuration, "configuration");
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sectionName, "sectionName");
+      ArgumentValidator.EnsureArgumentNotNull(configuration, nameof(configuration));
+      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sectionName, nameof(sectionName));
 
       var section = (ConfigurationSection) configuration.GetSection(sectionName);
       if (section==null)
@@ -80,12 +82,36 @@ namespace Xtensive.Orm.Configuration
       return loggingConfiguration;
     }
 
+    /// <summary>
+    /// Loads logging configuration from the specified configuration section.
+    /// </summary>
+    /// <param name="configurationSection">Root configuration section where logging configuration is placed.</param>
+    /// <returns>Logging configuration.</returns>
+    /// <exception cref="InvalidOperationException">The logging section is not found.</exception>
     public static LoggingConfiguration Load(IConfigurationSection configurationSection)
     {
       return new LoggingConfigurationReader().Read(configurationSection);
     }
 
+    /// <summary>
+    /// Loads logging configuration from default section.
+    /// </summary>
+    /// <param name="configurationRoot">Root of configuration.</param>
+    /// <returns>Read configuration.</returns>
+    /// <exception cref="InvalidOperationException">The logging section is not found.</exception>
+    public static LoggingConfiguration Load(IConfigurationRoot configurationRoot)
+    {
       return new LoggingConfigurationReader().Read(configurationRoot);
+    }
+
+    /// <summary>
+    /// Loads logging configuration from specific section.
+    /// </summary>
+    /// <param name="configurationRoot">Root of configuration.</param>
+    /// <param name="sectionName">Section name where logging configuration is defined.</param>
+    /// <returns>Read configuration.</returns>
+    /// <exception cref="InvalidOperationException">The logging section is not found.</exception>
+    public static LoggingConfiguration Load(IConfigurationRoot configurationRoot, string sectionName)
     {
       return new LoggingConfigurationReader().Read(configurationRoot, sectionName);
     }

--- a/Orm/Xtensive.Orm/Orm/Configuration/NamingConvention.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/NamingConvention.cs
@@ -18,6 +18,10 @@ namespace Xtensive.Orm.Configuration
   public class NamingConvention : LockableBase,
     ICloneable
   {
+    public const LetterCasePolicy DefaultLetterCasePolicy = LetterCasePolicy.Default;
+    public const NamespacePolicy DefaultNamespacePolicy = NamespacePolicy.Default;
+    public const NamingRules DefaultNamingRules = NamingRules.Default;
+
     private LetterCasePolicy letterCasePolicy;
     private NamespacePolicy namespacePolicy;
     private NamingRules namingRules;

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/DatabaseOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/DatabaseOptions.cs
@@ -1,0 +1,69 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using Xtensive.Core;
+using Xtensive.Orm.Model;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class DatabaseOptions : IIdentifyableOptions,
+    IValidatableOptions,
+    IToNativeConvertable<DatabaseConfiguration>,
+    INamedOptionsCollectionElement
+  {
+    public object Identifier => Name;
+
+    /// <summary>
+    /// Logical database name.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Physical database name.
+    /// </summary>
+    public string RealName { get; set; }
+
+    /// <summary>
+    /// Type ID minimal value
+    /// for types mapped to this database.
+    /// Default value is <see cref="TypeInfo.MinTypeId"/>.
+    /// </summary>
+    public int MinTypeId { get; set; } = TypeInfo.MinTypeId;
+
+    /// <summary>
+    /// Type ID maximal value
+    /// for types mapped to this database.
+    /// Default value is <see cref="int.MaxValue"/>.
+    /// </summary>
+    public int MaxTypeId { get; set; } = int.MaxValue;
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentException"><see cref="Name"/> is empty or null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><see cref="MinTypeId"/> or <see cref="MaxTypeId"/> is not in valid range.</exception>
+    public void Validate()
+    {
+      if (Name.IsNullOrEmpty())
+        throw new ArgumentException(Strings.ExArgumentCannotBeEmptyString,"Name");
+      if (MinTypeId < TypeInfo.MinTypeId)
+        throw new ArgumentOutOfRangeException("MinTypeId", MinTypeId,
+          string.Format(Strings.ExArgumentMustBeGreaterThatOrEqualX, TypeInfo.MinTypeId));
+      if (MaxTypeId < TypeInfo.MinTypeId)
+        throw new ArgumentOutOfRangeException("MaxTypeId", MinTypeId,
+          string.Format(Strings.ExArgumentMustBeGreaterThatOrEqualX, TypeInfo.MinTypeId));
+    }
+
+    /// <inheritdoc />
+    public DatabaseConfiguration ToNative()
+    {
+      Validate();
+
+      return new DatabaseConfiguration(Name) {
+        RealName = RealName,
+        MinTypeId = MinTypeId,
+        MaxTypeId = MaxTypeId,
+      };
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/DomainConfigurationOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/DomainConfigurationOptions.cs
@@ -301,19 +301,11 @@ namespace Xtensive.Orm.Configuration.Options
         }
       }
 
-      foreach (var element in Sessions)
+      foreach (var element in Sessions) {
         config.Sessions.Add(element.Value.ToNative(connectionStrings));
+      }
 
       return config;
-    }
-
-    private static T ParseEnum<T>(string value)
-      where T : struct
-    {
-      if (!Enum.TryParse<T>(value, true, out var result)) {
-        throw new ArgumentException($"Can't parse given value '{value}' to enum type '{typeof(T).FullName}'");
-      }
-      return result;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/DomainConfigurationOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/DomainConfigurationOptions.cs
@@ -1,0 +1,319 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class DomainConfigurationOptions
+  {
+    /// <summary>
+    /// Domain configuration name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Url that will be used in <see cref="DomainConfiguration.ConnectionInfo"/>.
+    /// </summary>
+    public string ConnectionUrl { get; set; } = null;
+
+    /// <summary>
+    /// Connection string that will be used in <see cref="DomainConfiguration.ConnectionInfo"/>.
+    /// </summary>
+    public string ConnectionString { get; set; } = null;
+
+    /// <summary>
+    /// Provider that will be used in <see cref="DomainConfiguration.ConnectionInfo"/>.
+    /// </summary>
+    public string Provider { get; set; } = WellKnown.Provider.SqlServer;
+
+    /// <summary>
+    /// Types tha are about to be registered in <see cref="Domain"/>.
+    /// </summary>
+    public TypeRegistrationOptions[] Types { get; set; } = Array.Empty<TypeRegistrationOptions>();
+
+    /// <summary>
+    /// Size of the key cache. Default value is <see cref="DomainConfiguration.DefaultKeyCacheSize"/>
+    /// </summary>
+    public int KeyCacheSize { get; set; } = DomainConfiguration.DefaultKeyCacheSize;
+
+    /// <summary>
+    /// Size of the key generator cache size.
+    /// Default value is <see cref="DomainConfiguration.DefaultKeyGeneratorCacheSize"/>
+    /// </summary>
+    public int KeyGeneratorCacheSize { get; set; } = DomainConfiguration.DefaultKeyGeneratorCacheSize;
+
+    /// <summary>
+    /// Size of the query cache (see <see cref="Query.Execute{TElement}(System.Func{System.Linq.IQueryable{TElement}})"/>).
+    /// Default value is <see cref="DomainConfiguration.DefaultQueryCacheSize"/>.
+    /// </summary>
+    public int QueryCacheSize { get; set; } = DomainConfiguration.DefaultQueryCacheSize;
+
+    /// <summary>
+    /// Size of the record set mapping cache.
+    /// Default value is <see cref="DomainConfiguration.DefaultRecordSetMappingCacheSize"/>.
+    /// </summary>
+    public int RecordSetMappingCacheSize { get; set; } = DomainConfiguration.DefaultRecordSetMappingCacheSize;
+
+    /// <summary>
+    /// Domain upgrade behavior.
+    /// </summary>
+    public DomainUpgradeMode UpgradeMode { get; set; } = DomainConfiguration.DefaultUpgradeMode;
+
+    /// <summary>
+    /// <see cref="SchemaSynchronizationException"/> format.
+    /// </summary>
+    public SchemaSyncExceptionFormat SchemaSyncExceptionFormat { get; set; } = DomainConfiguration.DefaultSchemaSyncExceptionFormat;
+
+    /// <summary>
+    /// Foreign key mode. 
+    /// Default value is <see cref="Orm.ForeignKeyMode.Default"/>.
+    /// </summary>
+    public ForeignKeyMode ForeignKeyMode { get; set; } = DomainConfiguration.DefaultForeignKeyMode;
+
+    /// <summary>
+    /// Change tracking mode of full-text indexes.
+    /// Default value is <see cref="DomainConfiguration.DefaultFullTextChangeTrackingMode"/>.
+    /// </summary>
+    public FullTextChangeTrackingMode FullTextChangeTrackingMode { get; set; } = DomainConfiguration.DefaultFullTextChangeTrackingMode;
+
+    /// <summary>
+    /// Collation for all columns. See <see cref="DomainConfiguration.Collation" /> for details.
+    /// </summary>
+    public string Collation { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Session configurations.
+    /// </summary>
+    public SessionOptionsCollection Sessions { get; set; } = new SessionOptionsCollection();
+
+    /// <summary>
+    /// Registered mapping rules.
+    /// </summary>
+    public MappingRuleOptionsCollection MappingRules { get; set; } = new MappingRuleOptionsCollection();
+
+    /// <summary>
+    /// Registered ignore rules.
+    /// </summary>
+    public IgnoreRuleOptionsCollection IgnoreRules { get; set; } = new IgnoreRuleOptionsCollection();
+
+    /// <summary>
+    /// Registered database aliases.
+    /// </summary>
+    public DatabaseOptionsCollection Databases { get; set; } = new DatabaseOptionsCollection();
+
+    /// <summary>
+    /// Key generators.
+    /// </summary>
+    public KeyGeneratorOptionsCollection KeyGenerators {get; set;} = new KeyGeneratorOptionsCollection();
+
+    /// <summary>
+    /// Type of service container
+    /// </summary>
+    public string ServiceContainerType { get; set; } = null;
+
+    /// <summary>
+    /// Default schema.
+    /// </summary>
+    public string DefaultSchema { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Default database.
+    /// </summary>
+    public string DefaultDatabase { get; set; } = string.Empty;
+
+
+    /// <summary>
+    /// Value indicating whether SQL should be included in exception messages.
+    /// Default value is <see cref="DomainConfiguration.DefaultIncludeSqlInExceptions"/>
+    /// </summary>
+    public bool IncludeSqlInExceptions { get; set; } = DomainConfiguration.DefaultIncludeSqlInExceptions;
+
+    /// <summary>
+    /// Value indicating whether cyclic database dependencied are allowed.
+    /// Default value is <see cref="DomainConfiguration.DefaultAllowCyclicDatabaseDependencies"/>
+    /// </summary>
+    public bool AllowCyclicDatabaseDependencies { get; set; } = DomainConfiguration.DefaultAllowCyclicDatabaseDependencies;
+
+    /// <summary>
+    /// Value indicating whether parallel build should be used where and if it is possible.
+    /// Default value is <see cref="DomainConfiguration.DefaultBuildInParallel"/>
+    /// </summary>
+    public bool BuildInParallel { get; set; } = DomainConfiguration.DefaultBuildInParallel;
+
+    /// <summary>
+    /// Value indicating whether multidatabase keys should be used.
+    /// Default value is <see cref="DomainConfiguration.DefaultMultidatabaseKeys"/>
+    /// </summary>
+    public bool MultidatabaseKeys { get; set; } = DomainConfiguration.DefaultMultidatabaseKeys;
+
+    /// <summary>
+    /// Value indicating whether same storage schema is shared across <see cref="StorageNode"/>s.
+    /// Default value is <see cref="DomainConfiguration.DefaultShareStorageSchemaOverNodes"/>
+    /// </summary>
+    public bool ShareStorageSchemaOverNodes { get; set; } = DomainConfiguration.DefaultShareStorageSchemaOverNodes;
+
+    /// <summary>
+    /// Enables extra check if connection is not broken on its opening.
+    /// </summary>
+    public bool EnsureConnectionIsAlive { get; set; } = DomainConfiguration.DefaultEnsureConnectionIsAlive;
+
+    /// <summary>
+    /// Makes queries use parameters instead of constant values for persistent type identifiers.
+    /// </summary>
+    public bool PreferTypeIdsAsQueryParameters { get; set; } = DomainConfiguration.DefaultPreferTypeIdsAsQueryParameters;
+
+    /// <summary>
+    /// Forced server version.
+    /// </summary>
+    public string ForcedServerVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Connection initialization SQL script.
+    /// </summary>
+    public string ConnectionInitializationSql { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Domain options
+    /// </summary>
+    public DomainOptions Options { get; set; } = DomainConfiguration.DefaultDomainOptions;
+
+    /// <summary>
+    /// Naming convention.
+    /// </summary>
+    public NamingConventionOptions NamingConventionRaw { get; internal set; } = null;
+
+    /// <summary>
+    /// Versioning convention.
+    /// </summary>
+    public VersioningConventionOptions VersioningConvention { get; set; } = null;
+
+    /// <summary>
+    /// Defines tags location within query or turn them off if <see cref="TagsLocation.Nowhere"/> is set.
+    /// </summary>
+    public TagsLocation TagsLocation { get; set; } = DomainConfiguration.DefaultTagLocation;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="connectionStrings"></param>
+    /// <returns></returns>
+    /// <exception cref="System.AggregateException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
+    public DomainConfiguration ToNative(IDictionary<string, string> connectionStrings)
+    {
+      var config = new DomainConfiguration {
+        Name = Name,
+        ConnectionInfo = ConnectionInfoParser.GetConnectionInfo(connectionStrings,
+          ConnectionUrl, Provider, ConnectionString),
+        KeyCacheSize = KeyCacheSize,
+        KeyGeneratorCacheSize = KeyGeneratorCacheSize,
+        QueryCacheSize = QueryCacheSize,
+        RecordSetMappingCacheSize = RecordSetMappingCacheSize,
+        DefaultSchema = DefaultSchema,
+        DefaultDatabase = DefaultDatabase,
+        UpgradeMode = UpgradeMode,
+        ForeignKeyMode = ForeignKeyMode,
+        SchemaSyncExceptionFormat = SchemaSyncExceptionFormat,
+        Options = Options,
+        ServiceContainerType = !ServiceContainerType.IsNullOrEmpty() ? Type.GetType(ServiceContainerType) : null,
+        IncludeSqlInExceptions = IncludeSqlInExceptions,
+        BuildInParallel = BuildInParallel,
+        AllowCyclicDatabaseDependencies = AllowCyclicDatabaseDependencies,
+        ForcedServerVersion = ForcedServerVersion,
+        Collation = Collation,
+        ConnectionInitializationSql = ConnectionInitializationSql,
+        MultidatabaseKeys = MultidatabaseKeys,
+        ShareStorageSchemaOverNodes = ShareStorageSchemaOverNodes,
+        EnsureConnectionIsAlive = EnsureConnectionIsAlive,
+        PreferTypeIdsAsQueryParameters = PreferTypeIdsAsQueryParameters,
+        FullTextChangeTrackingMode = FullTextChangeTrackingMode,
+        TagsLocation = TagsLocation,
+      };
+
+      if (NamingConventionRaw != null)
+        config.NamingConvention = NamingConventionRaw.ToNative();
+      if (VersioningConvention != null)
+        config.VersioningConvention = VersioningConvention.ToNative();
+      
+      foreach (var element in Types) {
+        _ = config.Types.Register(element.ToNative());
+      }
+      HashSet<object> uniqueElements;
+      if (Databases.AnyExceptionOccur) {
+        var exceptions = Databases.Exceptions;
+        if (exceptions.Count == 1)
+          throw exceptions[0];
+        throw new System.AggregateException(Strings.ExASetOfExceptionsIsCaught + " during reading 'Databases' section of configuration", exceptions.ToArray());
+      }
+      else if (Databases.Count > 0) {
+        foreach (var element in Databases) {
+          config.Databases.Add(element.Value.ToNative());
+        }
+      }
+
+      if (KeyGenerators.AnyExceptionOccur) {
+        var exceptions = KeyGenerators.Exceptions;
+        if (exceptions.Count == 1)
+          throw exceptions[0];
+        throw new System.AggregateException(Strings.ExASetOfExceptionsIsCaught + " during reading 'KeyGenerators' section of configuration", exceptions.ToArray());
+      }
+      else if (KeyGenerators.Count > 0) {
+        uniqueElements = new HashSet<object>();
+        foreach (var element in KeyGenerators) {
+          //resolves cases when alias and database was used which provides different indetifiers but database conflict exists
+          var identifier = element.GetMappedIdentifier(Databases);
+          if (!uniqueElements.Add(identifier))
+            throw new ArgumentException($"Key generator with name '{element.Name}' for database '{element.Database}' has already been declared.");
+
+          config.KeyGenerators.Add(element.ToNative());
+        }
+      }
+      if (IgnoreRules.AnyExceptionOccur) {
+        var exceptions = IgnoreRules.Exceptions;
+        if (exceptions.Count==1)
+          throw exceptions[0];
+        throw new System.AggregateException("Set of exceptions occured during reading 'IgnoreRules' section of configuration", exceptions.ToArray());
+      }
+      else if (IgnoreRules.Count > 0) {
+        uniqueElements = new HashSet<object>();
+        foreach (var element in IgnoreRules) {
+          var identifier = element.GetMappedIdentifier(Databases);
+          if (!uniqueElements.Add(identifier))
+            throw new Exception("Ignore rule with same set of properties has already been declared.");
+          config.IgnoreRules.Add(element.ToNative());
+        }
+      }
+
+      if (MappingRules.AnyExceptionOccur) {
+        var exceptions = MappingRules.Exceptions;
+        if (exceptions.Count == 1)
+          throw exceptions[0];
+        throw new System.AggregateException("Set of exceptions occured during reading 'MappingRules' section of configuration", exceptions.ToArray());
+      }
+      else if (MappingRules.Count > 0) {
+        foreach (var element in MappingRules) {
+          config.MappingRules.Add(element.ToNative());
+        }
+      }
+
+      foreach (var element in Sessions)
+        config.Sessions.Add(element.Value.ToNative(connectionStrings));
+
+      return config;
+    }
+
+    private static T ParseEnum<T>(string value)
+      where T : struct
+    {
+      if (!Enum.TryParse<T>(value, true, out var result)) {
+        throw new ArgumentException($"Can't parse given value '{value}' to enum type '{typeof(T).FullName}'");
+      }
+      return result;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/IgnoreRuleOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/IgnoreRuleOptions.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class IgnoreRuleOptions : IIdentifyableOptions,
+    IHasDatabaseOption,
+    IValidatableOptions,
+    IToNativeConvertable<IgnoreRule>
+  {
+    public object Identifier =>
+      (Database ?? string.Empty,
+       Schema ?? string.Empty,
+       Table ?? string.Empty,
+       Column ?? string.Empty,
+       Index ?? string.Empty);
+
+    public string Database { get; set; }
+    public string Schema { get; set; }
+    public string Table { get; set; }
+    public string Column { get; set; }
+    public string Index { get; set; }
+
+    /// <inheritdoc />
+    /// <exception cref="ArgumentException">Configuration of properties is not valid, e.g.
+    /// none of Table, Column and Index filled, or both Column and Index filled.</exception>
+    public void Validate()
+    {
+      if (Table.IsNullOrEmpty() && Column.IsNullOrEmpty() && Index.IsNullOrEmpty()) {
+        throw new ArgumentException("Ignore rule should be configured for at least column, index or table");
+      }
+      if (!Column.IsNullOrEmpty() && !Index.IsNullOrEmpty()) {
+        throw new ArgumentException("Ignore rule can't be configured for column and index at the same time");
+      }
+    }
+
+    public object GetMappedIdentifier(IDictionary<string, DatabaseOptions> databaseMap)
+    {
+      if (!Database.IsNullOrEmpty() && databaseMap.TryGetValue(Database, out var map) && !map.RealName.IsNullOrEmpty()) {
+        return (map.RealName, Schema ?? string.Empty, Table ?? string.Empty, Column ?? string.Empty, Index ?? string.Empty);
+      }
+      return Identifier;
+    }
+
+    /// <inheritdoc />
+    public IgnoreRule ToNative()
+    {
+      Validate();
+
+      return new IgnoreRule(Database, Schema, Table, Column, Index);
+    }
+
+    
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/IgnoreRuleOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/IgnoreRuleOptions.cs
@@ -13,6 +13,7 @@ namespace Xtensive.Orm.Configuration.Options
     IValidatableOptions,
     IToNativeConvertable<IgnoreRule>
   {
+    /// <inheritdoc/>
     public object Identifier =>
       (Database ?? string.Empty,
        Schema ?? string.Empty,
@@ -20,10 +21,29 @@ namespace Xtensive.Orm.Configuration.Options
        Column ?? string.Empty,
        Index ?? string.Empty);
 
+    /// <summary>
+    /// Database part of the rule
+    /// </summary>
     public string Database { get; set; }
+
+    /// <summary>
+    /// Schema part of the rule.
+    /// </summary>
     public string Schema { get; set; }
+
+    /// <summary>
+    /// Table part of the rule.
+    /// </summary>
     public string Table { get; set; }
+
+    /// <summary>
+    /// Column part of the rule.
+    /// </summary>
     public string Column { get; set; }
+
+    /// <summary>
+    /// Index part of the rule.
+    /// </summary>
     public string Index { get; set; }
 
     /// <inheritdoc />

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IHasDatabaseOption.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IHasDatabaseOption.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal interface IHasDatabaseOption : IIdentifyableOptions
+  {
+    /// <summary>
+    /// Database (real or alias). In cases when database is part of instance identifier
+    /// it might require to be mapped
+    /// </summary>
+    string Database { get; set; }
+
+    /// <summary>
+    /// Tries to map database part of identifier from alias to real database names.
+    /// It might be required if <see cref="DomainConfiguration.Databases"/> declare
+    /// aliases and 
+    /// </summary>
+    /// <param name="databaseMap">Map of databases</param>
+    /// <returns>If alias is used then new identifier with substituted alias, otherwise, the same identifier.</returns>
+    object GetMappedIdentifier(IDictionary<string, DatabaseOptions> databaseMap);
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IIdentifyableOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IIdentifyableOptions.cs
@@ -1,0 +1,32 @@
+// Copyright (C) 2007-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+// Created by: Dmitri Maximov
+// Created:    2007.08.03
+
+using System;
+using System.Collections.Generic;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal interface IIdentifyableOptions
+  {
+    object Identifier { get; }
+  }
+
+  internal interface IValidatableOptions
+  {
+    /// <summary>
+    /// Performs validation of properties
+    /// </summary>
+    void Validate();
+  }
+
+  internal interface IHasDatabaseOption : IIdentifyableOptions
+  {
+    string Database { get; set; }
+
+    object GetMappedIdentifier(IDictionary<string, DatabaseOptions> databaseMap);
+  }
+
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IIdentifyableOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IIdentifyableOptions.cs
@@ -1,32 +1,15 @@
-// Copyright (C) 2007-2022 Xtensive LLC.
+// Copyright (C) 2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
-// Created by: Dmitri Maximov
-// Created:    2007.08.03
 
-using System;
-using System.Collections.Generic;
 
 namespace Xtensive.Orm.Configuration.Options
 {
   internal interface IIdentifyableOptions
   {
+    /// <summary>
+    /// Identifier of options instance in collections where uniqueness is required.
+    /// </summary>
     object Identifier { get; }
   }
-
-  internal interface IValidatableOptions
-  {
-    /// <summary>
-    /// Performs validation of properties
-    /// </summary>
-    void Validate();
-  }
-
-  internal interface IHasDatabaseOption : IIdentifyableOptions
-  {
-    string Database { get; set; }
-
-    object GetMappedIdentifier(IDictionary<string, DatabaseOptions> databaseMap);
-  }
-
 }

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/INamedOptionsCollectionElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/INamedOptionsCollectionElement.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (C) 2007-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+// Created by: Dmitri Maximov
+// Created:    2007.08.03
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  /// <summary>
+  /// Defines options where name is key of collection
+  /// </summary>
+  internal interface INamedOptionsCollectionElement
+  {
+    string Name { get; set; }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/INamedOptionsCollectionElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/INamedOptionsCollectionElement.cs
@@ -1,8 +1,6 @@
-﻿// Copyright (C) 2007-2022 Xtensive LLC.
+// Copyright (C) 2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
-// Created by: Dmitri Maximov
-// Created:    2007.08.03
 
 namespace Xtensive.Orm.Configuration.Options
 {

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IOptionsCollectionElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IOptionsCollectionElement.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (C) 2007-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+// Created by: Dmitri Maximov
+// Created:    2007.08.03
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal interface IOptionsCollectionElement
+  {
+
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IToNativeConvertable.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IToNativeConvertable.cs
@@ -1,0 +1,17 @@
+// Copyright (C) 2007-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+// Created by: Dmitri Maximov
+// Created:    2007.08.03
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal interface IToNativeConvertable<TNative>
+  {
+    /// <summary>
+    /// Converts element of options pattern to native configuration it corresponds to (<typeparamref name="TNative"/>)
+    /// </summary>
+    /// <returns><typeparamref name="TNative"/> instance.</returns>
+    TNative ToNative();
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IToNativeConvertable.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IToNativeConvertable.cs
@@ -1,8 +1,6 @@
-// Copyright (C) 2007-2022 Xtensive LLC.
+// Copyright (C) 2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
-// Created by: Dmitri Maximov
-// Created:    2007.08.03
 
 namespace Xtensive.Orm.Configuration.Options
 {

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IValidatableOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/Interfaces/IValidatableOptions.cs
@@ -1,13 +1,14 @@
-﻿// Copyright (C) 2007-2022 Xtensive LLC.
+﻿// Copyright (C) 2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
-// Created by: Dmitri Maximov
-// Created:    2007.08.03
 
 namespace Xtensive.Orm.Configuration.Options
 {
-  internal interface IOptionsCollectionElement
+  internal interface IValidatableOptions
   {
-
+    /// <summary>
+    /// Performs validation of properties.
+    /// </summary>
+    void Validate();
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/KeyGeneratorOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/KeyGeneratorOptions.cs
@@ -1,0 +1,75 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class KeyGeneratorOptions : IIdentifyableOptions,
+    IValidatableOptions,
+    IHasDatabaseOption,
+    IToNativeConvertable<KeyGeneratorConfiguration>
+  {
+    public object Identifier => (Name ?? string.Empty, Database ?? string.Empty);
+
+    /// <summary>
+    /// Key generator name.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Database for key generator
+    /// </summary>
+    public string Database { get; set; }
+
+    /// <summary>
+    /// Seed (initial value) for key generator.
+    /// </summary>
+    public long Seed { get; set; } = 0L;
+
+    /// <summary>
+    /// Cache size (increment) for cache generator.
+    /// </summary>
+    public long CacheSize { get; set; } =  DomainConfiguration.DefaultKeyGeneratorCacheSize;
+
+    public object GetMappedIdentifier(IDictionary<string, DatabaseOptions> databaseMap)
+    {
+      if (!Database.IsNullOrEmpty() && databaseMap.TryGetValue(Database, out var map) && !map.RealName.IsNullOrEmpty()) {
+        return(Name ?? string.Empty, map.RealName);
+      }
+      return Identifier;
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentException">Name is null or empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Seed or CacheSize value is out of valid range.</exception>
+    public void Validate()
+    {
+      if (Name.IsNullOrEmpty()) {
+        throw new ArgumentException("Key generator should have not empty name.");
+      }
+      if (Seed < 0) {
+        throw new ArgumentOutOfRangeException("Key generator seed must be non-negative value");
+      }
+      if (CacheSize <= 0) {
+        throw new ArgumentOutOfRangeException("Key generator cache size must be positive value");
+      }
+    }
+
+    /// <inheritdoc />
+    public KeyGeneratorConfiguration ToNative()
+    {
+      Validate();
+
+      return new KeyGeneratorConfiguration(Name) {
+        CacheSize = CacheSize,
+        Seed = Seed,
+        Database = Database,
+      };
+    }
+
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/MappingRuleOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/MappingRuleOptions.cs
@@ -1,0 +1,59 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class MappingRuleOptions : IIdentifyableOptions,
+    IValidatableOptions,
+    IToNativeConvertable<MappingRule>
+  {
+    public object Identifier => (Assembly ?? string.Empty, Namespace ?? string.Empty);
+
+    /// <summary>
+    /// Assembly condition.
+    /// See <see cref="MappingRule.Assembly"/> for details.
+    /// </summary>
+    public string Assembly { get; set; }
+
+    /// <summary>
+    /// Namespace condition.
+    /// See <see cref="MappingRule.Namespace"/> for details.
+    /// </summary>
+    public string Namespace { get; set; }
+
+    /// <summary>
+    /// Database that is assigned to mapped type when this rule is applied.
+    /// See <see cref="MappingRule.Database"/> for details.
+    /// </summary>
+    public string Database { get; set; }
+
+    /// <summary>
+    /// Schema that is assigned to mapped type when this rule is applied.
+    /// See <see cref="MappingRule.Schema"/> for details.
+    /// </summary>
+    public string Schema { get; set; }
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentException">Configuration of values in properties is not valid.</exception>
+    public void Validate()
+    {
+      if (Assembly.IsNullOrEmpty() && Namespace.IsNullOrEmpty())
+        throw new ArgumentException("Mapping rule should declare at least either Assembly or Namespace");
+      if (Database.IsNullOrEmpty() && Schema.IsNullOrEmpty())
+        throw new ArgumentException("Mapping rule should map assembly and(or) namespace to database, schema or both");
+    }
+
+    /// <inheritdoc />
+    public MappingRule ToNative()
+    {
+      Validate();
+
+      var assembly = !string.IsNullOrEmpty(Assembly) ? System.Reflection.Assembly.Load(Assembly) : null;
+      return new MappingRule(assembly, Namespace, Database, Schema);
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/NamedOptionsCollection{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/NamedOptionsCollection{T}.cs
@@ -1,0 +1,128 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class SessionOptionsCollection : NamedOptionsCollection<SessionConfigurationOptions>
+  {
+    protected override bool AllowEmptyNames => true;
+  }
+
+  internal sealed class DatabaseOptionsCollection : NamedOptionsCollection<DatabaseOptions>
+  {
+
+  }
+
+  internal abstract class NamedOptionsCollection<T> : IDictionary<string, T>
+    where T: INamedOptionsCollectionElement
+  {
+    private readonly Dictionary<string, T> internalDictionary = new();
+    private readonly List<Exception> exceptionsOccur = new();
+
+    public T this[string key]
+    {
+      get => internalDictionary[key];
+      set {
+        
+        if (!internalDictionary.ContainsKey(key)) {
+          Add(key, value);
+        }
+        else {
+          ValidateName(key);
+          value.Name = key;
+          ValidateItemOnAdd(value);
+          internalDictionary[key] = value;
+        }
+      }
+    }
+
+    public ICollection<string> Keys => internalDictionary.Keys;
+
+    public ICollection<T> Values => internalDictionary.Values;
+
+    public int Count => internalDictionary.Count;
+
+    protected virtual bool AllowEmptyNames => false;
+
+    internal bool AnyExceptionOccur => exceptionsOccur.Any();
+
+    // Section to object materialisation "swollows" exceptions,
+    // which means we will get partially populated collections
+    // without even knowing that something went wrong.
+    // This collection of exceptions helps to understand whether
+    // the collection populated without an issues or not.
+    internal List<Exception> Exceptions => exceptionsOccur;
+
+    public void Add(string name, T value)
+    {
+      ValidateName(name);
+
+      if (value == null) {
+        throw new ArgumentNullException(nameof(value));
+      }
+      value.Name = name;
+
+      if (!internalDictionary.TryAdd(name, value)) {
+        throw new ArgumentException(string.Format(Strings.ExItemWithNameXAlreadyExists, name));
+      }
+    }
+
+    public void Clear() => internalDictionary.Clear();
+
+    public bool ContainsKey(string key) => internalDictionary.ContainsKey(key);
+    public IEnumerator<KeyValuePair<string, T>> GetEnumerator() => ((ICollection<KeyValuePair<string, T>>) internalDictionary).GetEnumerator();
+    public bool Remove(string key) => internalDictionary.Remove(key);
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out T value) => internalDictionary.TryGetValue(key, out value);
+
+
+    protected virtual void ValidateItemOnAdd(T item)
+    {
+      if (item is IValidatableOptions validatableOptions) {
+        validatableOptions.Validate();
+      }
+    }
+
+    protected Exception RegisterValidationException(Exception exception)
+    {
+      exceptionsOccur.Add(exception);
+      return exception;
+    }
+
+    private void ValidateName(string name)
+    {
+      if (!AllowEmptyNames && name.IsNullOrEmpty()) {
+        throw RegisterValidationException((name == null)
+          ? new ArgumentNullException(nameof(name))
+          : new ArgumentException(Strings.ExArgumentCannotBeEmptyString, nameof(name)));
+      }
+      else {
+        if (name == null) {
+          throw RegisterValidationException(new ArgumentNullException(nameof(name)));
+        }
+      }
+    }
+
+    bool ICollection<KeyValuePair<string, T>>.IsReadOnly => ((ICollection<KeyValuePair<string, T>>) internalDictionary).IsReadOnly;
+    void ICollection<KeyValuePair<string, T>>.Add(KeyValuePair<string, T> item)
+    {
+      Add(item.Key, item.Value);
+    }
+    void ICollection<KeyValuePair<string, T>>.CopyTo(KeyValuePair<string, T>[] array, int arrayIndex) =>
+      ((IDictionary<string, T>) internalDictionary).CopyTo(array, arrayIndex);
+    bool ICollection<KeyValuePair<string, T>>.Contains(KeyValuePair<string, T> item) =>
+      ((IDictionary<string, T>) internalDictionary).Contains(item);
+    bool ICollection<KeyValuePair<string, T>>.Remove(KeyValuePair<string, T> item) =>
+      ((IDictionary<string, T>) internalDictionary).Remove(item);
+
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/NamespaceSynonymOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/NamespaceSynonymOptions.cs
@@ -1,0 +1,19 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class NamespaceSynonymOptions
+  {
+    /// <summary>
+    /// Namespace to synonymize.
+    /// </summary>
+    public string Namespace { get; set; }
+
+    /// <summary>
+    /// Synonym of namespace.
+    /// </summary>
+    public string Synonym { get; set; }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/NamingConventionOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/NamingConventionOptions.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class NamingConventionOptions : IToNativeConvertable<NamingConvention>
+  {
+    /// <summary>
+    /// Letter case policy.
+    /// </summary>
+    public LetterCasePolicy LetterCasePolicy { get; set; } = NamingConvention.DefaultLetterCasePolicy;
+
+    /// <summary>
+    /// Namespace policy.
+    /// </summary>
+    public NamespacePolicy NamespacePolicy { get; set; } = NamingConvention.DefaultNamespacePolicy;
+
+    /// <summary>
+    /// Rules of naming.
+    /// </summary>
+    public NamingRules NamingRules { get; set; } = NamingConvention.DefaultNamingRules;
+
+    /// <summary>
+    /// Collection of namespace synonyms.
+    /// </summary>
+    public NamespaceSynonymOptions[] NamespaceSynonyms { get; set; }
+
+    /// <inheritdoc />
+    public NamingConvention ToNative()
+    {
+      var result = new NamingConvention {
+        LetterCasePolicy = LetterCasePolicy,
+        NamespacePolicy = NamespacePolicy,
+        NamingRules = NamingRules,
+      };
+
+      foreach (var namespaceSynonym in NamespaceSynonyms) {
+        if (namespaceSynonym.Namespace.IsNullOrEmpty()) {
+          ArgumentValidator.EnsureArgumentNotNullOrEmpty(namespaceSynonym.Namespace, namespaceSynonym.Namespace);
+        }
+        if (!result.NamespaceSynonyms.TryAdd(namespaceSynonym.Namespace, namespaceSynonym.Synonym)) {
+          throw new Exception($"Synonym for namespace '{namespaceSynonym.Namespace}' has already been assigned.");
+        }
+      }
+      return result;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/OptionsCollection{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/OptionsCollection{T}.cs
@@ -1,0 +1,108 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class MappingRuleOptionsCollection : OptionsCollection<MappingRuleOptions>
+  {
+  }
+
+  internal sealed class IgnoreRuleOptionsCollection : OptionsCollection<IgnoreRuleOptions>
+  {
+  }
+
+  internal sealed class KeyGeneratorOptionsCollection : OptionsCollection<KeyGeneratorOptions>
+  {
+  }
+
+  internal abstract class OptionsCollection<T> : ICollection<T>
+    where T : class, IIdentifyableOptions
+  {
+    private readonly Dictionary<object, T> map = new();
+    private readonly List<Exception> exceptionsOccur = new();
+
+    public int Count => map.Count;
+
+    public bool IsReadOnly => false;
+
+    internal bool AnyExceptionOccur => exceptionsOccur.Any();
+
+    // Section to object materialisation "swollows" exceptions,
+    // which means we will get partially populated collections
+    // without even knowing that something went wrong.
+    // This collection of exceptions helps to understand whether
+    // the collection populated without an issues or not.
+    internal List<Exception> Exceptions => exceptionsOccur;
+
+    public void Add(T item)
+    {
+      if (item == null) {
+        throw RegisterValidationException(new ArgumentNullException(nameof(item)));
+      }
+
+      if (!map.TryAdd(item.Identifier, item)) {
+        throw RegisterValidationException(
+          new ArgumentException(
+            $"Item with the same identifier '{item.Identifier}' has already been declared."));
+      }
+    }
+
+    public bool Contains(T item)
+    {
+      if (item == null)
+        return false;
+      if (map.ContainsKey(item.Identifier))
+        return true;
+      if (map.Values.Contains(item)) {
+        return true;
+      }
+      return false;
+    }
+
+    public void Clear() => map.Clear();
+
+    public bool Remove(T item)
+    {
+      if (map.Remove(item.Identifier))
+        return true;
+      var result = map.Where(kv => kv.Value == item).Select(kv => kv.Key).FirstOrDefault();
+      if (result != null) {
+        return map.Remove(result);
+      }
+      return false;
+    }
+
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(array, nameof(array));
+      ArgumentValidator.EnsureArgumentIsGreaterThanOrEqual(arrayIndex, 0, nameof(arrayIndex));
+
+      if (array.Length - arrayIndex < map.Count) {
+        throw new ArgumentException(
+          "The number of elements in the source collection is greater than the available space from arrayIndex to the end of the destination array");
+      }
+
+      var index = arrayIndex;
+      foreach (var item in map.Values) {
+        array[index] = item;
+        index++;
+      }
+    }
+
+    protected Exception RegisterValidationException(Exception exception)
+    {
+      exceptionsOccur.Add(exception);
+      return exception;
+    }
+
+    public IEnumerator<T> GetEnumerator() => map.Values.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/SessionConfigurationOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/SessionConfigurationOptions.cs
@@ -1,0 +1,145 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Transactions;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class SessionConfigurationOptions :
+    IIdentifyableOptions,
+    IValidatableOptions,
+    INamedOptionsCollectionElement
+  {
+    public object Identifier => Name;
+
+    /// <summary>
+    /// Session name.
+    /// <see cref="SessionConfiguration.Name"/>
+    /// </summary>
+    public string Name { get; set; } = WellKnown.Sessions.Default;
+
+    /// <summary>
+    /// User name to authenticate.
+    /// Default value is <see langword="null" />.
+    /// </summary>
+    public string UserName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Password to authenticate.
+    /// Default value is <see langword="null" />.
+    /// </summary>
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// session options.
+    /// Default value is <see cref="SessionOptions.Default"/>.
+    /// </summary>
+    public SessionOptions Options { get; set; } = SessionOptions.Default;
+
+    /// <summary>
+    /// Size of the session entity state cache.
+    /// Default value is <see cref="SessionConfiguration.DefaultCacheSize"/>.
+    /// </summary>
+    public int CacheSize { get; set; } = SessionConfiguration.DefaultCacheSize;
+
+    /// <summary>
+    /// Type of session cache.
+    /// Default value is <see cref="SessionConfiguration.DefaultCacheType"/>.
+    /// </summary>
+    public SessionCacheType CacheType { get; set; } = SessionConfiguration.DefaultCacheType;
+
+    /// <summary>
+    /// Default isolation level.
+    /// Default value is <see cref="SessionConfiguration.DefaultDefaultIsolationLevel"/>.
+    /// </summary>
+    public IsolationLevel DefaultIsolationLevel { get; set; } = SessionConfiguration.DefaultDefaultIsolationLevel;
+
+    /// <summary>
+    /// Default command timeout.
+    /// Default value is <see cref="SessionConfiguration.DefaultCommandTimeout"/>.
+    /// </summary>
+    public int? DefaultCommandTimeout { get; set; } = null;
+
+    /// <summary>
+    /// Size of the batch.
+    /// This affects create, update, delete operations and future queries.
+    /// Default value is <see cref="SessionConfiguration.DefaultBatchSize"/>
+    /// </summary>
+    public int BatchSize { get; set; } = SessionConfiguration.DefaultBatchSize;
+
+    /// <summary>
+    /// Size of the entity change registry.
+    /// Default value is <see cref="SessionConfiguration.DefaultEntityChangeRegistrySize"/>
+    /// </summary>
+    public int EntityChangeRegistrySize { get; set; } = SessionConfiguration.DefaultEntityChangeRegistrySize;
+
+    /// <summary>
+    /// Reader preloading policy.
+    /// It affects query results reading.
+    /// Default value is <see cref="SessionConfiguration.DefaultReaderPreloadingPolicy"/>.
+    /// </summary>
+    public ReaderPreloadingPolicy ReaderPreloading { get; set; } = SessionConfiguration.DefaultReaderPreloadingPolicy;
+
+    /// <summary>
+    /// Type of the service container
+    /// </summary>
+    public string ServiceContainerType { get; set; } = null;
+
+    public string ConnectionString { get; set; } = null;
+    public string ConnectionUrl { get; set; } = null;
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentException">Name is null or empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">CacheSize, BatchSize or EntityChangeRegistry value is out of valid range.</exception>
+    public void Validate()
+    {
+      if (Name.IsNullOrEmpty())
+        throw new ArgumentException(Strings.ExNameMustBeNotNullOrEmpty);
+      if (CacheSize <= 1)
+        throw new ArgumentOutOfRangeException(nameof(CacheSize), CacheSize, string.Format(Strings.ExArgumentMustBeGreaterThanX, 1));
+      if (BatchSize < 1)
+        throw new ArgumentOutOfRangeException(nameof(BatchSize), BatchSize, string.Format(Strings.ExArgumentMustBeGreaterThatOrEqualX, 1));
+      if (EntityChangeRegistrySize < 1)
+        throw new ArgumentOutOfRangeException(nameof(EntityChangeRegistrySize), EntityChangeRegistrySize, string.Format(Strings.ExArgumentMustBeGreaterThatOrEqualX, 1));
+    }
+
+    /// <inheritdoc />
+    public SessionConfiguration ToNative(IDictionary<string, string> connectionStrings)
+    {
+      // Minor hack:
+      // We should not require user to specify provider name.
+      // We actually know it when opening new session.
+      // However, we do not know it in this method
+      // We are going easy way and substituting a fake provider.
+      // SQL SessionHandler is aware of this and always uses correct provider.
+
+      var connectionInfo = ConnectionInfoParser.GetConnectionInfo(connectionStrings, ConnectionUrl, "_dummy_", ConnectionString);
+
+      if (Name.IsNullOrEmpty()) {
+        Name = WellKnown.Sessions.Default;
+      }
+
+      Validate();
+
+      var result = new SessionConfiguration(Name) {
+        UserName = UserName,
+        Password = Password,
+        CacheSize = CacheSize,
+        BatchSize = BatchSize,
+        CacheType = CacheType,
+        Options = Options,
+        DefaultIsolationLevel = DefaultIsolationLevel,
+        ReaderPreloading = ReaderPreloading,
+        ServiceContainerType = (!ServiceContainerType.IsNullOrEmpty()) ? Type.GetType(ServiceContainerType) : null,
+        EntityChangeRegistrySize = EntityChangeRegistrySize,
+        DefaultCommandTimeout = DefaultCommandTimeout,
+        ConnectionInfo = connectionInfo,
+      };
+      return result;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/TypeRegistrationOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/TypeRegistrationOptions.cs
@@ -1,0 +1,72 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using Xtensive.Collections;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class TypeRegistrationOptions : IIdentifyableOptions,
+    IValidatableOptions,
+    IToNativeConvertable<TypeRegistration>
+  {
+    public object Identifier
+    {
+      get {
+        if (!Type.IsNullOrEmpty())
+          return Type;
+        else
+          return (Assembly, Namespace.IsNullOrEmpty() ? null : Namespace);
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the type to register.
+    /// </summary>
+    public string Type { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets the assembly where types to register are located.
+    /// </summary>
+    public string Assembly { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets the namespace withing the <see cref="Assembly"/>, 
+    /// where types to register are located.
+    /// If <see langword="null" /> or <see cref="string.Empty"/>, 
+    /// all the persistent types from the <see cref="Assembly"/> will be registered.
+    /// </summary>
+    public string Namespace { get; set; } = null;
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentException">Combination of properties is not valid.</exception>
+    public void Validate()
+    {
+      if (!Type.IsNullOrEmpty() && (!Assembly.IsNullOrEmpty() || !Namespace.IsNullOrEmpty()))
+        throw new ArgumentException("Either type or assembly can be declared, not both at the same time.");
+      if (!Assembly.IsNullOrEmpty() && !Type.IsNullOrEmpty())
+        throw new ArgumentException("Either type or assembly can be declared, not both at the same time.");
+      if (!Namespace.IsNullOrEmpty() && Assembly.IsNullOrEmpty())
+        throw new ArgumentException("Namespace can only be declared with Assembly.");
+    }
+
+    /// <inheritdoc />
+    public TypeRegistration ToNative()
+    {
+      Validate();
+
+      if (!Type.IsNullOrEmpty())
+        return new TypeRegistration(System.Type.GetType(Type, true));
+      else if (!Assembly.IsNullOrEmpty()) {
+        var assembly = System.Reflection.Assembly.Load(Assembly);
+        if (Namespace.IsNullOrEmpty())
+          return new TypeRegistration(assembly);
+        else
+          return new TypeRegistration(assembly, Namespace);
+      }
+      throw new InvalidOperationException();
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/Options/VersioningConventionOptions.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Options/VersioningConventionOptions.cs
@@ -1,0 +1,31 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+namespace Xtensive.Orm.Configuration.Options
+{
+  internal sealed class VersioningConventionOptions : IToNativeConvertable<VersioningConvention>
+  {
+    /// <summary>
+    /// Versioning policy for entities.
+    /// Default value is <see cref="VersioningConvention.DefaultVersioningPolicy"/>
+    /// </summary>
+    public EntityVersioningPolicy EntityVersioningPolicy { get; set; } = VersioningConvention.DefaultVersioningPolicy;
+
+    /// <summary>
+    /// Value indicating that change of an <see cref="EntitySet{TItem}"/> owner version should be denied where possible.
+    /// Default value is <see langword="false"/>
+    /// </summary>
+    public bool DenyEntitySetOwnerVersionChange { get; set; } = false;
+
+    /// <inheritdoc />
+    public VersioningConvention ToNative()
+    {
+      var result = new VersioningConvention {
+        EntityVersioningPolicy = EntityVersioningPolicy,
+        DenyEntitySetOwnerVersionChange = DenyEntitySetOwnerVersionChange
+      };
+      return result;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Configuration/SessionConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/SessionConfiguration.cs
@@ -23,11 +23,26 @@ namespace Xtensive.Orm.Configuration
     /// Default cache size.
     /// </summary>
     public const int DefaultCacheSize = 16 * 1024;
-    
+
+    /// <summary>
+    /// Default session options.
+    /// </summary>
+    public const SessionOptions DefaultSessionOptions = SessionOptions.Default;
+
     ///<summary>
     /// Default isolation level.
     ///</summary>
     public const IsolationLevel DefaultDefaultIsolationLevel = IsolationLevel.RepeatableRead;
+
+    /// <summary>
+    /// Default cache type.
+    /// </summary>
+    public const SessionCacheType DefaultCacheType = SessionCacheType.Default;
+
+    /// <summary>
+    /// Default reader preloading policy.
+    /// </summary>
+    public const ReaderPreloadingPolicy DefaultReaderPreloadingPolicy = ReaderPreloadingPolicy.Default;
 
     /// <summary>
     /// Default batch size.
@@ -46,13 +61,13 @@ namespace Xtensive.Orm.Configuration
     /// </summary>
     public static readonly SessionConfiguration Default = new SessionConfiguration(WellKnown.Sessions.Default);
 
-    private SessionOptions options = SessionOptions.Default;
+    private SessionOptions options = DefaultSessionOptions;
     private string userName = string.Empty;
     private string password = string.Empty;
     private int cacheSize = DefaultCacheSize;
     private int batchSize = DefaultBatchSize;
     private int entityChangeRegistrySize = DefaultEntityChangeRegistrySize;
-    private SessionCacheType cacheType = SessionCacheType.Default;
+    private SessionCacheType cacheType = DefaultCacheType;
     private IsolationLevel defaultIsolationLevel = DefaultDefaultIsolationLevel; // what a fancy name?
     private int? defaultCommandTimeout = null;
     private ReaderPreloadingPolicy readerPreloading = ReaderPreloadingPolicy.Default;

--- a/Orm/Xtensive.Orm/Orm/Configuration/SessionConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/SessionConfiguration.cs
@@ -118,6 +118,7 @@ namespace Xtensive.Orm.Configuration
 
     /// <summary>
     /// Gets or sets the type of the session cache.
+    /// Default value is <see cref="DefaultCacheType"/>.
     /// </summary>
     public SessionCacheType CacheType {
       get { return cacheType; }
@@ -160,6 +161,7 @@ namespace Xtensive.Orm.Configuration
     /// <summary>
     /// Gets or sets the size of the batch.
     /// This affects create, update, delete operations and future queries.
+    /// Default value is <see cref="DefaultBatchSize"/>.
     /// </summary>
     public int BatchSize {
       get { return batchSize; }
@@ -183,6 +185,8 @@ namespace Xtensive.Orm.Configuration
 
     /// <summary>
     /// Gets or sets the reader preloading policy.
+    /// It affects query results reading.
+    /// Default value is <see cref="DefaultReaderPreloadingPolicy"/>.
     /// </summary>
     public ReaderPreloadingPolicy ReaderPreloading
     {
@@ -195,6 +199,7 @@ namespace Xtensive.Orm.Configuration
 
     /// <summary>
     /// Gets or sets the size of the entity change registry.
+    /// Default value is <see cref="DefaultEntityChangeRegistrySize"/>.
     /// </summary>
     public int EntityChangeRegistrySize
     {

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -50,7 +50,11 @@ namespace Xtensive.Orm.Upgrade
         configuration.Lock();
       }
 
-      LogManager.Default.AutoInitialize();
+      var logConfiguration = configuration.ExtensionConfigurations.Get<LoggingConfiguration>();
+      if (logConfiguration != null)
+        LogManager.Default.Initialize(logConfiguration);
+      else
+        LogManager.Default.AutoInitialize();
 
       var context = new UpgradeContext(configuration);
 
@@ -72,7 +76,11 @@ namespace Xtensive.Orm.Upgrade
         configuration.Lock();
       }
 
-      LogManager.Default.AutoInitialize();
+      var logConfiguration = configuration.ExtensionConfigurations.Get<LoggingConfiguration>();
+      if (logConfiguration != null)
+        LogManager.Default.Initialize(logConfiguration);
+      else
+        LogManager.Default.AutoInitialize();
 
       var context = new UpgradeContext(configuration);
 

--- a/Orm/Xtensive.Orm/Orm/WellKnown.cs
+++ b/Orm/Xtensive.Orm/Orm/WellKnown.cs
@@ -33,6 +33,11 @@ namespace Xtensive.Orm
     public const string DefaultConfigurationSection = "Xtensive.Orm";
 
     /// <summary>
+    /// Default name of domain.
+    /// </summary>
+    public const string DefaultDomainConfigurationName = "Default";
+
+    /// <summary>
     /// Name of the <see cref="Entity.Key"/> field.
     /// </summary>
     public const string KeyFieldName = "Key";

--- a/Orm/Xtensive.Orm/Xtensive.Orm.csproj
+++ b/Orm/Xtensive.Orm/Xtensive.Orm.csproj
@@ -51,16 +51,14 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Label="Packages">
     <PackageReference Include="BitFaster.Caching" Version="2.3.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Label="T4 templates">
     <None Include="Arithmetic\Internal\PrimitiveArithmetics.tt">

--- a/Orm/Xtensive.Orm/Xtensive.Orm.csproj
+++ b/Orm/Xtensive.Orm/Xtensive.Orm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
@@ -51,9 +51,13 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Label="Packages">
     <PackageReference Include="BitFaster.Caching" Version="2.3.3" />


### PR DESCRIPTION
Adds Load overloads to configuration classes of main project and some extensions.

Introduces a collection of configurations of extensions - ```DomainConfiguration.ExtensionConfigurations```. Before that, extensions relied on default ```Load()``` methods which is not relevant today because App/Web.config files are outdated yet presented, now reading such configs is not easy and sometimes require a workaround. Also, there was no way to just create a configuration instance for some extension and use it to set up the settings. We allow it for main configuration but not for extensions. Being able to use configuration instances and "attach" them to domain configuration is a future-proof solution which can overcome further changes of .NET Configuration Files APIs.

Extensions' configurations are based on ```ConfigurationBase``` abstract type and can be locked. If any extension is developed outside ours and has some configuration then it can be based on ours ```ConfigurationBase``` and be placed to this unified collection and be expected there when it is needed.

Additionally, extension methods for ```DomainConfiguration``` added - ConfigureXxxExtension(), many variants available. They Load configuration from different APIs or just receive instance and put it to the collection of additional configurations, sometimes even register types of the extension to domain if it needed.