### PR TITLE
Fix of race condition with TranslatorState.NonVisitableExpressions

### DIFF
--- a/ChangeLog/7.1.3_dev.txt
+++ b/ChangeLog/7.1.3_dev.txt
@@ -1,0 +1,1 @@
+[main] Addressed race condition issue with TranslatorState.NonVisitableExpressions

--- a/Orm/Xtensive.Orm/Orm/Linq/LocalCollectionKeyTypeExtractor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/LocalCollectionKeyTypeExtractor.cs
@@ -24,14 +24,14 @@ namespace Xtensive.Orm.Linq
         return key.EntityType.UnderlyingType;
       }
 
-      var expr = VisitBinaryExpession(expression);
+      var expr = VisitBinaryExpression(expression);
       if (expr.Type.IsSubclassOf(WellKnownOrmTypes.Entity)) {
         return expr.Type;
       }
       throw new NotSupportedException(string.Format(Strings.ExCurrentTypeXIsNotSupported, expr.Type));
     }
 
-    private static Expression VisitBinaryExpession(BinaryExpression binaryExpression)
+    private static Expression VisitBinaryExpression(BinaryExpression binaryExpression)
     {
       if (!(binaryExpression.Right is MemberExpression memberExpression)) {
         throw new InvalidOperationException(string.Format(Strings.ExCantConvertXToY, binaryExpression.Type, typeof(MemberExpression)));

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -33,7 +33,9 @@ namespace Xtensive.Orm.Linq
     private readonly TranslatorContext context;
     private readonly bool tagsEnabled;
 
-    internal TranslatorState State { get; private set; } = TranslatorState.InitState;
+    internal TranslatorState State { get; private set; } = new(TranslatorState.InitState) {
+      NonVisitableExpressions = new()
+    };
 
     protected override Expression VisitConstant(ConstantExpression c)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Orm.Linq
 
 
     /// <summary>
-    /// Expessions that were constructed during original expression translation
+    /// Expressions that were constructed during original expression translation
     /// and aim to replace original parts so they are avoidable to visit by Linq translator.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
Addresses issue #398,

Copy of changes from https://github.com/servicetitan/dataobjects-net/pull/295, shout out to Sergei Pavlov.
