### PR TITLE
Improves compatibility of certain async query extension methods with EntitySets

### DIFF
--- a/ChangeLog/7.1.3_dev.txt
+++ b/ChangeLog/7.1.3_dev.txt
@@ -1,4 +1,5 @@
 [main] Addressed race condition issue with TranslatorState.NonVisitableExpressions
 [main] Improved working with nullable enum constants in queries
+[main] Improved compatibility of .ToListAsync/.ToArrayAsync/.ToHashSetAsync/.AsAsyncEnumerable extension methods with EntitySet
 [postgresql] Improved database structucture extraction
 [postgresql] Addressed certain cases of decimal results of aggregate operations being unable to fit to .NET decimal

--- a/Orm/Xtensive.Orm.Tests/Storage/AsyncQueries/AsyncExtensionsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/AsyncQueries/AsyncExtensionsTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Xtensive LLC.
+// Copyright (C) 2020-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
@@ -100,7 +100,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
       }
     }
 
@@ -127,7 +127,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).Select(stat => stat.IntFactor).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.IntFactor));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.IntFactor));
       }
     }
 
@@ -242,7 +242,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
       }
     }
 
@@ -269,7 +269,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).Select(stat => stat.LongFactor).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.LongFactor));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.LongFactor));
       }
     }
 
@@ -384,7 +384,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
       }
     }
 
@@ -411,7 +411,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).Select(stat => stat.DoubleFactor).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.DoubleFactor));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.DoubleFactor));
       }
     }
 
@@ -526,7 +526,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
       }
     }
 
@@ -553,7 +553,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).Select(stat => stat.FloatFactor).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.FloatFactor));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.FloatFactor));
       }
     }
 
@@ -668,7 +668,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync());
       }
     }
 
@@ -695,7 +695,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
 
         var emptyFactors = (await emptyQuery.ExecuteAsync()).Select(stat => stat.DecimalFactor).ToList();
         Assert.AreEqual(0, emptyFactors.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.DecimalFactor));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => emptyQuery.AverageAsync(stat => stat.DecimalFactor));
       }
     }
 
@@ -867,7 +867,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>().Take(0);
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.FirstAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.FirstAsync());
       }
     }
 
@@ -888,7 +888,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>();
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.FirstAsync(teacher => teacher.Id < 0));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.FirstAsync(teacher => teacher.Id < 0));
       }
     }
 
@@ -955,7 +955,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>().Take(0);
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.LastAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.LastAsync());
       }
     }
 
@@ -976,7 +976,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>();
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.LastAsync(teacher => teacher.Id < 0));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.LastAsync(teacher => teacher.Id < 0));
       }
     }
 
@@ -1129,7 +1129,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
           .Select(stat => stat.IntFactor);
         var elements = query.ToList();
         Assert.AreEqual(0, elements.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.MaxAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.MaxAsync());
       }
     }
 
@@ -1201,8 +1201,8 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
         var query = session.Query.All<StatRecord>().Where(stat => stat.Id < 0);
         var elements = query.ToList();
         Assert.AreEqual(0, elements.Count);
-        Assert.Throws<InvalidOperationException>(() => _ = elements.Max(stat => stat.IntFactor));
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.MaxAsync(stat => stat.IntFactor));
+        _ = Assert.Throws<InvalidOperationException>(() => _ = elements.Max(stat => stat.IntFactor));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.MaxAsync(stat => stat.IntFactor));
       }
     }
 
@@ -1276,7 +1276,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
           .Select(stat => stat.IntFactor);
         var elements = query.ToList();
         Assert.AreEqual(0, elements.Count);
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.MinAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.MinAsync());
       }
     }
 
@@ -1348,8 +1348,8 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
         var query = session.Query.All<StatRecord>().Where(stat => stat.Id < 0);
         var elements = query.ToList();
         Assert.AreEqual(0, elements.Count);
-        Assert.Throws<InvalidOperationException>(() => _ = elements.Min(stat => stat.IntFactor));
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.MinAsync(stat => stat.IntFactor));
+        _ = Assert.Throws<InvalidOperationException>(() => _ = elements.Min(stat => stat.IntFactor));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.MinAsync(stat => stat.IntFactor));
       }
     }
 
@@ -1385,7 +1385,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>().Take(0);
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleAsync());
       }
     }
 
@@ -1395,7 +1395,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>();
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleAsync());
       }
     }
 
@@ -1416,7 +1416,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>();
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleAsync(teacher => teacher.Id < 0));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleAsync(teacher => teacher.Id < 0));
       }
     }
 
@@ -1426,7 +1426,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>();
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleAsync(teacher => teacher.Gender==Gender.Male));
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleAsync(teacher => teacher.Gender==Gender.Male));
       }
     }
 
@@ -1459,7 +1459,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>();
-        Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleOrDefaultAsync());
+        _ = Assert.ThrowsAsync<InvalidOperationException>(() => query.SingleOrDefaultAsync());
       }
     }
 
@@ -1490,7 +1490,7 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
       await using var session = await OpenSessionAsync(Domain, isClientProfile);
       await using (OpenTransactionAsync(session, isClientProfile)) {
         var query = session.Query.All<Teacher>();
-        Assert.ThrowsAsync<InvalidOperationException>(
+        _ = Assert.ThrowsAsync<InvalidOperationException>(
           () => query.SingleOrDefaultAsync(teacher => teacher.Gender==Gender.Male));
       }
     }
@@ -2216,6 +2216,20 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
         var allTeachers = query.ToList();
         var allTeachersAsync = await query.ToListAsync();
         Assert.IsTrue(allTeachers.SequenceEqual(allTeachersAsync));
+
+        var firstTeacher = allTeachers[0];
+        var disceplines = firstTeacher.Disciplines.Where(d => d.Discepline != null).ToList();
+        var disceplinesAsync = await firstTeacher.Disciplines.Where(d => d.Discepline != null).ToListAsync();
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
+
+        var secondTeacher = allTeachers[1];
+        disceplines = secondTeacher.Disciplines.ToList();
+        disceplinesAsync = await secondTeacher.Disciplines.ToListAsync();
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
       }
     }
 
@@ -2230,6 +2244,20 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
         var allTeachers = query.ToArray();
         var allTeachersAsync = await query.ToArrayAsync();
         Assert.IsTrue(allTeachers.SequenceEqual(allTeachersAsync));
+
+        var firstTeacher = allTeachers[0];
+        var disceplines = firstTeacher.Disciplines.Where(d => d.Discepline != null).ToArray();
+        var disceplinesAsync = await firstTeacher.Disciplines.Where(d => d.Discepline != null).ToArrayAsync();
+        Assert.That(disceplines.Length, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Length, Is.EqualTo(disceplines.Length));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
+
+        var secondTeacher = allTeachers[1];
+        disceplines = secondTeacher.Disciplines.ToArray();
+        disceplinesAsync = await secondTeacher.Disciplines.ToArrayAsync();
+        Assert.That(disceplines.Length, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Length, Is.EqualTo(disceplines.Length));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
       }
     }
 
@@ -2247,6 +2275,19 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
         foreach (var teacherId in allTeachers.Keys) {
           Assert.AreEqual(allTeachers[teacherId], allTeachersAsync[teacherId]);
         }
+
+        var firstTeacher = allTeachers.Values.First();
+        var disceplines = firstTeacher.Disciplines.Where(d => d.Discepline != null).ToDictionary(d => d.Course.Id);
+        var disceplinesAsync = await firstTeacher.Disciplines.Where(d => d.Discepline != null).ToDictionaryAsync(d => d.Course.Id);
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
+
+        disceplines = firstTeacher.Disciplines.ToDictionary(d => d.Course.Id);
+        disceplinesAsync = await firstTeacher.Disciplines.ToDictionaryAsync(d => d.Course.Id);
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
       }
     }
 
@@ -2262,6 +2303,20 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
         foreach (var teacherId in allTeachers.Keys) {
           Assert.AreEqual(allTeachers[teacherId], allTeachersAsync[teacherId]);
         }
+
+        var firstTeacher = session.Query.All<Teacher>().First();
+        var disceplines = firstTeacher.Disciplines.Where(d => d.Discepline != null).ToDictionary(d => d.Course.Id, d => d.Discepline.Id);
+        var disceplinesAsync = await firstTeacher.Disciplines.Where(d => d.Discepline != null).ToDictionaryAsync(d => d.Course.Id, d => d.Discepline.Id);
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
+
+
+        disceplines = firstTeacher.Disciplines.ToDictionary(d => d.Course.Id, d => d.Discepline.Id);
+        disceplinesAsync = await firstTeacher.Disciplines.ToDictionaryAsync(d => d.Course.Id, d => d.Discepline.Id);
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
       }
     }
 
@@ -2279,6 +2334,19 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
         foreach (var teacher in allTeachers) {
           Assert.IsTrue(allTeachersAsync.Contains(teacher));
         }
+
+        var firstTeacher = session.Query.All<Teacher>().First();
+        var disceplines = firstTeacher.Disciplines.Where(d => d.Discepline != null).ToHashSet();
+        var disceplinesAsync = await firstTeacher.Disciplines.Where(d => d.Discepline != null).ToHashSetAsync();
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
+
+        disceplines = firstTeacher.Disciplines.ToHashSet();
+        disceplinesAsync = await firstTeacher.Disciplines.ToHashSetAsync();
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        Assert.That(disceplines.Except(disceplinesAsync), Is.Empty);
       }
     }
 
@@ -2297,6 +2365,41 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
           Assert.IsTrue(grouping.OrderBy(teacher => teacher.Id)
             .SequenceEqual(teachersByGenderAsync[grouping.Key].OrderBy(teacher => teacher.Id)));
         }
+
+        var firstTeacher = session.Query.All<Teacher>().First();
+        var disceplines = firstTeacher.Disciplines.Where(d => d.Discepline != null).ToLookup(d => d.Discepline.Id);
+        var disceplinesAsync = await firstTeacher.Disciplines.Where(d => d.Discepline != null).ToLookupAsync(d => d.Discepline.Id);
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        var zipped = disceplines
+          .Zip(disceplinesAsync,
+            (first, second) => new {
+              FirstKey = first.Key,
+              FirstSeq = first.AsEnumerable(),
+              SecondKey = second.Key,
+              SecondSeq = second.AsEnumerable()
+            });
+        foreach (var pair in zipped) {
+          Assert.That(pair.FirstKey, Is.EqualTo(pair.SecondKey));
+          Assert.That(pair.FirstSeq.Except(pair.SecondSeq), Is.Empty);
+        }
+
+        disceplines = firstTeacher.Disciplines.ToLookup(d => d.Discepline.Id);
+        disceplinesAsync = await firstTeacher.Disciplines.ToLookupAsync(d => d.Discepline.Id);
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        zipped = disceplines
+          .Zip(disceplinesAsync,
+            (first, second) => new {
+              FirstKey = first.Key,
+              FirstSeq = first.AsEnumerable(),
+              SecondKey = second.Key,
+              SecondSeq = second.AsEnumerable()
+            });
+        foreach (var pair in zipped) {
+          Assert.That(pair.FirstKey, Is.EqualTo(pair.SecondKey));
+          Assert.That(pair.FirstSeq.Except(pair.SecondSeq), Is.Empty);
+        }
       }
     }
 
@@ -2312,6 +2415,41 @@ namespace Xtensive.Orm.Tests.Storage.AsyncQueries
         foreach (var grouping in teachersByGender) {
           Assert.IsTrue(grouping.OrderBy(teacherId => teacherId)
             .SequenceEqual(teachersByGenderAsync[grouping.Key].OrderBy(teacherId => teacherId)));
+        }
+
+        var firstTeacher = session.Query.All<Teacher>().First();
+        var disceplines = firstTeacher.Disciplines.Where(d => d.Discepline != null).ToLookup(d => d.Discepline.Id, d => d.Course.Id);
+        var disceplinesAsync = await firstTeacher.Disciplines.Where(d => d.Discepline != null).ToLookupAsync(d => d.Discepline.Id, d => d.Course.Id);
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        var zipped = disceplines
+          .Zip(disceplinesAsync,
+            (first, second) => new {
+              FirstKey = first.Key,
+              FirstSeq = first.AsEnumerable(),
+              SecondKey = second.Key,
+              SecondSeq = second.AsEnumerable()
+            });
+        foreach (var pair in zipped) {
+          Assert.That(pair.FirstKey, Is.EqualTo(pair.SecondKey));
+          Assert.That(pair.FirstSeq.Except(pair.SecondSeq), Is.Empty);
+        }
+
+        disceplines = firstTeacher.Disciplines.ToLookup(d => d.Discepline.Id, d => d.Course.Id);
+        disceplinesAsync = await firstTeacher.Disciplines.ToLookupAsync(d => d.Discepline.Id, d => d.Course.Id);
+        Assert.That(disceplines.Count, Is.GreaterThan(0));
+        Assert.That(disceplinesAsync.Count, Is.EqualTo(disceplines.Count));
+        zipped = disceplines
+          .Zip(disceplinesAsync,
+            (first, second) => new {
+              FirstKey = first.Key,
+              FirstSeq = first.AsEnumerable(),
+              SecondKey = second.Key,
+              SecondSeq = second.AsEnumerable()
+            });
+        foreach (var pair in zipped) {
+          Assert.That(pair.FirstKey, Is.EqualTo(pair.SecondKey));
+          Assert.That(pair.FirstSeq.Except(pair.SecondSeq), Is.Empty);
         }
       }
     }

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Xtensive LLC.
+// Copyright (C) 2020-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -50,9 +50,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously determines whether all the elements of a sequence satisfy a condition.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
     /// <param name="source">An <see cref="IQueryable{T}"/> whose elements to test for a condition.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
@@ -72,9 +76,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously determines whether a sequence contains any elements.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{T}"/> to check for being empty.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
@@ -91,9 +99,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously determines whether any element of a sequence satisfies a condition.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{T}"/> whose elements to test for a condition.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
@@ -111,14 +123,20 @@ namespace Xtensive.Orm
         WellKnownMembers.Queryable.AnyWithPredicate, source, predicate, cancellationToken);
     }
 
+    #region AverageAsync
+
     // Average<int>
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -135,9 +153,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -155,9 +177,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -179,9 +205,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -204,9 +234,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -223,9 +257,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -243,9 +281,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -267,9 +309,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -292,9 +338,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -311,9 +361,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -331,9 +385,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -355,9 +413,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -380,9 +442,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -399,9 +465,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -419,9 +489,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -443,9 +517,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -468,9 +546,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -487,9 +569,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -507,9 +593,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -531,9 +621,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the average of a sequence of values that is obtained
     /// by invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values to calculate the average of.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -551,14 +645,20 @@ namespace Xtensive.Orm
         source, selector, cancellationToken);
     }
 
+    #endregion
+
     // Contains
 
     /// <summary>
     /// Asynchronously determines whether a sequence contains a specified element.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the ssingle element of.</param>
     /// <param name="item">The object to locate in the sequence.</param>
@@ -574,14 +674,18 @@ namespace Xtensive.Orm
         source, Expression.Constant(item, typeof(TSource)), cancellationToken);
     }
 
-    // Count
+    #region Count
 
     /// <summary>
     /// Asynchronously returns the number of elements in a sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> that contains elements to be counted.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -598,9 +702,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously returns the number of elements in a sequence that satisfy a condition.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> that contains elements to be counted.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
@@ -617,14 +725,22 @@ namespace Xtensive.Orm
         source, predicate, cancellationToken);
     }
 
+    #endregion
+
+    #region First, FirstOrDefault
+
     // First
 
     /// <summary>
     /// Asynchronously returns the first element of a sequence
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the first element of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -641,9 +757,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously returns the first element of a sequence that satisfies a specified condition.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the first element of.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
@@ -666,9 +786,13 @@ namespace Xtensive.Orm
     /// Asynchronously returns the first element of a sequence, or a default value if
     /// the sequence contains no elements.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the first element of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -686,9 +810,13 @@ namespace Xtensive.Orm
     /// Asynchronously returns the first element of a sequence that satisfies a specified
     /// condition or a default value if no such element is found.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the first element of.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
@@ -706,14 +834,21 @@ namespace Xtensive.Orm
         source, predicate, cancellationToken);
     }
 
+    #endregion
+
+    #region Last, LastOrDefault
     // Last
 
     /// <summary>
     /// Asynchronously returns the last element of a sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the last element of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -730,9 +865,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously returns the last element of a sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the last element of.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
@@ -755,9 +894,13 @@ namespace Xtensive.Orm
     /// Asynchronously returns the last element of a sequence, or a default value if
     /// the sequence contains no elements.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the last element of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -775,9 +918,13 @@ namespace Xtensive.Orm
     /// Asynchronously returns the last element of a sequence that satisfies a specified
     /// condition or a default value if no such element is found.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the last element of.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
@@ -795,15 +942,21 @@ namespace Xtensive.Orm
         source, predicate, cancellationToken);
     }
 
-    // LongCount
+    #endregion
+
+    #region LongCount
 
     /// <summary>
     /// Asynchronously returns an System.Int64 that represents the number of elements
     /// in a sequence that satisfy a condition.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> that contains the elements to be counted.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -821,9 +974,13 @@ namespace Xtensive.Orm
     /// Asynchronously returns an System.Int64 that represents the number of elements
     /// in a sequence that satisfy a condition.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> that contains the elements to be counted.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
@@ -841,14 +998,22 @@ namespace Xtensive.Orm
         source, predicate, cancellationToken);
     }
 
+    #endregion
+
+    #region Min, Max
+
     // Max
 
     /// <summary>
     /// Asynchronously returns the maximum value of a sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> that contains the elements ot determine the maximum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -866,9 +1031,13 @@ namespace Xtensive.Orm
     /// Asynchronously invokes a projection function on each element of a sequence and
     /// returns the maximum resulting value.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <typeparam name="TResult">he type of the value returned by the function represented by selector.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> that contains the elements ot determine the maximum of.</param>
@@ -891,9 +1060,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously returns the minimum value of a sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> that contains the elements ot determine the minimum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -907,12 +1080,16 @@ namespace Xtensive.Orm
     }
 
     /// <summary>
-    /// synchronously invokes a projection function on each element of a sequence and
+    /// Asynchronously invokes a projection function on each element of a sequence and
     /// returns the minimum resulting value.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <typeparam name="TResult">The type of the value returned by the function represented by selector.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> that contains the elements ot determine the minimum of.</param>
@@ -929,15 +1106,23 @@ namespace Xtensive.Orm
         source, selector, cancellationToken);
     }
 
+    #endregion
+
+    #region Single, SingleOrDefault
+
     // Single
 
     /// <summary>
     /// Asynchronously returns the only element of a sequence that satisfies a specified
     /// condition, and throws an exception if more than one such element exists.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the single element of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -955,9 +1140,13 @@ namespace Xtensive.Orm
     /// Asynchronously returns the only element of a sequence that satisfies a specified
     /// condition, and throws an exception if more than one such element exists.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the single element of.</param>
     /// <param name="predicate">A function to test an element for a condition.</param>
@@ -981,9 +1170,13 @@ namespace Xtensive.Orm
     /// the sequence is empty; this method throws an exception if there is more than
     /// one element in the sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the single element of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -1004,9 +1197,13 @@ namespace Xtensive.Orm
     /// the sequence is empty; this method throws an exception if there is more than
     /// one element in the sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{TSource}"/> to return the single element of.</param>
     /// <param name="predicate">A function to test an element for a condition.</param>
@@ -1024,14 +1221,22 @@ namespace Xtensive.Orm
         source, predicate, cancellationToken);
     }
 
+    #endregion
+
+    #region Sum
+
     // Sum<int>
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1048,9 +1253,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1068,9 +1277,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1092,9 +1305,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1117,9 +1334,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1136,9 +1357,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1156,9 +1381,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1180,9 +1409,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1205,9 +1438,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1224,9 +1461,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1244,9 +1485,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1268,9 +1513,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1293,9 +1542,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1312,9 +1565,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1332,9 +1589,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1356,9 +1617,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1381,9 +1646,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1400,9 +1669,13 @@ namespace Xtensive.Orm
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <param name="source">A sequence of values to calculate the sum of.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the
@@ -1420,9 +1693,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1444,9 +1721,13 @@ namespace Xtensive.Orm
     /// Asynchronously computes the sum of the sequence of values that is obtained by
     /// invoking a projection function on each element of the input sequence.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
     /// <param name="selector">A projection function to apply to each element.</param>
@@ -1464,7 +1745,9 @@ namespace Xtensive.Orm
         source, selector, cancellationToken);
     }
 
-    // Collection methods
+    #endregion
+
+    #region Collection methods
 
     private static readonly MethodInfo TupleCreateMethod =
       typeof(Tuple).GetMethods(BindingFlags.Public | BindingFlags.Static)
@@ -1474,9 +1757,13 @@ namespace Xtensive.Orm
     /// Asynchronously creates a <see cref="List{TSource}"/> from an <see cref="IQueryable{TSource}"/>
     /// by enumerating it asynchronously.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{T}"/> to create a <see cref="List{TSource}"/> from.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -1498,9 +1785,13 @@ namespace Xtensive.Orm
     /// Asynchronously creates an array from an <see cref="IQueryable{TSource}"/> System.Linq.IQueryable`1
     /// by enumerating it asynchronously.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{T}"/> to create an array from.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -1514,9 +1805,13 @@ namespace Xtensive.Orm
     /// Creates a <see cref="Dictionary{TKey, TSource}"/> from an <see cref="IQueryable{TSource}"/>
     /// by enumerating it asynchronously according to a specified key selector function.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TKey">>The type of the key returned by <paramref name="keySelector"/>.</typeparam>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{T}"/> to create a <see cref="Dictionary{TKey, TSource}"/> from.</param>
@@ -1548,9 +1843,13 @@ namespace Xtensive.Orm
     /// Creates a <see cref="Dictionary{TKey, TValue}"/> from an <see cref="IQueryable{TSource}"/>
     /// by enumerating it asynchronously according to a specified key selector and value selector functions.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TKey">>The type of the key returned by <paramref name="keySelector"/>.</typeparam>
     /// <typeparam name="TValue">>The type of the key returned by <paramref name="valueSelector"/>.</typeparam>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
@@ -1586,9 +1885,13 @@ namespace Xtensive.Orm
     /// Asynchronously creates a <see cref="HashSet{TSource}"/> from an <see cref="IQueryable{TSource}"/>
     /// by enumerating it asynchronously.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{T}"/> to create a <see cref="HashSet{TSource}"/> from.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
@@ -1600,7 +1903,7 @@ namespace Xtensive.Orm
       var hashSet = new HashSet<TSource>();
       var asyncSource = source.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false);
       await foreach (var element in asyncSource) {
-        hashSet.Add(element);
+        _ = hashSet.Add(element);
       }
 
       return hashSet;
@@ -1610,9 +1913,13 @@ namespace Xtensive.Orm
     /// Asynchronously creates a <see cref="ILookup{TKey, TSource}"/> from an <see cref="IQueryable{T}"/>
     /// by enumerating it asynchronously according to a specified key selector function.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IQueryable{T}"/> to create a <see cref="ILookup{TKey, TSource}"/> from.</param>
@@ -1639,9 +1946,13 @@ namespace Xtensive.Orm
     /// by enumerating it asynchronously according to a specified key selector and an
     /// element selector function.
     /// </summary>
-    /// <remarks>Multiple active operations in the same session instance are not supported. Use
+    /// <remarks>
+    /// Multiple active operations in the same session instance are not supported. Use
     /// <see langword="await"/> to ensure that all asynchronous operations have completed before calling
-    /// another method in this session.</remarks>
+    /// another method in this session.
+    /// Notice that operation executes query so with some session options (like <see cref="Configuration.SessionOptions.ClientProfile"/>)
+    /// result may not include newly created or locally removed entities or their data. Save local changes for them to be taken into account.
+    /// </remarks>
     /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
     /// <typeparam name="TValue">The type of the value returned by <paramref name="valueSelector"/>.</typeparam>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
@@ -1666,6 +1977,8 @@ namespace Xtensive.Orm
       var queryResult = await query.ExecuteAsync(cancellationToken).ConfigureAwait(false);
       return queryResult.ToLookup(tuple => tuple.Item1, tuple => tuple.Item2);
     }
+
+    #endregion
 
     /// <summary>
     /// Returns an <see cref="IAsyncEnumerable{TSource}"/> which can be enumerated asynchronously.


### PR DESCRIPTION
Add special wrapper for queries that are not IAsyncEnumerable natively, such as EntitySets. The wrapper allows to apply .ToArrayAsync/ToListAsync/ToHashSetAsync extension methods to EntitySets. Correct implementation of IAsyncEnumerable would take a lot of resources because many APIs should support async operations, this approach less painful, though has a caviar - in ClientProfile mode results does not contain local changes.