### PR TITLE
Improves schema extraction for PostgreSQL

### DIFF
--- a/ChangeLog/7.1.3_dev.txt
+++ b/ChangeLog/7.1.3_dev.txt
@@ -1,0 +1,1 @@
+[postgresql] Improved database structucture extraction

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/DriverFactory.cs
@@ -111,19 +111,15 @@ namespace Xtensive.Sql.Drivers.PostgreSql
 
       // We support 8.3, 8.4 and any 9.0+
 
-      if (version.Major == 8) {
-        return version.Minor == 3 ? new v8_3.Driver(coreServerInfo) : new v8_4.Driver(coreServerInfo);
-      }
-
-      if (version.Major == 9) {
-        return version.Minor == 0 ? new v9_0.Driver(coreServerInfo) : new v9_1.Driver(coreServerInfo);
-      }
-
-      if (version.Major < 12) {
-        return new v10_0.Driver(coreServerInfo);
-      }
-
-      return new v12_0.Driver(coreServerInfo);
+      return version.Major switch {
+        8 when version.Minor == 3 => new v8_3.Driver(coreServerInfo),
+        8 when version.Minor > 3  => new v8_4.Driver(coreServerInfo),
+        9 when version.Minor == 0 => new v9_0.Driver(coreServerInfo),
+        9 when version.Minor > 0 => new v9_1.Driver(coreServerInfo),
+        10 => new v10_0.Driver(coreServerInfo),
+        11 => new v10_0.Driver(coreServerInfo),
+        _ => new v12_0.Driver(coreServerInfo)
+      };
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.Designer.cs
@@ -61,11 +61,11 @@ namespace Xtensive.Sql.Drivers.PostgreSql.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t find schema &apos;{0}&apos; owner with oid &apos;{1}&apos; in the list of users..
+        ///   Looks up a localized string similar to Can&apos;t find schema &apos;{0}&apos; owner with oid &apos;{1}&apos; in the list of roles..
         /// </summary>
-        internal static string ExCantFindSchemaXOwnerWithIdYInTheListOfUsers {
+        internal static string ExCantFindSchemaXOwnerWithIdYInTheListOfRoles {
             get {
-                return ResourceManager.GetString("ExCantFindSchemaXOwnerWithIdYInTheListOfUsers", resourceCulture);
+                return ResourceManager.GetString("ExCantFindSchemaXOwnerWithIdYInTheListOfRoles", resourceCulture);
             }
         }
         

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.Designer.cs
@@ -61,6 +61,15 @@ namespace Xtensive.Sql.Drivers.PostgreSql.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Can&apos;t find schema &apos;{0}&apos; owner with oid &apos;{1}&apos; in the list of users..
+        /// </summary>
+        internal static string ExCantFindSchemaXOwnerWithIdYInTheListOfUsers {
+            get {
+                return ResourceManager.GetString("ExCantFindSchemaXOwnerWithIdYInTheListOfUsers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to FreeText search on custom columns not supported..
         /// </summary>
         internal static string ExFreeTextSearchOnCustomColumnsNotSupported {

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.resx
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.resx
@@ -135,7 +135,7 @@
   <data name="ExSchemaXDoesNotExistOrBelongsToAnotherUser" xml:space="preserve">
     <value>Schema '{0}' either does not exist or belongs to another user.</value>
   </data>
-  <data name="ExCantFindSchemaXOwnerWithIdYInTheListOfUsers" xml:space="preserve">
-    <value>Can't find schema '{0}' owner with oid '{1}' in the list of users.</value>
+  <data name="ExCantFindSchemaXOwnerWithIdYInTheListOfRoles" xml:space="preserve">
+    <value>Can't find schema '{0}' owner with oid '{1}' in the list of roles.</value>
   </data>
 </root>

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.resx
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/Resources/Strings.resx
@@ -135,4 +135,7 @@
   <data name="ExSchemaXDoesNotExistOrBelongsToAnotherUser" xml:space="preserve">
     <value>Schema '{0}' either does not exist or belongs to another user.</value>
   </data>
+  <data name="ExCantFindSchemaXOwnerWithIdYInTheListOfUsers" xml:space="preserve">
+    <value>Can't find schema '{0}' owner with oid '{1}' in the list of users.</value>
+  </data>
 </root>

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
@@ -630,8 +630,8 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       select.Columns.Add(relationsTable["relnamespace"]);
       select.Columns.Add(tablespacesTable["spcname"]);
       select.Columns.Add(new Func<SqlCase>(() => {
-        var defCase = SqlDml.Case(relationsTable["relkind"]);
-        defCase.Add('v', SqlDml.FunctionCall("pg_get_viewdef", relationsTable["oid"]));
+        var defCase = SqlDml.Case(relationsTable["relkind"])
+          .Add('v', SqlDml.FunctionCall("pg_get_viewdef", relationsTable["oid"]));
         return defCase;
       })(), "definition");
       return select;
@@ -777,7 +777,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       }
       else {
         var view = viewMap[columnOwnerId];
-        view.CreateColumn(columnName);
+        _ = view.CreateColumn(columnName);
       }
     }
 
@@ -948,8 +948,9 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
         else {
           for (int j = 0; j < indexKey.Length; j++) {
             int colIndex = indexKey[j];
-            if (colIndex > 0)
-              index.CreateIndexColumn(tableColumns[tableIdentifier][colIndex], true);
+            if (colIndex > 0) {
+              _ = index.CreateIndexColumn(tableColumns[tableIdentifier][colIndex], true);
+            }
             else {
               //column index is 0
               //this means that this index column is an expression
@@ -1003,12 +1004,9 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       var exprIndexInfo = expressionIndexMap[Convert.ToInt64(dataReader[1])];
       for (var j = 0; j < exprIndexInfo.Columns.Length; j++) {
         int colIndex = exprIndexInfo.Columns[j];
-        if (colIndex > 0) {
-          exprIndexInfo.Index.CreateIndexColumn(tableColumns[Convert.ToInt64(dataReader[0])][colIndex], true);
-        }
-        else {
-          exprIndexInfo.Index.CreateIndexColumn(SqlDml.Native(dataReader[(j + 1).ToString()].ToString()));
-        }
+        _ = colIndex > 0
+          ? exprIndexInfo.Index.CreateIndexColumn(tableColumns[Convert.ToInt64(dataReader[0])][colIndex], true)
+          : exprIndexInfo.Index.CreateIndexColumn(SqlDml.Native(dataReader[(j + 1).ToString()].ToString()));
       }
     }
 

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
@@ -26,12 +26,17 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       /// <summary>
       /// Specific schemas to extract
       /// </summary>
-      public readonly Dictionary<string, Schema> TargetSchemes = new Dictionary<string, Schema>();
+      public readonly Dictionary<string, Schema> TargetSchemes = new();
 
       /// <summary>
-      /// Extracted users.
+      /// Extracted users (subset of <see cref="RoleLookup"/>).
       /// </summary>
-      public readonly Dictionary<long, string> UserLookup = new Dictionary<long, string>();
+      public readonly Dictionary<long, string> UserLookup = new();
+
+      /// <summary>
+      /// Extracted roles.
+      /// </summary>
+      public readonly Dictionary<long, string> RoleLookup = new();
 
       /// <summary>
       /// Catalog to extract information.
@@ -41,45 +46,53 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       /// <summary>
       /// Extracted schemas.
       /// </summary>
-      public readonly Dictionary<long, Schema> SchemaMap = new Dictionary<long, Schema>();
+      public readonly Dictionary<long, Schema> SchemaMap = new();
 
       /// <summary>
       /// Extracted schemas identifiers.
       /// </summary>
-      public readonly Dictionary<Schema, long> ReversedSchemaMap = new Dictionary<Schema, long>();
+      public readonly Dictionary<Schema, long> ReversedSchemaMap = new();
 
       /// <summary>
       /// Extracted tables.
       /// </summary>
-      public readonly Dictionary<long, Table> TableMap = new Dictionary<long, Table>();
+      public readonly Dictionary<long, Table> TableMap = new();
 
       /// <summary>
       /// Extracted views.
       /// </summary>
-      public readonly Dictionary<long, View> ViewMap = new Dictionary<long, View>();
+      public readonly Dictionary<long, View> ViewMap = new();
 
       /// <summary>
       /// Extracted sequences.
       /// </summary>
-      public readonly Dictionary<long, Sequence> SequenceMap = new Dictionary<long, Sequence>();
+      public readonly Dictionary<long, Sequence> SequenceMap = new();
 
       /// <summary>
       /// Extracted index expressions.
       /// </summary>
-      public readonly Dictionary<long, ExpressionIndexInfo> ExpressionIndexMap = new Dictionary<long, ExpressionIndexInfo>();
+      public readonly Dictionary<long, ExpressionIndexInfo> ExpressionIndexMap = new();
 
       /// <summary>
       /// Extracted domains.
       /// </summary>
-      public readonly Dictionary<long, Domain> DomainMap = new Dictionary<long, Domain>();
+      public readonly Dictionary<long, Domain> DomainMap = new();
 
       /// <summary>
       /// Extracted columns connected grouped by owner (table or view)
       /// </summary>
-      public readonly Dictionary<long, Dictionary<long, TableColumn>> TableColumnMap = new Dictionary<long, Dictionary<long, TableColumn>>();
+      public readonly Dictionary<long, Dictionary<long, TableColumn>> TableColumnMap = new();
 
+      /// <summary>
+      /// Roles in which current user is a member, self included.
+      /// </summary>
+      public readonly List<long> CurrentUserRoles = new();
+
+      public string CurrentUserName { get; set; }
       public long CurrentUserSysId { get; set; } = -1;
       public long? CurrentUserIdentifier { get; set; }
+
+      public bool IsMe(string name) => name == CurrentUserName;
 
       public ExtractionContext(Catalog catalog)
       {
@@ -332,7 +345,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
     {
       var (catalog, context) = CreateCatalogAndContext(catalogName, schemaNames);
 
-      ExtractUsers(context);
+      _ = ExtractRoles(context, false);
       ExtractSchemas(context);
       return catalog;
     }
@@ -343,7 +356,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
     {
       var (catalog, context) = CreateCatalogAndContext(catalogName, schemaNames);
 
-      await ExtractUsersAsync(context, token).ConfigureAwait(false);
+      await ExtractRoles(context, true, token).ConfigureAwait(false);
       await ExtractSchemasAsync(context, token).ConfigureAwait(false);
       return catalog;
     }
@@ -360,48 +373,62 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       return (catalog, context);
     }
 
-    private void ExtractUsers(ExtractionContext context)
+    private async ValueTask ExtractRoles(ExtractionContext context, bool isAsync, CancellationToken token = default)
     {
       context.UserLookup.Clear();
-      string me;
-      using (var command = Connection.CreateCommand("SELECT user")) {
-        me = (string) command.ExecuteScalar();
-      }
 
-      using (var cmd = Connection.CreateCommand("SELECT usename, usesysid FROM pg_user"))
-      using (var dr = cmd.ExecuteReader()) {
-        while (dr.Read()) {
-          ReadUserData(dr, context, me);
+      var extractCurentUserCommand = Connection.CreateCommand("SELECT user");
+      // Roles include users.
+      // Users also can have members for some reason and it doesn't make them groups,
+      // the only thing that defines user is ability to login :-)
+      const string ExtractRolesQueryTemplate = "SELECT rolname, oid, rolcanlogin, pg_has_role('{0}', oid,'member') FROM pg_roles";
+      
+
+      if (isAsync) {
+        await using (extractCurentUserCommand.ConfigureAwait(false)) {
+          context.CurrentUserName = (string) await extractCurentUserCommand.ExecuteScalarAsync(token).ConfigureAwait(false);
+        }
+
+        var getAllUsersCommand = Connection.CreateCommand(string.Format(ExtractRolesQueryTemplate, context.CurrentUserName));
+        await using (getAllUsersCommand.ConfigureAwait(false)) {
+          var reader = await getAllUsersCommand.ExecuteReaderAsync(token).ConfigureAwait(false);
+          await using (reader.ConfigureAwait(false)) {
+            while (await reader.ReadAsync(token).ConfigureAwait(false)) {
+              ReadUserData(reader, context);
+            }
+          }
         }
       }
-    }
+      else {
+        using (extractCurentUserCommand) {
+          context.CurrentUserName = (string) extractCurentUserCommand.ExecuteScalar();
+        }
 
-    private async Task ExtractUsersAsync(ExtractionContext context, CancellationToken token = default)
-    {
-      context.UserLookup.Clear();
-      string me;
-      var command = Connection.CreateCommand("SELECT user");
-      await using (command.ConfigureAwait(false)) {
-        me = (string) await command.ExecuteScalarAsync(token).ConfigureAwait(false);
-      }
-
-      command = Connection.CreateCommand("SELECT usename, usesysid FROM pg_user");
-      await using (command.ConfigureAwait(false)) {
-        var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
-        await using (reader.ConfigureAwait(false)) {
-          while (await reader.ReadAsync(token).ConfigureAwait(false)) {
-            ReadUserData(reader, context, me);
+        var getAllUsersCommand = Connection.CreateCommand(string.Format(ExtractRolesQueryTemplate, context.CurrentUserName));
+        using (getAllUsersCommand)
+        using (var dr = getAllUsersCommand.ExecuteReader()) {
+          while (dr.Read()) {
+            ReadUserData(dr, context);
           }
         }
       }
     }
 
-    private static void ReadUserData(DbDataReader dr, ExtractionContext context, string me)
+    private static void ReadUserData(DbDataReader dr, ExtractionContext context)
     {
-      var name = dr[0].ToString();
+      var name = dr.GetString(0);
+      // oid, which is basically a number, has its own type - oid! can't be read as int or long (facepalm)
       var sysId = Convert.ToInt64(dr[1]);
-      context.UserLookup.Add(sysId, name);
-      if (name == me) {
+      var canLogin = dr.GetBoolean(2);
+      var containsCurrentUser = dr.GetBoolean(3);
+      context.RoleLookup.Add(sysId, name);
+      if(containsCurrentUser) {
+        context.CurrentUserRoles.Add(sysId);
+      }
+      if (canLogin) {
+        context.UserLookup.Add(sysId, name);
+      }
+      if (context.IsMe(name)) {
         context.CurrentUserSysId = sysId;
       }
     }
@@ -499,7 +526,11 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       selectPublic.Columns.Add(namespaceTable1["nspowner"]);
 
       var selectMine = SqlDml.Select(namespaceTable2);
-      selectMine.Where = namespaceTable2["nspowner"] == context.CurrentUserIdentifier;
+      if (context.CurrentUserRoles.Count == 0)
+        selectMine.Where = namespaceTable2["nspowner"] == context.CurrentUserIdentifier;
+      else {
+        selectMine.Where = SqlDml.In(namespaceTable2["nspowner"], SqlDml.Array(context.CurrentUserRoles.ToArray()));
+      }
       selectMine.Columns.Add(namespaceTable2["nspname"]);
       selectMine.Columns.Add(namespaceTable2["oid"]);
       selectMine.Columns.Add(namespaceTable2["nspowner"]);
@@ -522,11 +553,11 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
         catalog.DefaultSchema = schema;
       }
 
-      if (context.UserLookup.TryGetValue(owner, out var ownerName)) {
-        schema.Owner = ownerName;
+      if (context.RoleLookup.TryGetValue(owner, out var userName)) {
+        schema.Owner = userName;
       }
       else {
-        throw new InvalidOperationException(string.Format(Resources.Strings.ExCantFindSchemaXOwnerWithIdYInTheListOfUsers, name, owner));
+        throw new InvalidOperationException(string.Format(Resources.Strings.ExCantFindSchemaXOwnerWithIdYInTheListOfRoles, name, owner));
       }
       context.SchemaMap[oid] = schema;
       context.ReversedSchemaMap[schema] = oid;

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
@@ -522,7 +522,12 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
         catalog.DefaultSchema = schema;
       }
 
-      schema.Owner = context.UserLookup[owner];
+      if (context.UserLookup.TryGetValue(owner, out var ownerName)) {
+        schema.Owner = ownerName;
+      }
+      else {
+        throw new InvalidOperationException(string.Format(Resources.Strings.ExCantFindSchemaXOwnerWithIdYInTheListOfUsers, name, owner));
+      }
       context.SchemaMap[oid] = schema;
       context.ReversedSchemaMap[schema] = oid;
     }

--- a/Orm/Xtensive.Orm.Tests.Framework/Orm.config
+++ b/Orm/Xtensive.Orm.Tests.Framework/Orm.config
@@ -72,6 +72,9 @@
     <domain name="pgsql150"
             connectionUrl="postgresql://dotest:dotest@localhost:54150/dotest" />
 
+    <domain name="pgsql160"
+            connectionUrl="postgresql://dotest:dotest@localhost:54160/dotest" />
+
     <domain name="oracle10"
             connectionUrl="oracle://dotest:dotest@localhost:5510/ora10" />
 
@@ -166,6 +169,9 @@
 
     <domain name="pgsql150cs" provider="postgresql"
             connectionString="HOST=localhost;PORT=54150;DATABASE=dotest;USER ID=dotest;PASSWORD=dotest" />
+
+    <domain name="pgsql160cs" provider="postgresql"
+            connectionString="HOST=localhost;PORT=54160;DATABASE=dotest;USER ID=dotest;PASSWORD=dotest" />
 
     <domain name="oracle10cs" provider="oracle"
             connectionString="DATA SOURCE=&quot;(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=5510))(CONNECT_DATA=(SERVICE_NAME=ora10)))&quot;;USER ID=dotest;PASSWORD=dotest" />


### PR DESCRIPTION
- Handles inability to resolve schema owner with understandable exception message
- Extraction algorithm supports not only users but roles as owners of schema (in PostgreSQL user is just a role which allows to log in); this also allows to extract public schema of PostgreSQL v14+ where system role ```pg_database_owner``` was introduced and later became default owner for ```public``` schema