### PR TITLE
Addresses IndexOutOfRangeException on translation of certain queries with aggregates

### DIFF
--- a/ChangeLog/7.1.4_dev.txt
+++ b/ChangeLog/7.1.4_dev.txt
@@ -1,0 +1,1 @@
+[main] Addressed IndexOutOfRangeException on translation of certain queries with aggregates

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/DomainHandler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/DomainHandler.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xtensive.Core;
 using Xtensive.Orm.Rse.Compilation;
+using Xtensive.Orm.Rse.Transformation;
 
 namespace Xtensive.Orm.Providers.PostgreSql
 {
@@ -20,6 +21,12 @@ namespace Xtensive.Orm.Providers.PostgreSql
     /// <inheritdoc/>
     protected override ICompiler CreateCompiler(CompilerConfiguration configuration) =>
       new SqlCompiler(Handlers, configuration);
+
+    protected override IPreCompiler CreatePreCompiler(CompilerConfiguration configuration)
+    {
+      var decimalAggregateCorrector = new AggregateOverDecimalColumnCorrector(Handlers.Domain.Model);
+      return new CompositePreCompiler(decimalAggregateCorrector, base.CreatePreCompiler(configuration));
+    }
 
     /// <inheritdoc/>
     protected override IEnumerable<Type> GetProviderCompilerContainers()

--- a/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0761_ReadingAvgAndSumByDecimalField.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0761_ReadingAvgAndSumByDecimalField.cs
@@ -8,9 +8,9 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using Xtensive.Orm.Configuration;
-using Xtensive.Orm.Tests.Issues.IssueJira0761_ReadingAverageByDecimalFieldModel;
+using Xtensive.Orm.Tests.Issues.IssueJira0761_ReadingAvgAndSumByDecimalFieldModel;
 
-namespace Xtensive.Orm.Tests.Issues.IssueJira0761_ReadingAverageByDecimalFieldModel
+namespace Xtensive.Orm.Tests.Issues.IssueJira0761_ReadingAvgAndSumByDecimalFieldModel
 {
   [HierarchyRoot]
   public class DecimalValueStructureEntityByRefCase : Entity
@@ -168,7 +168,7 @@ namespace Xtensive.Orm.Tests.Issues.IssueJira0761_ReadingAverageByDecimalFieldMo
 
 namespace Xtensive.Orm.Tests.Issues
 {
-  public class IssueJira0761_ReadingAverageByDecimalField : AutoBuildTest
+  public class IssueJira0761_ReadingAvgAndSumByDecimalField : AutoBuildTest
   {
     private const int OrderCount = 100;
 

--- a/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/AggregatesProblemTestBase.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/AggregatesProblemTestBase.cs
@@ -21,24 +21,8 @@ namespace Xtensive.Orm.Tests.Issues.IssueJira0786_AggregatesProblem
     protected decimal DoubleValueAccuracy { get; private set; } = 0.00000000000001m;
     protected decimal DecimalValueAccuracy { get; private set; } = 0.00000000000000001m;
 
-
-    protected override Domain BuildDomain(DomainConfiguration configuration)
-    {
-      var firstTryConfig = configuration.Clone();
-      firstTryConfig.UpgradeMode = DomainUpgradeMode.Validate;
-      try {
-        return base.BuildDomain(firstTryConfig);
-      }
-      catch (SchemaSynchronizationException) { }
-      catch (Exception) {
-        throw;
-      }
-
-      refillDatabase = true;
-      var secondTryConfig = configuration.Clone();
-      secondTryConfig.UpgradeMode = DomainUpgradeMode.Recreate;
-      return base.BuildDomain(secondTryConfig);
-    }
+    protected Session GlobalSession { get; private set; }
+    protected TransactionScope GlobalTransaction { get; private set; }
 
     protected override DomainConfiguration BuildConfiguration()
     {
@@ -62,93 +46,88 @@ namespace Xtensive.Orm.Tests.Issues.IssueJira0786_AggregatesProblem
         DecimalValueAccuracy = 0.00001m;
       }
 
-      if (!refillDatabase)
-        return;
+      (GlobalSession, GlobalTransaction) = CreateSessionAndTransaction();
 
+      _ = new TestEntity(GlobalSession) {
+        ByteValue = 2,
+        SByteValue = 4,
+        ShortValue = 8,
+        UShortValue = 9,
+        IntValue = 10,
+        UIntValue = 11,
+        LongValue = 20,
+        ULongValue = 25,
+        FloatValue = 0.1f,
+        DecimalValue = 1.2m,
+        DoubleValue1 = 2.0,
+        DoubleValue2 = 3.0,
+        NullableByteValue = 2,
+        NullableSByteValue = 4,
+        NullableShortValue = 8,
+        NullableUShortValue = 9,
+        NullableIntValue = 30,
+        NullableUIntValue = 31,
+        NullableLongValue = 40,
+        NullableULongValue = 45,
+        NullableFloatValue = 0.4f,
+        NullableDecimalValue = 4.2m,
+        NullableDoubleValue1 = 5.0,
+        NullableDoubleValue2 = 6.0
+      };
+      _ = new TestEntity(GlobalSession) {
+        ByteValue = 3,
+        SByteValue = 5,
+        ShortValue = 9,
+        UShortValue = 10,
+        IntValue = 11,
+        UIntValue = 12,
+        LongValue = 21,
+        ULongValue = 26,
+        FloatValue = 0.2f,
+        DecimalValue = 1.3m,
+        DoubleValue1 = 2.1,
+        DoubleValue2 = 3.1,
+        NullableByteValue = 3,
+        NullableSByteValue = 5,
+        NullableShortValue = 9,
+        NullableUShortValue = 10,
+        NullableIntValue = 31,
+        NullableUIntValue = 32,
+        NullableLongValue = 41,
+        NullableULongValue = 46,
+        NullableFloatValue = 0.5f,
+        NullableDecimalValue = 4.3m,
+        NullableDoubleValue1 = 5.1,
+        NullableDoubleValue2 = 6.1
+      };
+      _ = new TestEntity(GlobalSession) {
+        ByteValue = 4,
+        SByteValue = 6,
+        ShortValue = 10,
+        UShortValue = 11,
+        IntValue = 12,
+        UIntValue = 13,
+        LongValue = 22,
+        ULongValue = 27,
+        FloatValue = 0.3f,
+        DecimalValue = 1.4m,
+        DoubleValue1 = 2.3,
+        DoubleValue2 = 3.3,
+        NullableByteValue = 4,
+        NullableSByteValue = 6,
+        NullableShortValue = 10,
+        NullableUShortValue = 11,
+        NullableIntValue = 32,
+        NullableUIntValue = 33,
+        NullableLongValue = 42,
+        NullableULongValue = 47,
+        NullableFloatValue = 0.6f,
+        NullableDecimalValue = 4.4m,
+        NullableDoubleValue1 = 5.3,
+        NullableDoubleValue2 = 6.3
+      };
 
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        _ = new TestEntity() {
-          ByteValue = 2,
-          SByteValue = 4,
-          ShortValue = 8,
-          UShortValue = 9,
-          IntValue = 10,
-          UIntValue = 11,
-          LongValue = 20,
-          ULongValue = 25,
-          FloatValue = 0.1f,
-          DecimalValue = 1.2m,
-          DoubleValue1 = 2.0,
-          DoubleValue2 = 3.0,
-          NullableByteValue = 2,
-          NullableSByteValue = 4,
-          NullableShortValue = 8,
-          NullableUShortValue = 9,
-          NullableIntValue = 30,
-          NullableUIntValue = 31,
-          NullableLongValue = 40,
-          NullableULongValue = 45,
-          NullableFloatValue = 0.4f,
-          NullableDecimalValue = 4.2m,
-          NullableDoubleValue1 = 5.0,
-          NullableDoubleValue2 = 6.0
-        };
-        _ = new TestEntity() {
-          ByteValue = 3,
-          SByteValue = 5,
-          ShortValue = 9,
-          UShortValue = 10,
-          IntValue = 11,
-          UIntValue = 12,
-          LongValue = 21,
-          ULongValue = 26,
-          FloatValue = 0.2f,
-          DecimalValue = 1.3m,
-          DoubleValue1 = 2.1,
-          DoubleValue2 = 3.1,
-          NullableByteValue = 3,
-          NullableSByteValue = 5,
-          NullableShortValue = 9,
-          NullableUShortValue = 10,
-          NullableIntValue = 31,
-          NullableUIntValue = 32,
-          NullableLongValue = 41,
-          NullableULongValue = 46,
-          NullableFloatValue = 0.5f,
-          NullableDecimalValue = 4.3m,
-          NullableDoubleValue1 = 5.1,
-          NullableDoubleValue2 = 6.1
-        };
-        _ = new TestEntity() {
-          ByteValue = 4,
-          SByteValue = 6,
-          ShortValue = 10,
-          UShortValue = 11,
-          IntValue = 12,
-          UIntValue = 13,
-          LongValue = 22,
-          ULongValue = 27,
-          FloatValue = 0.3f,
-          DecimalValue = 1.4m,
-          DoubleValue1 = 2.3,
-          DoubleValue2 = 3.3,
-          NullableByteValue = 4,
-          NullableSByteValue = 6,
-          NullableShortValue = 10,
-          NullableUShortValue = 11,
-          NullableIntValue = 32,
-          NullableUIntValue = 33,
-          NullableLongValue = 42,
-          NullableULongValue = 47,
-          NullableFloatValue = 0.6f,
-          NullableDecimalValue = 4.4m,
-          NullableDoubleValue1 = 5.3,
-          NullableDoubleValue2 = 6.3
-        };
-
-        tx.Complete();
-      }
+      GlobalSession.SaveChanges();
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/AverageProcessingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/AverageProcessingTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Xtensive LLC.
+// Copyright (C) 2020-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
@@ -7,3023 +7,1310 @@
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Xtensive.Orm.Tests.Issues.IssueJira0786_AggregatesProblem
 {
   public sealed class AverageProcessingTest : AggregatesProblemTestBase
   {
     [Test]
-    public void ByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldTest() => TestAverage(i => i.ByteValue);
 
     [Test]
-    public void SByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldTest() => TestAverage(i => i.SByteValue);
 
     [Test]
-    public void ShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldTest() => TestAverage(i => i.ShortValue);
 
     [Test]
-    public void UShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldTest() => TestAverage(i => i.UShortValue);
 
     [Test]
-    public void IntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldTest() => TestAverage(i => i.IntValue);
 
     [Test]
-    public void UIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldTest() => TestAverage(i => i.UIntValue);
 
     [Test]
-    public void LongFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldTest() => TestAverage(i => i.LongValue);
 
     [Test]
-    public void FloatFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void FloatFieldTest() => TestAverage(i => i.FloatValue);
 
     [Test]
-    public void DoubleFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.DoubleValue1 + 1.0);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.DoubleValue1 + 1.0);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DoubleFieldTest() => TestAverage(i => i.DoubleValue1 + 1.0);
 
     [Test]
-    public void DecimalFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DecimalFieldTest() => TestAverage(i => i.DecimalValue);
 
     [Test]
-    public void NullableByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldTest() => TestAverage(i => i.NullableByteValue);
 
     [Test]
-    public void NullableSByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldTest() => TestAverage(i => i.NullableSByteValue);
 
     [Test]
-    public void NullableShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldTest() => TestAverage(i => i.NullableShortValue);
 
     [Test]
-    public void NullableUShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldTest() => TestAverage(i => i.NullableUShortValue);
 
     [Test]
-    public void NullableIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldTest() => TestAverage(i => i.NullableIntValue);
 
     [Test]
-    public void NullableUIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldTest() => TestAverage(i => i.NullableUIntValue);
 
     [Test]
-    public void NullableLongFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldTest() => TestAverage(i => i.NullableLongValue);
 
     [Test]
-    public void NullableFloatFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableFloatFieldTest() => TestAverage(i => i.NullableFloatValue);
 
     [Test]
-    public void NullableDoubleFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableDoubleFieldTest() => TestAverage(i => i.NullableDoubleValue1);
 
     [Test]
-    public void NullableDecimalFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableDecimalFieldTest() => TestAverage(i => i.NullableDecimalValue);
 
     [Test]
-    public void ByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest01() => TestAverage(i => i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (short) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (short) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest02() =>
+      TestAverage(i => (short) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (short) i.ByteValue + (short) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (short) i.ByteValue + (short) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest03() =>
+      TestAverage(i => (short) i.ByteValue + (short) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest04() =>
+      TestAverage(i => (int) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int) i.ByteValue + (int) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int) i.ByteValue + (int) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest05() =>
+      TestAverage(i => (int) i.ByteValue + (int) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest06() =>
+      TestAverage(i => (long) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.ByteValue + (long) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.ByteValue + (long) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest07() =>
+      TestAverage(i => (long) i.ByteValue + (long) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest08() =>
+      TestAverage(i => (float) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.ByteValue + (float) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.ByteValue + (float) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest09() =>
+      TestAverage(i => (float) i.ByteValue + (float) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest10() =>
+      TestAverage(i => (double) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.ByteValue + (double) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.ByteValue + (double) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest11() =>
+      TestAverage(i => (double) i.ByteValue + (double) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.ByteValue + i.ByteValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void ByteFieldExpressionTest12() =>
+      TestAverageWithAccuracy(i => (decimal) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest13() =>
+      TestAverage(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ByteValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ByteValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest14() => TestAverage(i => i.ByteValue + i.IntValue);
 
     [Test]
-    public void ByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ByteValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ByteValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest15() => TestAverage(i => i.ByteValue + i.LongValue);
 
     [Test]
-    public void ByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ByteValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ByteValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest16() => TestAverage(i => i.ByteValue + i.FloatValue);
 
     [Test]
-    public void ByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ByteValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ByteValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest17() => TestAverage(i => i.ByteValue + i.DoubleValue1);
 
     [Test]
-    public void ByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ByteValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ByteValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest18() => TestAverage(i => i.ByteValue + i.DecimalValue);
 
     [Test]
-    public void SByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest01() => TestAverage(i => i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (short) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (short) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest02() =>
+      TestAverage(i => (short) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (short) i.SByteValue + (short) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (short) i.SByteValue + (short) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest03() =>
+      TestAverage(i => (short) i.SByteValue + (short) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest04() =>
+      TestAverage(i => (int) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int) i.SByteValue + (int) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int) i.SByteValue + (int) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest05() =>
+      TestAverage(i => (int) i.SByteValue + (int) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest06() =>
+      TestAverage(i => (long) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.SByteValue + (long) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.SByteValue + (long) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest07() =>
+      TestAverage(i => (long) i.SByteValue + (long) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest08() =>
+      TestAverage(i => (float) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.SByteValue + (float) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.SByteValue + (float) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest09() =>
+      TestAverage(i => (float) i.SByteValue + (float) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest10() =>
+      TestAverage(i => (double) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.SByteValue + (double) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.SByteValue + (double) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest11() =>
+      TestAverage(i => (double) i.SByteValue + (double) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest12() =>
+      TestAverage(i => (decimal) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest13() =>
+      TestAverage(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.SByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.SByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest14() => TestAverage(i => i.SByteValue + i.ByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.SByteValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.SByteValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest15() => TestAverage(i => i.SByteValue + i.IntValue);
 
     [Test]
-    public void SByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.SByteValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.SByteValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest16() => TestAverage(i => i.SByteValue + i.LongValue);
 
     [Test]
-    public void SByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.SByteValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.SByteValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest17() => TestAverage(i => i.SByteValue + i.FloatValue);
 
     [Test]
-    public void SByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.SByteValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.SByteValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest18() => TestAverage(i => i.SByteValue + i.DoubleValue1);
 
     [Test]
-    public void SByteFieldExpressionTest19()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.SByteValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.SByteValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest19() => TestAverage(i => i.SByteValue + i.DecimalValue);
 
     [Test]
-    public void ShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest01() => TestAverage(i => i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest02() =>
+      TestAverage(i => (int) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int) i.ShortValue + (int) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int) i.ShortValue + (int) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest03() =>
+      TestAverage(i => (int) i.ShortValue + (int) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest04() =>
+      TestAverage(i => (long) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.ShortValue + (long) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.ShortValue + (long) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest05() =>
+      TestAverage(i => (long) i.ShortValue + (long) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest06() =>
+      TestAverage(i => (float) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.ShortValue + (float) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.ShortValue + (float) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest07() =>
+      TestAverage(i => (float) i.ShortValue + (float) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest08() =>
+      TestAverage(i => (double) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.ShortValue + (double) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.ShortValue + (double) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest09() =>
+      TestAverage(i => (double) i.ShortValue + (double) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest10() =>
+      TestAverage(i => (decimal) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest11() =>
+      TestAverage(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ShortValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ShortValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest12() =>
+      TestAverage(i => i.ShortValue + i.ByteValue);
 
     [Test]
-    public void ShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ShortValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ShortValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest13() =>
+      TestAverage(i => i.ShortValue + i.IntValue);
 
     [Test]
-    public void ShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ShortValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ShortValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest14() =>
+      TestAverage(i => i.ShortValue + i.LongValue);
 
     [Test]
-    public void ShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ShortValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ShortValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest15() =>
+      TestAverage(i => i.ShortValue + i.FloatValue);
 
     [Test]
-    public void ShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ShortValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ShortValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest16() =>
+      TestAverage(i => i.ShortValue + i.DoubleValue1);
 
     [Test]
-    public void ShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ShortValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ShortValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest17() =>
+      TestAverage(i => i.ShortValue + i.DecimalValue);
 
     [Test]
-    public void UShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest01() =>
+      TestAverage(i => i.ShortValue + i.ShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest02() =>
+      TestAverage(i => (int) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int) i.UShortValue + (int) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int) i.UShortValue + (int) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest03() =>
+      TestAverage(i => (int) i.UShortValue + (int) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest04() =>
+      TestAverage(i => (long) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.UShortValue + (long) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.UShortValue + (long) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest05() =>
+      TestAverage(i => (long) i.UShortValue + (long) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest06() =>
+      TestAverage(i => (float) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.UShortValue + (float) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.UShortValue + (float) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest07() =>
+      TestAverage(i => (float) i.UShortValue + (float) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest08() =>
+      TestAverage(i => (double) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.UShortValue + (double) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.UShortValue + (double) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest09() =>
+      TestAverage(i => (double) i.UShortValue + (double) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest10() =>
+      TestAverage(i => (decimal) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest11() =>
+      TestAverage(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UShortValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UShortValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest12() =>
+      TestAverage(i => i.UShortValue + i.ByteValue);
 
     [Test]
-    public void UShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UShortValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UShortValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest13() =>
+      TestAverage(i => i.UShortValue + i.IntValue);
 
     [Test]
-    public void UShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UShortValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UShortValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest14() =>
+      TestAverage(i => i.UShortValue + i.LongValue);
 
     [Test]
-    public void UShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UShortValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UShortValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest15() =>
+      TestAverage(i => i.UShortValue + i.FloatValue);
 
     [Test]
-    public void UShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UShortValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UShortValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest16() =>
+      TestAverage(i => i.UShortValue + i.DoubleValue1);
 
     [Test]
-    public void UShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UShortValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UShortValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest17() =>
+      TestAverage(i => i.UShortValue + i.DecimalValue);
 
     [Test]
-    public void IntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest01() =>
+      TestAverage(i => i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest02() =>
+      TestAverage(i => (long) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.IntValue * (long) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.IntValue * (long) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest03() =>
+      TestAverage(i => (long) i.IntValue * (long) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest04() =>
+      TestAverage(i => (float) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.IntValue * (float) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.IntValue * (float) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest05() =>
+      TestAverage(i => (float) i.IntValue * (float) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest06() =>
+      TestAverage(i => (double) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.IntValue * (double) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.IntValue * (double) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest07() =>
+      TestAverage(i => (double) i.IntValue * (double) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.IntValue * i.IntValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void IntFieldExpressionTest08() =>
+      TestAverageWithAccuracy(i => (decimal) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.IntValue * (decimal) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.IntValue * (decimal) i.IntValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void IntFieldExpressionTest09() =>
+      TestAverageWithAccuracy(i => (decimal) i.IntValue * (decimal) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.IntValue * i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.IntValue * i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest10() =>
+      TestAverage(i => i.IntValue * i.ByteValue);
 
     [Test]
-    public void IntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.IntValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.IntValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest11() =>
+      TestAverage(i => i.IntValue * i.LongValue);
 
     [Test]
-    public void IntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.IntValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.IntValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest12() =>
+      TestAverage(i => i.IntValue * i.FloatValue);
 
     [Test]
-    public void IntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.IntValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.IntValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest13() =>
+      TestAverage(i => i.IntValue * i.DoubleValue1);
 
     [Test]
-    public void IntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.IntValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.IntValue * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void IntFieldExpressionTest14() =>
+      TestAverageWithAccuracy(i => i.IntValue * i.DecimalValue);
 
     [Test]
-    public void UIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest01() =>
+      TestAverage(i => i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest02() =>
+      TestAverage(i => (long) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long) i.UIntValue * (long) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long) i.UIntValue * (long) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest03() =>
+      TestAverage(i => (long) i.UIntValue * (long) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest04() =>
+      TestAverage(i => (float) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.UIntValue * (float) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.UIntValue * (float) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest05() =>
+      TestAverage(i => (float) i.UIntValue * (float) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest06() =>
+      TestAverage(i => (double) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.UIntValue * (double) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.UIntValue * (double) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest07() =>
+      TestAverage(i => (double) i.UIntValue * (double) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.UIntValue * i.UIntValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void UIntFieldExpressionTest08() =>
+      TestAverageWithAccuracy(i => (decimal) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void UIntFieldExpressionTest09() =>
+      TestAverageWithAccuracy(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UIntValue + i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UIntValue + i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest10() =>
+      TestAverage(i => i.UIntValue + i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UIntValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UIntValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest11() =>
+      TestAverage(i => i.UIntValue * i.LongValue);
 
     [Test]
-    public void UIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UIntValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UIntValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest12() =>
+      TestAverage(i => i.UIntValue * i.FloatValue);
 
     [Test]
-    public void UIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UIntValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UIntValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest13() =>
+      TestAverage(i => i.UIntValue * i.DoubleValue1);
 
     [Test]
-    public void UIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.UIntValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.UIntValue * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void UIntFieldExpressionTest14() =>
+      TestAverageWithAccuracy(i => i.UIntValue * i.DecimalValue);
 
     [Test]
-    public void LongFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest01() =>
+      TestAverage(i => i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest02() =>
+      TestAverage(i => (float) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.LongValue * (float) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.LongValue * (float) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest03() =>
+      TestAverage(i => (float) i.LongValue * (float) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest04() =>
+      TestAverage(i => (double) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.LongValue * (double) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.LongValue * (double) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest05() =>
+      TestAverage(i => (double) i.LongValue * (double) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.LongValue * i.LongValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void LongFieldExpressionTest06() =>
+      TestAverageWithAccuracy(i => (decimal) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.LongValue * (decimal) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.LongValue * (decimal) i.LongValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void LongFieldExpressionTest07() =>
+      TestAverageWithAccuracy(i => (decimal) i.LongValue * (decimal) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.LongValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.LongValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest08() =>
+      TestAverage(i => i.LongValue * i.FloatValue);
 
     [Test]
-    public void LongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.LongValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.LongValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest09() =>
+      TestAverage(i => i.LongValue * i.DoubleValue1);
 
     [Test]
-    public void LongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.LongValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.LongValue * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void LongFieldExpressionTest10() =>
+      TestAverageWithAccuracy(i => i.LongValue * i.DecimalValue);
 
     [Test]
-    public void ULongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest02() =>
+      TestAverage(i => (float) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float) i.ULongValue * (float) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.ULongValue * (float) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest03() =>
+      TestAverage(i => (float) i.ULongValue * (float) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest04() =>
+      TestAverage(i => (double) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.ULongValue * (double) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.ULongValue * (double) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest05() =>
+      TestAverage(i => (double) i.ULongValue * (double) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.ULongValue * i.ULongValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void ULongFieldExpressionTest06() =>
+      TestAverageWithAccuracy(i => (decimal) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void ULongFieldExpressionTest07() =>
+      TestAverageWithAccuracy(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ULongValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ULongValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest08() =>
+      TestAverage(i => i.ULongValue * i.FloatValue);
 
     [Test]
-    public void ULongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ULongValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ULongValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest09() =>
+      TestAverage(i => i.ULongValue * i.DoubleValue1);
 
     [Test]
-    public void ULongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.ULongValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.ULongValue * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void ULongFieldExpressionTest10() =>
+      TestAverageWithAccuracy(i => i.ULongValue * i.DecimalValue);
 
     [Test]
-    public void FloatFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.FloatValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.FloatValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest01() =>
+      TestAverageWithAccuracy(i => i.FloatValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.FloatValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.FloatValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest02() =>
+      TestAverageWithAccuracy(i => (double) i.FloatValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.FloatValue * (double) i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.FloatValue * (double) i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest03() =>
+      TestAverageWithAccuracy(i => (double) i.FloatValue * (double) i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.FloatValue * (decimal) i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.FloatValue * (decimal) i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest04() =>
+      TestAverageWithAccuracy(i => (decimal) i.FloatValue * (decimal) i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.FloatValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.FloatValue * i.DoubleValue1);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest05() =>
+      TestAverageWithAccuracy(i => i.FloatValue * i.DoubleValue1, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.FloatValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.FloatValue * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest06() =>
+      TestAverageWithAccuracy(i => (decimal) i.FloatValue * i.DecimalValue, FloatValueAccuracy);
 
     [Test]
-    public void DoubleFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.DoubleValue1 * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.DoubleValue1 * i.DoubleValue1);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(DoubleValueAccuracy));
-      }
-    }
+    public void DoubleFieldExpressionTest01() =>
+      TestAverageWithAccuracy(i => i.DoubleValue1 * i.DoubleValue1, DoubleValueAccuracy);
 
     [Test]
-    public void DoubleFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal) i.DoubleValue1 * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal) i.DoubleValue1 * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(DoubleValueAccuracy));
-      }
-    }
+    public void DoubleFieldExpressionTest02() =>
+      TestAverageWithAccuracy(i => (decimal) i.DoubleValue1 * i.DecimalValue, DoubleValueAccuracy);
 
     [Test]
-    public void DecimalFieldExpressionTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.DecimalValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.DecimalValue * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void DecimalFieldExpressionTest() =>
+      TestAverageWithAccuracy(i => i.DecimalValue * i.DecimalValue, DecimalValueAccuracy);
 
     [Test]
-    public void NullableByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest01() =>
+      TestAverage(i => i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (short?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (short?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest02() =>
+      TestAverage(i => (short?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest03() =>
+      TestAverage(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest04() =>
+      TestAverage(i => (int?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest05() =>
+      TestAverage(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest06() =>
+      TestAverage(i => (long?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest07() =>
+      TestAverage(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.ByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest08() =>
+      TestAverage(i => (float?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest09() =>
+      TestAverage(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest10() =>
+      TestAverage(i => (double?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double) i.ByteValue + (double) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double) i.ByteValue + (double) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest11() =>
+      TestAverage(i => (double) i.ByteValue + (double) i.ByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest12() =>
+      TestAverage(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest13() =>
+      TestAverage(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableByteValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableByteValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest14() =>
+      TestAverage(i => i.NullableByteValue + i.NullableIntValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableByteValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableByteValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest15() =>
+      TestAverage(i => i.NullableByteValue + i.NullableLongValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableByteValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableByteValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest16() =>
+      TestAverage(i => i.NullableByteValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableByteValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableByteValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest17() =>
+      TestAverage(i => i.NullableByteValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableByteValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableByteValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest18() =>
+      TestAverage(i => i.NullableByteValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest01() =>
+      TestAverage(i => i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest02() =>
+      TestAverage(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest03() =>
+      TestAverage(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest04() =>
+      TestAverage(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest05() =>
+      TestAverage(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest06() =>
+      TestAverage(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest07() =>
+      TestAverage(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest08() =>
+      TestAverage(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest09() =>
+      TestAverage(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest10() =>
+      TestAverage(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest11() =>
+      TestAverage(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest12() =>
+      TestAverage(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest13() =>
+      TestAverage(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableSByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableSByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest14() =>
+      TestAverage(i => i.NullableSByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableSByteValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableSByteValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest15() =>
+      TestAverage(i => i.NullableSByteValue + i.NullableIntValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableSByteValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableSByteValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest16() =>
+      TestAverage(i => i.NullableSByteValue + i.NullableLongValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableSByteValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableSByteValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest17() =>
+      TestAverage(i => i.NullableSByteValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableSByteValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableSByteValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest18() =>
+      TestAverage(i => i.NullableSByteValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableSByteFieldExpressionTest19()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableSByteValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableSByteValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest19() =>
+      TestAverage(i => i.NullableSByteValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest01() =>
+      TestAverage(i => i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest02() =>
+      TestAverage(i => (int?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest03() =>
+      TestAverage(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest04() =>
+      TestAverage(i => (long?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest05() =>
+      TestAverage(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest06() =>
+      TestAverage(i => (float?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableShortValue + (float?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float) i.ShortValue + (float?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest07() =>
+      TestAverage(i => (float?) i.NullableShortValue + (float?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest08() =>
+      TestAverage(i => (double?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest09() =>
+      TestAverage(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest10() =>
+      TestAverage(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest11() =>
+      TestAverage(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableShortValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableShortValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest12() =>
+      TestAverage(i => i.NullableShortValue + i.NullableByteValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableShortValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableShortValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest13() =>
+      TestAverage(i => i.NullableShortValue + i.NullableIntValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableShortValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableShortValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest14() =>
+      TestAverage(i => i.NullableShortValue + i.NullableLongValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableShortValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableShortValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest15() =>
+      TestAverage(i => i.NullableShortValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableShortValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableShortValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest16() =>
+      TestAverage(i => i.NullableShortValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableShortValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableShortValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest17() =>
+      TestAverage(i => i.NullableShortValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest01() =>
+      TestAverage(i => i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest02() =>
+      TestAverage(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest03() =>
+      TestAverage(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest04() =>
+      TestAverage(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest05() =>
+      TestAverage(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest06() =>
+      TestAverage(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest07() =>
+      TestAverage(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest08() =>
+      TestAverage(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest09() =>
+      TestAverage(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest10() =>
+      TestAverage(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
 
+
     [Test]
-    public void NullableUShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest11() =>
+      TestAverage(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUShortValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUShortValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest12() =>
+      TestAverage(i => i.NullableUShortValue + i.NullableByteValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUShortValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUShortValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest13() =>
+      TestAverage(i => i.NullableUShortValue + i.NullableIntValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUShortValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUShortValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest14() =>
+      TestAverage(i => i.NullableUShortValue + i.NullableLongValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUShortValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUShortValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest15() =>
+      TestAverage(i => i.NullableUShortValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUShortValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUShortValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest16() =>
+      TestAverage(i => i.NullableUShortValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableUShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUShortValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUShortValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest17() =>
+      TestAverage(i => i.NullableUShortValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest01() =>
+      TestAverage(i => i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest02() =>
+      TestAverage(i => (long?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest03() =>
+      TestAverage(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest04() =>
+      TestAverage(i => (float?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest05() =>
+      TestAverage(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest06() =>
+      TestAverage(i => (double?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest07() =>
+      TestAverage(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void NullableIntFieldExpressionTest08() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void NullableIntFieldExpressionTest09() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableIntValue * i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableIntValue * i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest10() =>
+      TestAverage(i => i.NullableIntValue * i.NullableByteValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableIntValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableIntValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest11() =>
+      TestAverage(i => i.NullableIntValue * i.NullableLongValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableIntValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableIntValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest12() =>
+      TestAverage(i => i.NullableIntValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableIntValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableIntValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest13() =>
+      TestAverage(i => i.NullableIntValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableIntValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableIntValue * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void NullableIntFieldExpressionTest14() =>
+      TestAverageWithAccuracy(i => i.NullableIntValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest01() =>
+      TestAverage(i => i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest02() =>
+      TestAverage(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest03() =>
+      TestAverage(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest04() =>
+      TestAverage(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest05() =>
+      TestAverage(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest06() =>
+      TestAverage(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest07() =>
+      TestAverage(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void NullableUIntFieldExpressionTest08() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void NullableUIntFieldExpressionTest09() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUIntValue + i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUIntValue + i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest10() =>
+      TestAverage(i => i.NullableUIntValue + i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUIntValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUIntValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest11() =>
+      TestAverage(i => i.NullableUIntValue * i.NullableLongValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUIntValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUIntValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest12() =>
+      TestAverage(i => i.NullableUIntValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUIntValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUIntValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest13() =>
+      TestAverage(i => i.NullableUIntValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableUIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableUIntValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableUIntValue * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void NullableUIntFieldExpressionTest14() =>
+      TestAverageWithAccuracy(i => i.NullableUIntValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest01() =>
+      TestAverage(i => i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest02() =>
+      TestAverage(i => (float?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest03() =>
+      TestAverage(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest04() =>
+      TestAverage(i => (double?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest05() =>
+      TestAverage(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void NullableLongFieldExpressionTest06() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void NullableLongFieldExpressionTest07() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableLongValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableLongValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest08() =>
+      TestAverage(i => i.NullableLongValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableLongValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableLongValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest09() =>
+      TestAverage(i => i.NullableLongValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableLongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableLongValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableLongValue * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
-    }
+    public void NullableLongFieldExpressionTest10() =>
+      TestAverageWithAccuracy(i => i.NullableLongValue * i.NullableDecimalValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest02() =>
+      TestAverage(i => (float?) i.NullableULongValue * i.NullableULongValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest03() =>
+      TestAverage(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
 
+
+    [Test]
+    public void NullableULongFieldExpressionTest04() =>
+      TestAverage(i => (double?) i.NullableULongValue * i.NullableULongValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest05() =>
+      TestAverage(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest06() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest07() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest08() =>
+      TestAverage(i => i.NullableULongValue * i.NullableFloatValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest09() =>
+      TestAverage(i => i.NullableULongValue * i.NullableDoubleValue1);
+
+    [Test]
+    public void NullableULongFieldExpressionTest10() =>
+      TestAverageWithAccuracy(i => i.NullableULongValue * i.NullableDecimalValue);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest01() =>
+      TestAverageWithAccuracy(i => i.NullableFloatValue * i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest02() =>
+      TestAverageWithAccuracy(i => (double?) i.NullableFloatValue * i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest03() =>
+      TestAverageWithAccuracy(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue, FloatValueAccuracy);
+
     [Test]
-    public void NullableULongFieldExpressionTest02()
+    public void NullableFloatFieldExpressionTest04() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest05() =>
+      TestAverageWithAccuracy(i => i.NullableFloatValue * i.NullableDoubleValue1, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest06() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableDoubleFieldExpressionTest01() =>
+      TestAverage(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
+
+    [Test]
+    public void NullableDoubleFieldExpressionTest02() =>
+      TestAverageWithAccuracy(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue, DoubleValueAccuracy);
+
+    [Test]
+    public void NullableDecimalFieldExpressionTest() =>
+      TestAverageWithAccuracy(i => i.NullableDecimalValue * i.NullableDecimalValue);
+
+
+
+    private void TestAverage(Expression<Func<TestEntity, int>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest03()
+    private void TestAverage(Expression<Func<TestEntity, int?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest04()
+    private void TestAverage(Expression<Func<TestEntity, long>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest05()
+    private void TestAverage(Expression<Func<TestEntity, long?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest06()
+    private void TestAverage(Expression<Func<TestEntity, float>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest07()
+    private void TestAverage(Expression<Func<TestEntity, float?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest08()
+    private void TestAverage(Expression<Func<TestEntity, double>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableULongValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableULongValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest09()
+    private void TestAverage(Expression<Func<TestEntity, double?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableULongValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableULongValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest10()
+    private void TestAverage(Expression<Func<TestEntity, decimal>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableULongValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableULongValue * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest01()
+    private void TestAverage(Expression<Func<TestEntity, decimal?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableFloatValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableFloatValue * i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest02()
+    private void TestAverageWithAccuracy<TAccuracy>(Expression<Func<TestEntity, float>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableFloatValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableFloatValue * i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest03()
+    private void TestAverageWithAccuracy<TAccuracy>(Expression<Func<TestEntity, float?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest04()
+    private void TestAverageWithAccuracy<TAccuracy>(Expression<Func<TestEntity, double>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest05()
+    private void TestAverageWithAccuracy<TAccuracy>(Expression<Func<TestEntity, double?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableFloatValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableFloatValue * i.NullableDoubleValue1);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest06()
+    private void TestAverageWithAccuracy<TAccuracy>(Expression<Func<TestEntity, decimal>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableDoubleFieldExpressionTest01()
+    private void TestAverageWithAccuracy<TAccuracy>(Expression<Func<TestEntity, decimal?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableDoubleFieldExpressionTest02()
+    private void TestAverageWithAccuracy(Expression<Func<TestEntity, decimal>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(DoubleValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(Math.Abs(queryableResult - decimal.Round(enumerableResult, 19)), Is.LessThan(DecimalValueAccuracy), "Failed on Select(selector).Average(t => t)");
     }
 
-    [Test]
-    public void NullableDecimalFieldExpressionTest()
+    private void TestAverageWithAccuracy(Expression<Func<TestEntity, decimal?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Average(i => i.NullableDecimalValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Average(i => i.NullableDecimalValue * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Average(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Average(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy), "Failed on Average(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average();
+      Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy), "Failed on Select(selector).Average()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Average(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - decimal.Round(enumerableResult.Value, 19)), Is.LessThan(DecimalValueAccuracy), "Failed on Select(selector).Average(t => t)");
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/MaxProcessingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/MaxProcessingTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Xtensive LLC.
+// Copyright (C) 2020-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
@@ -7,3023 +7,1150 @@
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Xtensive.Orm.Tests.Issues.IssueJira0786_AggregatesProblem
 {
   public sealed class MaxProcessingTest : AggregatesProblemTestBase
   {
     [Test]
-    public void ByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldTest() => TestMax(i => i.ByteValue);
 
     [Test]
-    public void SByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldTest() => TestMax(i => i.SByteValue);
 
     [Test]
-    public void ShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldTest() => TestMax(i => i.ShortValue);
 
     [Test]
-    public void UShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldTest() => TestMax(i => i.UShortValue);
 
     [Test]
-    public void IntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldTest() => TestMax(i => i.IntValue);
 
     [Test]
-    public void UIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldTest() => TestMax(i => i.UIntValue);
 
     [Test]
-    public void LongFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldTest() => TestMax(i => i.LongValue);
 
     [Test]
-    public void FloatFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldTest() => TestMax(i => i.ULongValue);
 
     [Test]
-    public void DoubleFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void FloatFieldTest() => TestMax(i => i.FloatValue);
 
     [Test]
-    public void DecimalFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DoubleFieldTest() => TestMax(i => i.DoubleValue1);
 
     [Test]
-    public void NullableByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DecimalFieldTest() => TestMax(i => i.DecimalValue);
 
     [Test]
-    public void NullableSByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldTest() => TestMax(i => i.NullableByteValue);
 
     [Test]
-    public void NullableShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldTest() => TestMax(i => i.NullableSByteValue);
 
     [Test]
-    public void NullableUShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldTest() => TestMax(i => i.NullableShortValue);
 
     [Test]
-    public void NullableIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldTest() => TestMax(i => i.NullableUShortValue);
 
     [Test]
-    public void NullableUIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldTest() => TestMax(i => i.NullableIntValue);
 
     [Test]
-    public void NullableLongFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldTest() => TestMax(i => i.NullableUIntValue);
 
     [Test]
-    public void NullableFloatFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldTest() => TestMax(i => i.NullableLongValue);
 
     [Test]
-    public void NullableDoubleFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldTest() => TestMax(i => i.NullableULongValue);
 
     [Test]
-    public void NullableDecimalFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableFloatFieldTest() => TestMax(i => i.NullableFloatValue);
 
     [Test]
-    public void ByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableDoubleFieldTest() => TestMax(i => i.NullableDoubleValue1);
 
     [Test]
-    public void ByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (short) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (short) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableDecimalFieldTest() => TestMax(i => i.NullableDecimalValue);
 
     [Test]
-    public void ByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (short) i.ByteValue + (short) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (short) i.ByteValue + (short) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest01() => TestMax(i => i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest02() =>
+      TestMax(i => (short) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int) i.ByteValue + (int) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int) i.ByteValue + (int) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest03() =>
+      TestMax(i => (short) i.ByteValue + (short) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest04() =>
+      TestMax(i => (int) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.ByteValue + (long) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.ByteValue + (long) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest05() =>
+      TestMax(i => (int) i.ByteValue + (int) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest06() =>
+      TestMax(i => (long) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.ByteValue + (float) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.ByteValue + (float) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest07() =>
+      TestMax(i => (long) i.ByteValue + (long) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest08() =>
+      TestMax(i => (float) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.ByteValue + (double) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.ByteValue + (double) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest09() =>
+      TestMax(i => (float) i.ByteValue + (float) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest10() =>
+      TestMax(i => (double) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest11() =>
+      TestMax(i => (double) i.ByteValue + (double) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ByteValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ByteValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest12() =>
+      TestMax(i => (decimal) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ByteValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ByteValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest13() =>
+      TestMax(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ByteValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ByteValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest14() => TestMax(i => i.ByteValue + i.IntValue);
 
     [Test]
-    public void ByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ByteValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ByteValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest15() => TestMax(i => i.ByteValue + i.LongValue);
 
     [Test]
-    public void ByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ByteValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ByteValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest16() => TestMax(i => i.ByteValue + i.FloatValue);
 
     [Test]
-    public void SByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest17() => TestMax(i => i.ByteValue + i.DoubleValue1);
 
     [Test]
-    public void SByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (short) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (short) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest18() =>
+      TestMax(i => i.ByteValue + i.DecimalValue);
 
     [Test]
-    public void SByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (short) i.SByteValue + (short) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (short) i.SByteValue + (short) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest01() =>
+      TestMax(i => i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest02() =>
+      TestMax(i => (short) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int) i.SByteValue + (int) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int) i.SByteValue + (int) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest03() =>
+      TestMax(i => (short) i.SByteValue + (short) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest04() =>
+      TestMax(i => (int) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.SByteValue + (long) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.SByteValue + (long) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest05() =>
+      TestMax(i => (int) i.SByteValue + (int) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest06() =>
+      TestMax(i => (long) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.SByteValue + (float) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.SByteValue + (float) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest07() =>
+      TestMax(i => (long) i.SByteValue + (long) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest08() =>
+      TestMax(i => (float) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.SByteValue + (double) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.SByteValue + (double) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest09() =>
+      TestMax(i => (float) i.SByteValue + (float) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest10() =>
+      TestMax(i => (double) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest11() =>
+      TestMax(i => (double) i.SByteValue + (double) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.SByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.SByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest12() =>
+      TestMax(i => (decimal) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.SByteValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.SByteValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest13() =>
+      TestMax(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.SByteValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.SByteValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest14() => TestMax(i => i.SByteValue + i.ByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.SByteValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.SByteValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest15() => TestMax(i => i.SByteValue + i.IntValue);
 
     [Test]
-    public void SByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.SByteValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.SByteValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest16() => TestMax(i => i.SByteValue + i.LongValue);
 
     [Test]
-    public void SByteFieldExpressionTest19()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.SByteValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.SByteValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest17() => TestMax(i => i.SByteValue + i.FloatValue);
 
     [Test]
-    public void ShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest18() => TestMax(i => i.SByteValue + i.DoubleValue1);
 
     [Test]
-    public void ShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest19() => TestMax(i => i.SByteValue + i.DecimalValue);
 
     [Test]
-    public void ShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int) i.ShortValue + (int) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int) i.ShortValue + (int) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest01() => TestMax(i => i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest02() =>
+      TestMax(i => (int) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.ShortValue + (long) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.ShortValue + (long) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest03() =>
+      TestMax(i => (int) i.ShortValue + (int) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest04() =>
+      TestMax(i => (long) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.ShortValue + (float) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.ShortValue + (float) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest05() =>
+      TestMax(i => (long) i.ShortValue + (long) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest06() =>
+      TestMax(i => (float) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.ShortValue + (double) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.ShortValue + (double) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest07() =>
+      TestMax(i => (float) i.ShortValue + (float) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest08() =>
+      TestMax(i => (double) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest09() =>
+      TestMax(i => (double) i.ShortValue + (double) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ShortValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ShortValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest10() =>
+      TestMax(i => (decimal) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ShortValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ShortValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest11() =>
+      TestMax(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ShortValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ShortValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest12() =>
+      TestMax(i => i.ShortValue + i.ByteValue);
 
     [Test]
-    public void ShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ShortValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ShortValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest13() =>
+      TestMax(i => i.ShortValue + i.IntValue);
 
     [Test]
-    public void ShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ShortValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ShortValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest14() =>
+      TestMax(i => i.ShortValue + i.LongValue);
 
     [Test]
-    public void ShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ShortValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ShortValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest15() =>
+      TestMax(i => i.ShortValue + i.FloatValue);
 
     [Test]
-    public void UShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest16() =>
+      TestMax(i => i.ShortValue + i.DoubleValue1);
 
     [Test]
-    public void UShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest17() =>
+      TestMax(i => i.ShortValue + i.DecimalValue);
 
     [Test]
-    public void UShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int) i.UShortValue + (int) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int) i.UShortValue + (int) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest01() =>
+      TestMax(i => i.ShortValue + i.ShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest02() =>
+      TestMax(i => (int) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.UShortValue + (long) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.UShortValue + (long) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest03() =>
+      TestMax(i => (int) i.UShortValue + (int) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest04() =>
+      TestMax(i => (long) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.UShortValue + (float) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.UShortValue + (float) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest05() =>
+      TestMax(i => (long) i.UShortValue + (long) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest06() =>
+      TestMax(i => (float) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.UShortValue + (double) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.UShortValue + (double) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest07() =>
+      TestMax(i => (float) i.UShortValue + (float) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest08() =>
+      TestMax(i => (double) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest09() =>
+      TestMax(i => (double) i.UShortValue + (double) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UShortValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UShortValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest10() =>
+      TestMax(i => (decimal) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UShortValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UShortValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest11() =>
+      TestMax(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UShortValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UShortValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest12() => TestMax(i => i.UShortValue + i.ByteValue);
 
     [Test]
-    public void UShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UShortValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UShortValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest13() => TestMax(i => i.UShortValue + i.IntValue);
 
     [Test]
-    public void UShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UShortValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UShortValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest14() => TestMax(i => i.UShortValue + i.LongValue);
 
     [Test]
-    public void UShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UShortValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UShortValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest15() => TestMax(i => i.UShortValue + i.FloatValue);
 
     [Test]
-    public void IntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest16() =>
+      TestMax(i => i.UShortValue + i.DoubleValue1);
 
     [Test]
-    public void IntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest17() =>
+      TestMax(i => i.UShortValue + i.DecimalValue);
 
     [Test]
-    public void IntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.IntValue * (long) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.IntValue * (long) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest01() =>
+      TestMax(i => i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest02() =>
+      TestMax(i => (long) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.IntValue * (float) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.IntValue * (float) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest03() =>
+      TestMax(i => (long) i.IntValue * (long) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest04() =>
+      TestMax(i => (float) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.IntValue * (double) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.IntValue * (double) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest05() =>
+      TestMax(i => (float) i.IntValue * (float) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest06() =>
+      TestMax(i => (double) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.IntValue * (decimal) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.IntValue * (decimal) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest07() =>
+      TestMax(i => (double) i.IntValue * (double) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.IntValue * i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.IntValue * i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest08() =>
+      TestMax(i => (decimal) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.IntValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.IntValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest09() =>
+      TestMax(i => (decimal) i.IntValue * (decimal) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.IntValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.IntValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest10() => TestMax(i => i.IntValue * i.ByteValue);
 
     [Test]
-    public void IntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.IntValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.IntValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest11() => TestMax(i => i.IntValue * i.LongValue);
 
     [Test]
-    public void IntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.IntValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.IntValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest12() => TestMax(i => i.IntValue * i.FloatValue);
 
     [Test]
-    public void UIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest13() => TestMax(i => i.IntValue * i.DoubleValue1);
 
     [Test]
-    public void UIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest14() => TestMax(i => i.IntValue * i.DecimalValue);
 
     [Test]
-    public void UIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long) i.UIntValue * (long) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long) i.UIntValue * (long) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest01() => TestMax(i => i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest02() =>
+      TestMax(i => (long) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.UIntValue * (float) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.UIntValue * (float) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest03() =>
+      TestMax(i => (long) i.UIntValue * (long) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest04() =>
+      TestMax(i => (float) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.UIntValue * (double) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.UIntValue * (double) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest05() =>
+      TestMax(i => (float) i.UIntValue * (float) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest06() =>
+      TestMax(i => (double) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest07() =>
+      TestMax(i => (double) i.UIntValue * (double) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UIntValue + i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UIntValue + i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest08() =>
+      TestMax(i => (decimal) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UIntValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UIntValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest09() =>
+      TestMax(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UIntValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UIntValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest10() => TestMax(i => i.UIntValue + i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UIntValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UIntValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest11() => TestMax(i => i.UIntValue * i.LongValue);
 
     [Test]
-    public void UIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.UIntValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.UIntValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest12() => TestMax(i => i.UIntValue * i.FloatValue);
 
     [Test]
-    public void LongFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest13() => TestMax(i => i.UIntValue * i.DoubleValue1);
 
     [Test]
-    public void LongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest14() => TestMax(i => i.UIntValue * i.DecimalValue);
 
     [Test]
-    public void LongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.LongValue * (float) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.LongValue * (float) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest01() => TestMax(i => i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest02() =>
+      TestMax(i => (float) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.LongValue * (double) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.LongValue * (double) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest03() =>
+      TestMax(i => (float) i.LongValue * (float) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest04() =>
+      TestMax(i => (double) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.LongValue * (decimal) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.LongValue * (decimal) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest05() =>
+      TestMax(i => (double) i.LongValue * (double) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.LongValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.LongValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest06() =>
+      TestMax(i => (decimal) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.LongValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.LongValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest07() =>
+      TestMax(i => (decimal) i.LongValue * (decimal) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.LongValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.LongValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest08() => TestMax(i => i.LongValue * i.FloatValue);
 
     [Test]
-    public void ULongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest09() => TestMax(i => i.LongValue * i.DoubleValue1);
 
     [Test]
-    public void ULongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float) i.ULongValue * (float) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.ULongValue * (float) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest10() => TestMax(i => i.LongValue * i.DecimalValue);
 
     [Test]
-    public void ULongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest02() =>
+      TestMax(i => (float) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.ULongValue * (double) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.ULongValue * (double) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest03() =>
+      TestMax(i => (float) i.ULongValue * (float) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest04() =>
+      TestMax(i => (double) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest05() =>
+      TestMax(i => (double) i.ULongValue * (double) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ULongValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ULongValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest06() =>
+      TestMax(i => (decimal) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ULongValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ULongValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest07() =>
+      TestMax(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.ULongValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.ULongValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest08() => TestMax(i => i.ULongValue * i.FloatValue);
 
     [Test]
-    public void FloatFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.FloatValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.FloatValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ULongFieldExpressionTest09() => TestMax(i => i.ULongValue * i.DoubleValue1);
 
     [Test]
-    public void FloatFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.FloatValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.FloatValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ULongFieldExpressionTest10() => TestMax(i => i.ULongValue * i.DecimalValue);
 
     [Test]
-    public void FloatFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.FloatValue * (double) i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.FloatValue * (double) i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest01() =>
+      TestMaxWithAccuracy(i => i.FloatValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.FloatValue * (decimal) i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.FloatValue * (decimal) i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest02() =>
+      TestMaxWithAccuracy(i => (double) i.FloatValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.FloatValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.FloatValue * i.DoubleValue1);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest03() =>
+      TestMaxWithAccuracy(i => (double) i.FloatValue * (double) i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.FloatValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.FloatValue * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest04() =>
+      TestMaxWithAccuracy(i => (decimal) i.FloatValue * (decimal) i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void DoubleFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.DoubleValue1 * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.DoubleValue1 * i.DoubleValue1);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(DoubleValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest05() =>
+      TestMaxWithAccuracy(i => i.FloatValue * i.DoubleValue1, FloatValueAccuracy);
 
     [Test]
-    public void DoubleFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal) i.DoubleValue1 * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal) i.DoubleValue1 * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(DoubleValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest06() =>
+      TestMaxWithAccuracy(i => (decimal) i.FloatValue * i.DecimalValue, FloatValueAccuracy);
 
     [Test]
-    public void DecimalFieldExpressionTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.DecimalValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.DecimalValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DoubleFieldExpressionTest01() =>
+      TestMaxWithAccuracy(i => i.DoubleValue1 * i.DoubleValue1, DoubleValueAccuracy);
 
     [Test]
-    public void NullableByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DoubleFieldExpressionTest02() =>
+      TestMaxWithAccuracy(i => (decimal) i.DoubleValue1 * i.DecimalValue, DoubleValueAccuracy);
 
     [Test]
-    public void NullableByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (short?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (short?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DecimalFieldExpressionTest() =>
+      TestMax(i => i.DecimalValue * i.DecimalValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest01() =>
+      TestMax(i => i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest02() =>
+      TestMax(i => (short?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest03() =>
+      TestMax(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest04() =>
+      TestMax(i => (int?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest05() =>
+      TestMax(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.ByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest06() =>
+      TestMax(i => (long?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest07() =>
+      TestMax(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest08() =>
+      TestMax(i => (float?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double) i.ByteValue + (double) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double) i.ByteValue + (double) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest09() =>
+      TestMax(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest10() =>
+      TestMax(i => (double?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest11() =>
+      TestMax(i => (double) i.ByteValue + (double) i.ByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableByteValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableByteValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest12() =>
+      TestMax(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableByteValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableByteValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest13() =>
+      TestMax(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableByteValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableByteValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest14() =>
+      TestMax(i => i.NullableByteValue + i.NullableIntValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableByteValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableByteValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest15() =>
+      TestMax(i => i.NullableByteValue + i.NullableLongValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableByteValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableByteValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest16() =>
+      TestMax(i => i.NullableByteValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest17() =>
+      TestMax(i => i.NullableByteValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableSByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest18() =>
+      TestMax(i => i.NullableByteValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest01() =>
+      TestMax(i => i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest02() =>
+      TestMax(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest03() =>
+      TestMax(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest04() =>
+      TestMax(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest05() =>
+      TestMax(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest06() =>
+      TestMax(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest07() =>
+      TestMax(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest08() =>
+      TestMax(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest09() =>
+      TestMax(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest10() =>
+      TestMax(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest11() =>
+      TestMax(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableSByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableSByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest12() =>
+      TestMax(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableSByteValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableSByteValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest13() =>
+      TestMax(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableSByteValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableSByteValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest14() =>
+      TestMax(i => i.NullableSByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableSByteValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableSByteValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest15() =>
+      TestMax(i => i.NullableSByteValue + i.NullableIntValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableSByteValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableSByteValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest16() =>
+      TestMax(i => i.NullableSByteValue + i.NullableLongValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest19()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableSByteValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableSByteValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest17() =>
+      TestMax(i => i.NullableSByteValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest18() =>
+      TestMax(i => i.NullableSByteValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest19() =>
+      TestMax(i => i.NullableSByteValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest01() =>
+      TestMax(i => i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest02() =>
+      TestMax(i => (int?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest03() =>
+      TestMax(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest04() =>
+      TestMax(i => (long?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableShortValue + (float?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float) i.ShortValue + (float?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest05() =>
+      TestMax(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest06() =>
+      TestMax(i => (float?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest07() =>
+      TestMax(i => (float?) i.NullableShortValue + (float?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest08() =>
+      TestMax(i => (double?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest09() =>
+      TestMax(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableShortValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableShortValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest10() =>
+      TestMax(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableShortValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableShortValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest11() =>
+      TestMax(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableShortValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableShortValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest12() =>
+      TestMax(i => i.NullableShortValue + i.NullableByteValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableShortValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableShortValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest13() =>
+      TestMax(i => i.NullableShortValue + i.NullableIntValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableShortValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableShortValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest14() =>
+      TestMax(i => i.NullableShortValue + i.NullableLongValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableShortValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableShortValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest15() =>
+      TestMax(i => i.NullableShortValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest16() =>
+      TestMax(i => i.NullableShortValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableUShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest17() =>
+      TestMax(i => i.NullableShortValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest01() =>
+      TestMax(i => i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest02() =>
+      TestMax(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest03() =>
+      TestMax(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest04() =>
+      TestMax(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest05() =>
+      TestMax(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest06() =>
+      TestMax(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest07() =>
+      TestMax(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest08() =>
+      TestMax(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest09() =>
+      TestMax(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUShortValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUShortValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest10() =>
+      TestMax(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUShortValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUShortValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest11() =>
+      TestMax(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUShortValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUShortValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest12() =>
+      TestMax(i => i.NullableUShortValue + i.NullableByteValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUShortValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUShortValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest13() =>
+      TestMax(i => i.NullableUShortValue + i.NullableIntValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUShortValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUShortValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest14() =>
+      TestMax(i => i.NullableUShortValue + i.NullableLongValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUShortValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUShortValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest15() =>
+      TestMax(i => i.NullableUShortValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest16() =>
+      TestMax(i => i.NullableUShortValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest17() =>
+      TestMax(i => i.NullableUShortValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest01() =>
+      TestMax(i => i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest02() =>
+      TestMax(i => (long?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest03() =>
+      TestMax(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest04() =>
+      TestMax(i => (float?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest05() =>
+      TestMax(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest06() =>
+      TestMax(i => (double?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest07() =>
+      TestMax(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableIntValue * i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableIntValue * i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest08() =>
+      TestMax(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableIntValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableIntValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest09() =>
+      TestMax(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableIntValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableIntValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest10() =>
+      TestMax(i => i.NullableIntValue * i.NullableByteValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableIntValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableIntValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest11() =>
+      TestMax(i => i.NullableIntValue * i.NullableLongValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableIntValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableIntValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest12() =>
+      TestMax(i => i.NullableIntValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest13() =>
+      TestMax(i => i.NullableIntValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableUIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest14() =>
+      TestMax(i => i.NullableIntValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest01() =>
+      TestMax(i => i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest02() =>
+      TestMax(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest03() =>
+      TestMax(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest04() =>
+      TestMax(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest05() =>
+      TestMax(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest06() =>
+      TestMax(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest07() =>
+      TestMax(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUIntValue + i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUIntValue + i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest08() =>
+      TestMax(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUIntValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUIntValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest09() =>
+      TestMax(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUIntValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUIntValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest10() =>
+      TestMax(i => i.NullableUIntValue + i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUIntValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUIntValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest11() =>
+      TestMax(i => i.NullableUIntValue * i.NullableLongValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableUIntValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableUIntValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest12() =>
+      TestMax(i => i.NullableUIntValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest13() =>
+      TestMax(i => i.NullableUIntValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableLongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest14() =>
+      TestMax(i => i.NullableUIntValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest01() =>
+      TestMax(i => i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest02() =>
+      TestMax(i => (float?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest03() =>
+      TestMax(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest04() =>
+      TestMax(i => (double?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest05() =>
+      TestMax(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableLongValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableLongValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest06() =>
+      TestMax(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableLongValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableLongValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest07() =>
+      TestMax(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableLongValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableLongValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest08() =>
+      TestMax(i => i.NullableLongValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest09() =>
+      TestMax(i => i.NullableLongValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableULongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest10() =>
+      TestMax(i => i.NullableLongValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest02() =>
+      TestMax(i => (float?) i.NullableULongValue * i.NullableULongValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest03() =>
+      TestMax(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest04() =>
+      TestMax(i => (double?) i.NullableULongValue * i.NullableULongValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest05() =>
+      TestMax(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableULongValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableULongValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest06() =>
+      TestMax(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableULongValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableULongValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest07() =>
+      TestMax(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableULongValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableULongValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest08() =>
+      TestMax(i => i.NullableULongValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableFloatFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableFloatValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableFloatValue * i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableULongFieldExpressionTest09() =>
+      TestMax(i => i.NullableULongValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableFloatFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableFloatValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableFloatValue * i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableULongFieldExpressionTest10() =>
+      TestMax(i => i.NullableULongValue * i.NullableDecimalValue);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest01() =>
+      TestMaxWithAccuracy(i => i.NullableFloatValue * i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest02() =>
+      TestMaxWithAccuracy(i => (double?) i.NullableFloatValue * i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest03() =>
+      TestMaxWithAccuracy(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest04() =>
+      TestMaxWithAccuracy(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableFloatFieldExpressionTest03()
+    public void NullableFloatFieldExpressionTest05() =>
+      TestMaxWithAccuracy(i => i.NullableFloatValue * i.NullableDoubleValue1, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest06() =>
+      TestMaxWithAccuracy(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableDoubleFieldExpressionTest01() =>
+      TestMax(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
+
+    [Test]
+    public void NullableDoubleFieldExpressionTest02() =>
+      TestMax(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
+
+    [Test]
+    public void NullableDecimalFieldExpressionTest() =>
+      TestMax(i => i.NullableDecimalValue * i.NullableDecimalValue);
+
+
+    private void TestMax<TResult>(Expression<Func<TestEntity, TResult>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Max(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Max(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Max(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Max()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Max(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest04()
+    private void TestMaxWithAccuracy<TAccuracy>(Expression<Func<TestEntity, float>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Max(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Max(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Max(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Max()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Max(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest05()
+    private void TestMaxWithAccuracy<TAccuracy>(Expression<Func<TestEntity, float?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableFloatValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableFloatValue * i.NullableDoubleValue1);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Max(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Max(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Max(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Max()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Max(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest06()
+    private void TestMaxWithAccuracy<TAccuracy>(Expression<Func<TestEntity, double>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Max(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Max(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Max(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Max()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Max(t => t)");
     }
 
-    [Test]
-    public void NullableDoubleFieldExpressionTest01()
+    private void TestMaxWithAccuracy<TAccuracy>(Expression<Func<TestEntity, double?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Max(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Max(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Max(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Max()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Max(t => t)");
     }
 
-    [Test]
-    public void NullableDoubleFieldExpressionTest02()
+    private void TestMaxWithAccuracy<TAccuracy>(Expression<Func<TestEntity, decimal>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Max(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Max(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Max(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Max()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Max(t => t)");
     }
 
-    [Test]
-    public void NullableDecimalFieldExpressionTest()
+    private void TestMaxWithAccuracy<TAccuracy>(Expression<Func<TestEntity, decimal?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Max(i => i.NullableDecimalValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Max(i => i.NullableDecimalValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Max(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Max(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Max(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Max()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Max(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Max(t => t)");
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/MinProcessingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/MinProcessingTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Xtensive LLC.
+// Copyright (C) 2020-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
@@ -7,3023 +7,1134 @@
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Xtensive.Orm.Tests.Issues.IssueJira0786_AggregatesProblem
 {
   public sealed class MinProcessingTest : AggregatesProblemTestBase
   {
     [Test]
-    public void ByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldTest() => TestMin(i => i.ByteValue);
 
     [Test]
-    public void SByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldTest() => TestMin(i => i.SByteValue);
 
     [Test]
-    public void ShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldTest() => TestMin(i => i.ShortValue);
 
     [Test]
-    public void UShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldTest() => TestMin(i => i.UShortValue);
 
     [Test]
-    public void IntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldTest() => TestMin(i => i.IntValue);
 
     [Test]
-    public void UIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldTest() => TestMin(i => i.UIntValue);
 
     [Test]
-    public void LongFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldTest() => TestMin(i => i.LongValue);
 
     [Test]
-    public void FloatFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldTest() => TestMin(i => i.ULongValue);
 
     [Test]
-    public void DoubleFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void FloatFieldTest() => TestMin(i => i.FloatValue);
 
     [Test]
-    public void DecimalFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DoubleFieldTest() => TestMin(i => i.DoubleValue1);
 
     [Test]
-    public void NullableByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DecimalFieldTest() => TestMin(i => i.DecimalValue);
 
     [Test]
-    public void NullableSByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldTest() => TestMin(i => i.NullableByteValue);
 
     [Test]
-    public void NullableShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldTest() => TestMin(i => i.NullableSByteValue);
 
     [Test]
-    public void NullableUShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldTest() => TestMin(i => i.NullableShortValue);
 
     [Test]
-    public void NullableIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldTest() => TestMin(i => i.NullableUShortValue);
 
     [Test]
-    public void NullableUIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldTest() => TestMin(i => i.NullableByteValue);
 
     [Test]
-    public void NullableLongFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldTest() => TestMin(i => i.NullableUIntValue);
 
     [Test]
-    public void NullableFloatFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldTest() => TestMin(i => i.NullableByteValue);
 
     [Test]
-    public void NullableDoubleFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableFloatFieldTest() => TestMin(i => i.NullableFloatValue);
 
     [Test]
-    public void NullableDecimalFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableDoubleFieldTest() => TestMin(i => i.NullableDoubleValue1);
 
     [Test]
-    public void ByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableDecimalFieldTest() => TestMin(i => i.NullableDecimalValue);
 
     [Test]
-    public void ByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (short) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (short) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest01() => TestMin(i => i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (short) i.ByteValue + (short) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (short) i.ByteValue + (short) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest02() =>
+      TestMin(i => (short) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest03() =>
+      TestMin(i => (short) i.ByteValue + (short) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int) i.ByteValue + (int) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int) i.ByteValue + (int) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest04() =>
+      TestMin(i => (int) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest05() =>
+      TestMin(i => (int) i.ByteValue + (int) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.ByteValue + (long) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.ByteValue + (long) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest06() =>
+      TestMin(i => (long) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest07() =>
+      TestMin(i => (long) i.ByteValue + (long) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.ByteValue + (float) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.ByteValue + (float) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest08() =>
+      TestMin(i => (float) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest09() =>
+      TestMin(i => (float) i.ByteValue + (float) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.ByteValue + (double) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.ByteValue + (double) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest10() =>
+      TestMin(i => (double) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest11() =>
+      TestMin(i => (double) i.ByteValue + (double) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest12() =>
+      TestMin(i => (decimal) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ByteValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ByteValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest13() =>
+      TestMin(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ByteValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ByteValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest14() => TestMin(i => i.ByteValue + i.IntValue);
 
     [Test]
-    public void ByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ByteValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ByteValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest15() => TestMin(i => i.ByteValue + i.LongValue);
 
     [Test]
-    public void ByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ByteValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ByteValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest16() => TestMin(i => i.ByteValue + i.FloatValue);
 
     [Test]
-    public void ByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ByteValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ByteValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest17() => TestMin(i => i.ByteValue + i.DoubleValue1);
 
     [Test]
-    public void SByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest18() => TestMin(i => i.ByteValue + i.DecimalValue);
 
     [Test]
-    public void SByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (short) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (short) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest01() => TestMin(i => i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (short) i.SByteValue + (short) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (short) i.SByteValue + (short) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest02() =>
+      TestMin(i => (short) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest03() =>
+      TestMin(i => (short) i.SByteValue + (short) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int) i.SByteValue + (int) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int) i.SByteValue + (int) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest04() =>
+      TestMin(i => (int) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest05() =>
+      TestMin(i => (int) i.SByteValue + (int) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.SByteValue + (long) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.SByteValue + (long) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest06() =>
+      TestMin(i => (long) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest07() =>
+      TestMin(i => (long) i.SByteValue + (long) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.SByteValue + (float) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.SByteValue + (float) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest08() =>
+      TestMin(i => (float) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest09() =>
+      TestMin(i => (float) i.SByteValue + (float) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.SByteValue + (double) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.SByteValue + (double) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest10() =>
+      TestMin(i => (double) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest11() =>
+      TestMin(i => (double) i.SByteValue + (double) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest12() =>
+      TestMin(i => (decimal) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.SByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.SByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest13() =>
+      TestMin(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.SByteValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.SByteValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest14() => TestMin(i => i.SByteValue + i.ByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.SByteValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.SByteValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest15() => TestMin(i => i.SByteValue + i.IntValue);
 
     [Test]
-    public void SByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.SByteValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.SByteValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest16() => TestMin(i => i.SByteValue + i.LongValue);
 
     [Test]
-    public void SByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.SByteValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.SByteValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest17() => TestMin(i => i.SByteValue + i.FloatValue);
 
     [Test]
-    public void SByteFieldExpressionTest19()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.SByteValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.SByteValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest18() => TestMin(i => i.SByteValue + i.DoubleValue1);
 
     [Test]
-    public void ShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest19() => TestMin(i => i.SByteValue + i.DecimalValue);
 
     [Test]
-    public void ShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest01() => TestMin(i => i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int) i.ShortValue + (int) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int) i.ShortValue + (int) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest02() =>
+      TestMin(i => (int) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest03() =>
+      TestMin(i => (int) i.ShortValue + (int) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.ShortValue + (long) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.ShortValue + (long) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest04() =>
+      TestMin(i => (long) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest05() =>
+      TestMin(i => (long) i.ShortValue + (long) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.ShortValue + (float) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.ShortValue + (float) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest06() =>
+      TestMin(i => (float) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest07() =>
+      TestMin(i => (float) i.ShortValue + (float) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.ShortValue + (double) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.ShortValue + (double) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest08() =>
+      TestMin(i => (double) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest09() =>
+      TestMin(i => (double) i.ShortValue + (double) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest10() =>
+      TestMin(i => (decimal) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ShortValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ShortValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest11() =>
+      TestMin(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ShortValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ShortValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest12() => TestMin(i => i.ShortValue + i.ByteValue);
 
     [Test]
-    public void ShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ShortValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ShortValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest13() => TestMin(i => i.ShortValue + i.IntValue);
 
     [Test]
-    public void ShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ShortValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ShortValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest14() => TestMin(i => i.ShortValue + i.LongValue);
 
     [Test]
-    public void ShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ShortValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ShortValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest15() => TestMin(i => i.ShortValue + i.FloatValue);
 
     [Test]
-    public void ShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ShortValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ShortValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest16() => TestMin(i => i.ShortValue + i.DoubleValue1);
 
     [Test]
-    public void UShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest17() => TestMin(i => i.ShortValue + i.DecimalValue);
 
     [Test]
-    public void UShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest01() => TestMin(i => i.ShortValue + i.ShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int) i.UShortValue + (int) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int) i.UShortValue + (int) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest02() =>
+      TestMin(i => (int) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest03() =>
+      TestMin(i => (int) i.UShortValue + (int) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.UShortValue + (long) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.UShortValue + (long) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest04() =>
+      TestMin(i => (long) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest05() =>
+      TestMin(i => (long) i.UShortValue + (long) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.UShortValue + (float) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.UShortValue + (float) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest06() =>
+      TestMin(i => (float) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest07() =>
+      TestMin(i => (float) i.UShortValue + (float) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.UShortValue + (double) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.UShortValue + (double) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest08() =>
+      TestMin(i => (double) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest09() =>
+      TestMin(i => (double) i.UShortValue + (double) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest10() =>
+      TestMin(i => (decimal) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UShortValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UShortValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest11() =>
+      TestMin(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UShortValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UShortValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest12() => TestMin(i => i.UShortValue + i.ByteValue);
 
     [Test]
-    public void UShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UShortValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UShortValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest13() => TestMin(i => i.UShortValue + i.IntValue);
 
     [Test]
-    public void UShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UShortValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UShortValue + i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest14() => TestMin(i => i.UShortValue + i.LongValue);
 
     [Test]
-    public void UShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UShortValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UShortValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest15() => TestMin(i => i.UShortValue + i.FloatValue);
 
     [Test]
-    public void UShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UShortValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UShortValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest16() => TestMin(i => i.UShortValue + i.DoubleValue1);
 
     [Test]
-    public void IntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest17() => TestMin(i => i.UShortValue + i.DecimalValue);
 
     [Test]
-    public void IntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest01() => TestMin(i => i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.IntValue * (long) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.IntValue * (long) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest02() =>
+      TestMin(i => (long) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest03() =>
+      TestMin(i => (long) i.IntValue * (long) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.IntValue * (float) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.IntValue * (float) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest04() =>
+      TestMin(i => (float) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest05() =>
+      TestMin(i => (float) i.IntValue * (float) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.IntValue * (double) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.IntValue * (double) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest06() =>
+      TestMin(i => (double) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest07() =>
+      TestMin(i => (double) i.IntValue * (double) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.IntValue * (decimal) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.IntValue * (decimal) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest08() =>
+      TestMin(i => (decimal) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.IntValue * i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.IntValue * i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest09() =>
+      TestMin(i => (decimal) i.IntValue * (decimal) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.IntValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.IntValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest10() => TestMin(i => i.IntValue * i.ByteValue);
 
     [Test]
-    public void IntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.IntValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.IntValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest11() => TestMin(i => i.IntValue * i.LongValue);
 
     [Test]
-    public void IntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.IntValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.IntValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest12() => TestMin(i => i.IntValue * i.FloatValue);
 
     [Test]
-    public void IntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.IntValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.IntValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest13() => TestMin(i => i.IntValue * i.DoubleValue1);
 
     [Test]
-    public void UIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest14() => TestMin(i => i.IntValue * i.DecimalValue);
 
     [Test]
-    public void UIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest01() => TestMin(i => i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long) i.UIntValue * (long) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long) i.UIntValue * (long) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest02() =>
+      TestMin(i => (long) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest03() =>
+      TestMin(i => (long) i.UIntValue * (long) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.UIntValue * (float) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.UIntValue * (float) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest04() =>
+      TestMin(i => (float) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest05() =>
+      TestMin(i => (float) i.UIntValue * (float) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.UIntValue * (double) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.UIntValue * (double) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest06() =>
+      TestMin(i => (double) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest07() =>
+      TestMin(i => (double) i.UIntValue * (double) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest08() =>
+      TestMin(i => (decimal) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UIntValue + i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UIntValue + i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest09() =>
+      TestMin(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UIntValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UIntValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest10() => TestMin(i => i.UIntValue + i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UIntValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UIntValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest11() => TestMin(i => i.UIntValue * i.LongValue);
 
     [Test]
-    public void UIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UIntValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UIntValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest12() => TestMin(i => i.UIntValue * i.FloatValue);
 
     [Test]
-    public void UIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.UIntValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.UIntValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest13() => TestMin(i => i.UIntValue * i.DoubleValue1);
 
     [Test]
-    public void LongFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest14() => TestMin(i => i.UIntValue * i.DecimalValue);
 
     [Test]
-    public void LongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest01() => TestMin(i => i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.LongValue * (float) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.LongValue * (float) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest02() =>
+      TestMin(i => (float) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest03() =>
+      TestMin(i => (float) i.LongValue * (float) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.LongValue * (double) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.LongValue * (double) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest04() =>
+      TestMin(i => (double) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest05() =>
+      TestMin(i => (double) i.LongValue * (double) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.LongValue * (decimal) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.LongValue * (decimal) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest06() =>
+      TestMin(i => (decimal) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.LongValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.LongValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest07() =>
+      TestMin(i => (decimal) i.LongValue * (decimal) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.LongValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.LongValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest08() => TestMin(i => i.LongValue * i.FloatValue);
 
     [Test]
-    public void LongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.LongValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.LongValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest09() => TestMin(i => i.LongValue * i.DoubleValue1);
 
     [Test]
-    public void ULongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest10() => TestMin(i => i.LongValue * i.DecimalValue);
 
     [Test]
-    public void ULongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float) i.ULongValue * (float) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.ULongValue * (float) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest02() =>
+      TestMin(i => (float) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest03() =>
+      TestMin(i => (float) i.ULongValue * (float) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.ULongValue * (double) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.ULongValue * (double) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest04() =>
+      TestMin(i => (double) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest05() =>
+      TestMin(i => (double) i.ULongValue * (double) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest06() =>
+      TestMin(i => (decimal) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ULongValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ULongValue * i.FloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest07() =>
+      TestMin(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ULongValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ULongValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest08() => TestMin(i => i.ULongValue * i.FloatValue);
 
     [Test]
-    public void ULongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.ULongValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.ULongValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest09() => TestMin(i => i.ULongValue * i.DoubleValue1);
 
     [Test]
-    public void FloatFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.FloatValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.FloatValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ULongFieldExpressionTest10() =>
+      TestMin(i => i.ULongValue * i.DecimalValue);
 
     [Test]
-    public void FloatFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.FloatValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.FloatValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest01() =>
+      TestMinWithAccuracy(i => i.FloatValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.FloatValue * (double) i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.FloatValue * (double) i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest02() =>
+      TestMinWithAccuracy(i => (double) i.FloatValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.FloatValue * (decimal) i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.FloatValue * (decimal) i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest03() =>
+      TestMinWithAccuracy(i => (double) i.FloatValue * (double) i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.FloatValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.FloatValue * i.DoubleValue1);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest04() =>
+      TestMinWithAccuracy(i => (decimal) i.FloatValue * (decimal) i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.FloatValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.FloatValue * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest05() =>
+      TestMinWithAccuracy(i => i.FloatValue * i.DoubleValue1, FloatValueAccuracy);
 
     [Test]
-    public void DoubleFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.DoubleValue1 * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.DoubleValue1 * i.DoubleValue1);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(DoubleValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest06() =>
+      TestMinWithAccuracy(i => (decimal) i.FloatValue * i.DecimalValue, FloatValueAccuracy);
 
     [Test]
-    public void DoubleFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal) i.DoubleValue1 * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal) i.DoubleValue1 * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(DoubleValueAccuracy));
-      }
-    }
+    public void DoubleFieldExpressionTest01() =>
+      TestMinWithAccuracy(i => i.DoubleValue1 * i.DoubleValue1, DoubleValueAccuracy);
 
     [Test]
-    public void DecimalFieldExpressionTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.DecimalValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.DecimalValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DoubleFieldExpressionTest02() =>
+      TestMinWithAccuracy(i => (decimal) i.DoubleValue1 * i.DecimalValue, DoubleValueAccuracy);
 
     [Test]
-    public void NullableByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DecimalFieldExpressionTest() => TestMin(i => i.DecimalValue * i.DecimalValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (short?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (short?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest01() =>
+      TestMin(i => i.NullableByteValue + i.NullableByteValue);
+
+    [Test]
+    public void NullableByteFieldExpressionTest02() =>
+      TestMin(i => (short?) i.NullableByteValue + i.NullableByteValue);
+
+    [Test]
+    public void NullableByteFieldExpressionTest03() =>
+      TestMin(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
+
+    [Test]
+    public void NullableByteFieldExpressionTest04() =>
+      TestMin(i => (int?) i.NullableByteValue + i.NullableByteValue);
+
+    [Test]
+    public void NullableByteFieldExpressionTest05() =>
+      TestMin(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
+
+    [Test]
+    public void NullableByteFieldExpressionTest06() =>
+      TestMin(i => (long?) i.NullableByteValue + i.NullableByteValue);
+
+    [Test]
+    public void NullableByteFieldExpressionTest07() =>
+      TestMin(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
+
+    [Test]
+    public void NullableByteFieldExpressionTest08() =>
+      TestMin(i => (float?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest09() =>
+      TestMin(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest10() =>
+      TestMin(i => (double?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest11() =>
+      TestMin(i => (double) i.ByteValue + (double) i.ByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest12() =>
+      TestMin(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest13() =>
+      TestMin(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.ByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest14() =>
+      TestMin(i => i.NullableByteValue + i.NullableIntValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest15() =>
+      TestMin(i => i.NullableByteValue + i.NullableLongValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest16() =>
+      TestMin(i => i.NullableByteValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double) i.ByteValue + (double) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double) i.ByteValue + (double) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest17() =>
+      TestMin(i => i.NullableByteValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest18() =>
+      TestMin(i => i.NullableByteValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest01() =>
+      TestMin(i => i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableByteValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableByteValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest02() =>
+      TestMin(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableByteValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableByteValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest03() =>
+      TestMin(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableByteValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableByteValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest04() =>
+      TestMin(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableByteValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableByteValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest05() =>
+      TestMin(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableByteValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableByteValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest06() =>
+      TestMin(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest07() =>
+      TestMin(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest08() =>
+      TestMin(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest09() =>
+      TestMin(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest10() =>
+      TestMin(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest11() =>
+      TestMin(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest12() =>
+      TestMin(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest13() =>
+      TestMin(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest14() =>
+      TestMin(i => i.NullableSByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest15() =>
+      TestMin(i => i.NullableSByteValue + i.NullableIntValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest16() =>
+      TestMin(i => i.NullableSByteValue + i.NullableLongValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest17() =>
+      TestMin(i => i.NullableSByteValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest18() =>
+      TestMin(i => i.NullableSByteValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableSByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest19() =>
+      TestMin(i => i.NullableSByteValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableSByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableSByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest01() =>
+      TestMin(i => i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableSByteValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableSByteValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest02() =>
+      TestMin(i => (int?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableSByteValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableSByteValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest03() =>
+      TestMin(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableSByteValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableSByteValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest04() =>
+      TestMin(i => (long?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableSByteValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableSByteValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest05() =>
+      TestMin(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest19()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableSByteValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableSByteValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest06() =>
+      TestMin(i => (float?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest07() =>
+      TestMin(i => (float?) i.NullableShortValue + (float?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest08() =>
+      TestMin(i => (double?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest09() =>
+      TestMin(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest10() =>
+      TestMin(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest11() =>
+      TestMin(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest12() =>
+      TestMin(i => i.NullableShortValue + i.NullableByteValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableShortValue + (float?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float) i.ShortValue + (float?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest13() =>
+      TestMin(i => i.NullableShortValue + i.NullableIntValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest14() =>
+      TestMin(i => i.NullableShortValue + i.NullableLongValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest15() =>
+      TestMin(i => i.NullableShortValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest16() =>
+      TestMin(i => i.NullableShortValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest17() =>
+      TestMin(i => i.NullableShortValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableShortValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableShortValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest01() =>
+      TestMin(i => i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableShortValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableShortValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest02() =>
+      TestMin(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableShortValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableShortValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest03() =>
+      TestMin(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableShortValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableShortValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest04() =>
+      TestMin(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableShortValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableShortValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest05() =>
+      TestMin(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableShortValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableShortValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest06() =>
+      TestMin(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest07() =>
+      TestMin(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest08() =>
+      TestMin(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest09() =>
+      TestMin(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest10() =>
+      TestMin(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest11() =>
+      TestMin(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest12() =>
+      TestMin(i => i.NullableUShortValue + i.NullableByteValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest13() =>
+      TestMin(i => i.NullableUShortValue + i.NullableIntValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest14() =>
+      TestMin(i => i.NullableUShortValue + i.NullableLongValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest15() =>
+      TestMin(i => i.NullableUShortValue + i.NullableFloatValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest16() =>
+      TestMin(i => i.NullableUShortValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableUShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest17() =>
+      TestMin(i => i.NullableUShortValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUShortValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUShortValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest01() =>
+      TestMin(i => i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUShortValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUShortValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest02() =>
+      TestMin(i => (long?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUShortValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUShortValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest03() =>
+      TestMin(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUShortValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUShortValue + i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest04() =>
+      TestMin(i => (float?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUShortValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUShortValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest05() =>
+      TestMin(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUShortValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUShortValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest06() =>
+      TestMin(i => (double?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest07() =>
+      TestMin(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest08() =>
+      TestMin(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest09() =>
+      TestMin(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest10() =>
+      TestMin(i => i.NullableIntValue * i.NullableByteValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest11() =>
+      TestMin(i => i.NullableIntValue * i.NullableLongValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest12() =>
+      TestMin(i => i.NullableIntValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest13() =>
+      TestMin(i => i.NullableIntValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest14() =>
+      TestMin(i => i.NullableIntValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest01() =>
+      TestMin(i => i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableIntValue * i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableIntValue * i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest02() =>
+      TestMin(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableIntValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableIntValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest03() =>
+      TestMin(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableIntValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableIntValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest04() =>
+      TestMin(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableIntValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableIntValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest05() =>
+      TestMin(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableIntValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableIntValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest06() =>
+      TestMin(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest07() =>
+      TestMin(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest08() =>
+      TestMin(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest09() =>
+      TestMin(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest10() =>
+      TestMin(i => i.NullableUIntValue + i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest11() =>
+      TestMin(i => i.NullableUIntValue * i.NullableLongValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest12() =>
+      TestMin(i => i.NullableUIntValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest13() =>
+      TestMin(i => i.NullableUIntValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableUIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest14() =>
+      TestMin(i => i.NullableUIntValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest01() =>
+      TestMin(i => i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUIntValue + i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUIntValue + i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest02() =>
+      TestMin(i => (float?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUIntValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUIntValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest03() =>
+      TestMin(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUIntValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUIntValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest04() =>
+      TestMin(i => (double?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUIntValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUIntValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest05() =>
+      TestMin(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableUIntValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableUIntValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest06() =>
+      TestMin(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest07() =>
+      TestMin(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest08() =>
+      TestMin(i => i.NullableLongValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest09() =>
+      TestMin(i => i.NullableLongValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableLongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest10() =>
+      TestMin(i => i.NullableLongValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest02() =>
+      TestMin(i => (float?) i.NullableULongValue * i.NullableULongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest03() =>
+      TestMin(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest04() =>
+      TestMin(i => (double?) i.NullableULongValue * i.NullableULongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableLongValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableLongValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest05() =>
+      TestMin(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableLongValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableLongValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest06() =>
+      TestMin(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableLongValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableLongValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest07() =>
+      TestMin(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest08() =>
+      TestMin(i => i.NullableULongValue * i.NullableFloatValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest09() =>
+      TestMin(i => i.NullableULongValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableULongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableULongFieldExpressionTest10() =>
+      TestMin(i => i.NullableULongValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableFloatFieldExpressionTest01() =>
+      TestMinWithAccuracy(i => i.NullableFloatValue * i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableULongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableFloatFieldExpressionTest02() =>
+      TestMinWithAccuracy(i => (double?) i.NullableFloatValue * i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableULongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableFloatFieldExpressionTest03() =>
+      TestMinWithAccuracy(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableULongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableULongValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableULongValue * i.NullableFloatValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableFloatFieldExpressionTest04() =>
+      TestMinWithAccuracy(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableULongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableULongValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableULongValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableFloatFieldExpressionTest05() =>
+      TestMinWithAccuracy(i => i.NullableFloatValue * i.NullableDoubleValue1, FloatValueAccuracy);
 
     [Test]
-    public void NullableULongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableULongValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableULongValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableFloatFieldExpressionTest06() =>
+      TestMinWithAccuracy(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableFloatFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableFloatValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableFloatValue * i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableDoubleFieldExpressionTest01() =>
+      TestMin(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableFloatFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableFloatValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableFloatValue * i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableDoubleFieldExpressionTest02() =>
+      TestMin(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
 
     [Test]
-    public void NullableFloatFieldExpressionTest03()
+    public void NullableDecimalFieldExpressionTest() =>
+      TestMin(i => i.NullableDecimalValue * i.NullableDecimalValue);
+
+    private void TestMin<TResult>(Expression<Func<TestEntity, TResult>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Min(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Min(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Min(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Min()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Min(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest04()
+    private void TestMinWithAccuracy<TAccuracy>(Expression<Func<TestEntity, float>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Min(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Min(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Min(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Min()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Min(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest05()
+    private void TestMinWithAccuracy<TAccuracy>(Expression<Func<TestEntity, float?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableFloatValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableFloatValue * i.NullableDoubleValue1);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Min(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Min(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Min(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Min()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Min(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest06()
+    private void TestMinWithAccuracy<TAccuracy>(Expression<Func<TestEntity, double>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Min(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Min(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Min(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Min()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Min(t => t)");
     }
 
-    [Test]
-    public void NullableDoubleFieldExpressionTest01()
+    private void TestMinWithAccuracy<TAccuracy>(Expression<Func<TestEntity, double?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Min(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Min(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Min(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Min()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Min(t => t)");
     }
 
-    [Test]
-    public void NullableDoubleFieldExpressionTest02()
+    private void TestMinWithAccuracy<TAccuracy>(Expression<Func<TestEntity, decimal>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Min(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Min(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Min(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Min()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Min(t => t)");
     }
 
-    [Test]
-    public void NullableDecimalFieldExpressionTest()
+    private void TestMinWithAccuracy<TAccuracy>(Expression<Func<TestEntity, decimal?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Min(i => i.NullableDecimalValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Min(i => i.NullableDecimalValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Min(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Min(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Min(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Min()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Min(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Min(t => t)");
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/Model.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/Model.cs
@@ -88,5 +88,10 @@ namespace Xtensive.Orm.Tests.Issues.IssueJira0786_AggregatesProblem
 
     [Field(Precision = 20, Scale = 1)]
     public decimal? NullableDecimalValue { get; set; }
+
+    public TestEntity(Session session)
+      : base(session)
+    {
+    }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/SumProcessingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/SumProcessingTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Xtensive LLC.
+// Copyright (C) 2020-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov
@@ -7,3075 +7,1261 @@
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Xtensive.Orm.Tests.Issues.IssueJira0786_AggregatesProblem
 {
   public sealed class SumProcessingTest : AggregatesProblemTestBase
   {
     [Test]
-    public void ByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldTest() => TestSum(i => i.ByteValue);
 
     [Test]
-    public void SByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldTest() => TestSum(i => i.SByteValue);
 
     [Test]
-    public void ShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldTest() => TestSum(i => i.ShortValue);
 
     [Test]
-    public void UShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldTest() => TestSum(i => i.UShortValue);
 
     [Test]
-    public void IntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldTest() => TestSum(i => i.IntValue);
 
     [Test]
-    public void UIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldTest() => TestSum(i => i.UIntValue);
 
     [Test]
-    public void LongFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldTest() => TestSum(i => i.LongValue);
 
     [Test]
-    public void FloatFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldTest() => TestSum(i => i.FloatValue);
 
     [Test]
-    public void DoubleFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DoubleFieldTest() => TestSum(i => i.DoubleValue1);
 
     [Test]
-    public void DecimalFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DecimalFieldTest() => TestSum(i => i.DecimalValue);
 
     [Test]
-    public void NullableByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldTest() => TestSum(i => i.NullableByteValue);
 
     [Test]
-    public void NullableSByteFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldTest() => TestSum(i => i.NullableSByteValue);
 
     [Test]
-    public void NullableShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldTest() => TestSum(i => i.NullableShortValue);
 
     [Test]
-    public void NullableUShortFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldTest() => TestSum(i => i.NullableUShortValue);
 
     [Test]
-    public void NullableIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldTest() => TestSum(i => i.NullableIntValue);
 
     [Test]
-    public void NullableUIntFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldTest() => TestSum(i => i.NullableUIntValue);
 
     [Test]
-    public void NullableLongFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldTest() => TestSum(i => i.NullableLongValue);
 
     [Test]
-    public void NullableFloatFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableFloatFieldTest() =>
+      TestSumWithAccuracy(i => i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableDoubleFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableDoubleFieldTest() => TestSum(i => i.NullableDoubleValue1);
 
     [Test]
-    public void NullableDecimalFieldTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableDecimalFieldTest() => TestSum(i => i.NullableDecimalValue);
 
     [Test]
-    public void ByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest01() => TestSum(i => i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (short) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (short) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest02() =>
+      TestSum(i => (short) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (short) i.ByteValue + (short) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (short) i.ByteValue + (short) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest03() =>
+      TestSum(i => (short) i.ByteValue + (short) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest04() =>
+      TestSum(i => (int) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int) i.ByteValue + (int) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int) i.ByteValue + (int) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest05() =>
+      TestSum(i => (int) i.ByteValue + (int) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest06() =>
+      TestSum(i => (long) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.ByteValue + (long) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.ByteValue + (long) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest07() =>
+      TestSum(i => (long) i.ByteValue + (long) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.ByteValue + i.ByteValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ByteFieldExpressionTest08() =>
+      TestSumWithAccuracy(i => (float) i.ByteValue + i.ByteValue, FloatValueAccuracy);
 
     [Test]
-    public void ByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.ByteValue + (float) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.ByteValue + (float) i.ByteValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ByteFieldExpressionTest09() =>
+      TestSumWithAccuracy(i => (float) i.ByteValue + (float) i.ByteValue, FloatValueAccuracy);
 
     [Test]
-    public void ByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest10() =>
+      TestSum(i => (double) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.ByteValue + (double) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.ByteValue + (double) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest11() =>
+      TestSum(i => (double) i.ByteValue + (double) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.ByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.ByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest12() =>
+      TestSum(i => (decimal) i.ByteValue + i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest13() =>
+      TestSum(i => (decimal) i.ByteValue + (decimal) i.ByteValue);
 
     [Test]
-    public void ByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ByteValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ByteValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest14() => TestSum(i => i.ByteValue + i.IntValue);
 
     [Test]
-    public void ByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ByteValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ByteValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest15() => TestSum(i => i.ByteValue + i.LongValue);
 
     [Test]
-    public void ByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ByteValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ByteValue + i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ByteFieldExpressionTest16() =>
+      TestSumWithAccuracy(i => i.ByteValue + i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void ByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ByteValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ByteValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest17() => TestSum(i => i.ByteValue + i.DoubleValue1);
 
     [Test]
-    public void ByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ByteValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ByteValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ByteFieldExpressionTest18() => TestSum(i => i.ByteValue + i.DecimalValue);
 
     [Test]
-    public void SByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest01() => TestSum(i => i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (short) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (short) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest02() =>
+      TestSum(i => (short) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (short) i.SByteValue + (short) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (short) i.SByteValue + (short) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest03() =>
+      TestSum(i => (short) i.SByteValue + (short) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest04() =>
+      TestSum(i => (int) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int) i.SByteValue + (int) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int) i.SByteValue + (int) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest05() =>
+      TestSum(i => (int) i.SByteValue + (int) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest06() =>
+      TestSum(i => (long) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.SByteValue + (long) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.SByteValue + (long) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest07() =>
+      TestSum(i => (long) i.SByteValue + (long) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.SByteValue + i.SByteValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void SByteFieldExpressionTest08() =>
+      TestSumWithAccuracy(i => (float) i.SByteValue + i.SByteValue, FloatValueAccuracy);
 
     [Test]
-    public void SByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.SByteValue + (float) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.SByteValue + (float) i.SByteValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void SByteFieldExpressionTest09() =>
+      TestSumWithAccuracy(i => (float) i.SByteValue + (float) i.SByteValue, FloatValueAccuracy);
 
     [Test]
-    public void SByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest10() =>
+      TestSum(i => (double) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.SByteValue + (double) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.SByteValue + (double) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest11() =>
+      TestSum(i => (double) i.SByteValue + (double) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.SByteValue + i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.SByteValue + i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest12() =>
+      TestSum(i => (decimal) i.SByteValue + i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest13() =>
+      TestSum(i => (decimal) i.SByteValue + (decimal) i.SByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.SByteValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.SByteValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest14() => TestSum(i => i.SByteValue + i.ByteValue);
 
     [Test]
-    public void SByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.SByteValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.SByteValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest15() => TestSum(i => i.SByteValue + i.IntValue);
 
     [Test]
-    public void SByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.SByteValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.SByteValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest16() => TestSum(i => i.SByteValue + i.LongValue);
 
     [Test]
-    public void SByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.SByteValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.SByteValue + i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void SByteFieldExpressionTest17() =>
+      TestSumWithAccuracy(i => i.SByteValue + i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void SByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.SByteValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.SByteValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest18() => TestSum(i => i.SByteValue + i.DoubleValue1);
 
     [Test]
-    public void SByteFieldExpressionTest19()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.SByteValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.SByteValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void SByteFieldExpressionTest19() => TestSum(i => i.SByteValue + i.DecimalValue);
 
     [Test]
-    public void ShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest01() => TestSum(i => i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest02() =>
+      TestSum(i => (int) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int) i.ShortValue + (int) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int) i.ShortValue + (int) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest03() =>
+      TestSum(i => (int) i.ShortValue + (int) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest04() =>
+      TestSum(i => (long) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.ShortValue + (long) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.ShortValue + (long) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest05() =>
+      TestSum(i => (long) i.ShortValue + (long) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.ShortValue + i.ShortValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ShortFieldExpressionTest06() =>
+      TestSumWithAccuracy(i => (float) i.ShortValue + i.ShortValue, FloatValueAccuracy);
 
     [Test]
-    public void ShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.ShortValue + (float) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.ShortValue + (float) i.ShortValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ShortFieldExpressionTest07() =>
+      TestSumWithAccuracy(i => (float) i.ShortValue + (float) i.ShortValue, FloatValueAccuracy);
 
     [Test]
-    public void ShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest08() =>
+      TestSum(i => (double) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.ShortValue + (double) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.ShortValue + (double) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest09() =>
+      TestSum(i => (double) i.ShortValue + (double) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest10() =>
+      TestSum(i => (decimal) i.ShortValue + i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest11() =>
+      TestSum(i => (decimal) i.ShortValue + (decimal) i.ShortValue);
 
     [Test]
-    public void ShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ShortValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ShortValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest12() => TestSum(i => i.ShortValue + i.ByteValue);
 
     [Test]
-    public void ShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ShortValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ShortValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest13() => TestSum(i => i.ShortValue + i.IntValue);
 
     [Test]
-    public void ShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ShortValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ShortValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest14() => TestSum(i => i.ShortValue + i.LongValue);
 
     [Test]
-    public void ShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ShortValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ShortValue + i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ShortFieldExpressionTest15() =>
+      TestSumWithAccuracy(i => i.ShortValue + i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void ShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ShortValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ShortValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest16() => TestSum(i => i.ShortValue + i.DoubleValue1);
 
     [Test]
-    public void ShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ShortValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ShortValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ShortFieldExpressionTest17() => TestSum(i => i.ShortValue + i.DecimalValue);
 
     [Test]
-    public void UShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ShortValue + i.ShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ShortValue + i.ShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest01() => TestSum(i => i.ShortValue + i.ShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest02() =>
+      TestSum(i => (int) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int) i.UShortValue + (int) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int) i.UShortValue + (int) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest03() =>
+      TestSum(i => (int) i.UShortValue + (int) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest04() =>
+      TestSum(i => (long) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.UShortValue + (long) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.UShortValue + (long) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest05() =>
+      TestSum(i => (long) i.UShortValue + (long) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.UShortValue + i.UShortValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void UShortFieldExpressionTest06() =>
+      TestSum(i => (float) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.UShortValue + (float) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.UShortValue + (float) i.UShortValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void UShortFieldExpressionTest07() =>
+      TestSumWithAccuracy(i => (float) i.UShortValue + (float) i.UShortValue, FloatValueAccuracy);
 
     [Test]
-    public void UShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest08() =>
+      TestSum(i => (double) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.UShortValue + (double) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.UShortValue + (double) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest09() =>
+      TestSum(i => (double) i.UShortValue + (double) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.UShortValue + i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.UShortValue + i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest10() =>
+      TestSum(i => (decimal) i.UShortValue + i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest11() =>
+      TestSum(i => (decimal) i.UShortValue + (decimal) i.UShortValue);
 
     [Test]
-    public void UShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UShortValue + i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UShortValue + i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest12() => TestSum(i => i.UShortValue + i.ByteValue);
 
     [Test]
-    public void UShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UShortValue + i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UShortValue + i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest13() => TestSum(i => i.UShortValue + i.IntValue);
 
     [Test]
-    public void UShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UShortValue + i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UShortValue + i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest14() => TestSum(i => i.UShortValue + i.LongValue);
 
     [Test]
-    public void UShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UShortValue + i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UShortValue + i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void UShortFieldExpressionTest15() =>
+      TestSumWithAccuracy(i => i.UShortValue + i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void UShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UShortValue + i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UShortValue + i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest16() =>
+      TestSum(i => i.UShortValue + i.DoubleValue1);
 
     [Test]
-    public void UShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UShortValue + i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UShortValue + i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UShortFieldExpressionTest17() =>
+      TestSum(i => i.UShortValue + i.DecimalValue);
 
     [Test]
-    public void IntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest01() => TestSum(i => i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest02() =>
+      TestSum(i => (long) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.IntValue * (long) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.IntValue * (long) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest03() =>
+      TestSum(i => (long) i.IntValue * (long) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.IntValue * i.IntValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void IntFieldExpressionTest04() =>
+      TestSumWithAccuracy(i => (float) i.IntValue * i.IntValue, FloatValueAccuracy);
 
     [Test]
-    public void IntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.IntValue * (float) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.IntValue * (float) i.IntValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void IntFieldExpressionTest05() =>
+      TestSumWithAccuracy(i => (float) i.IntValue * (float) i.IntValue, FloatValueAccuracy);
 
     [Test]
-    public void IntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest06() =>
+      TestSum(i => (double) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.IntValue * (double) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.IntValue * (double) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest07() =>
+      TestSum(i => (double) i.IntValue * (double) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.IntValue * i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.IntValue * i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest08() =>
+      TestSum(i => (decimal) i.IntValue * i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.IntValue * (decimal) i.IntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.IntValue * (decimal) i.IntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest09() =>
+      TestSum(i => (decimal) i.IntValue * (decimal) i.IntValue);
 
     [Test]
-    public void IntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.IntValue * i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.IntValue * i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest10() => TestSum(i => i.IntValue * i.ByteValue);
 
     [Test]
-    public void IntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.IntValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.IntValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest11() => TestSum(i => i.IntValue * i.LongValue);
 
     [Test]
-    public void IntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.IntValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.IntValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void IntFieldExpressionTest12() =>
+      TestSumWithAccuracy(i => i.IntValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void IntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.IntValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.IntValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest13() => TestSum(i => i.IntValue * i.DoubleValue1);
 
     [Test]
-    public void IntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.IntValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.IntValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void IntFieldExpressionTest14() => TestSum(i => i.IntValue * i.DecimalValue);
 
     [Test]
-    public void UIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest01() => TestSum(i => i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest02() =>
+      TestSum(i => (long) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long) i.UIntValue * (long) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long) i.UIntValue * (long) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest03() =>
+      TestSum(i => (long) i.UIntValue * (long) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.UIntValue * i.UIntValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void UIntFieldExpressionTest04() =>
+      TestSumWithAccuracy(i => (float) i.UIntValue * i.UIntValue, FloatValueAccuracy);
 
     [Test]
-    public void UIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.UIntValue * (float) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.UIntValue * (float) i.UIntValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void UIntFieldExpressionTest05() =>
+      TestSumWithAccuracy(i => (float) i.UIntValue * (float) i.UIntValue, FloatValueAccuracy);
 
     [Test]
-    public void UIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest06() =>
+      TestSum(i => (double) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.UIntValue * (double) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.UIntValue * (double) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest07() =>
+      TestSum(i => (double) i.UIntValue * (double) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.UIntValue * i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.UIntValue * i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest08() =>
+      TestSum(i => (decimal) i.UIntValue * i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest09() =>
+      TestSum(i => (decimal) i.UIntValue * (decimal) i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UIntValue + i.UIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UIntValue + i.UIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest10() => TestSum(i => i.UIntValue + i.UIntValue);
 
     [Test]
-    public void UIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UIntValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UIntValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest11() => TestSum(i => i.UIntValue * i.LongValue);
 
     [Test]
-    public void UIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UIntValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UIntValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void UIntFieldExpressionTest12() =>
+      TestSumWithAccuracy(i => i.UIntValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void UIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UIntValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UIntValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest13() => TestSum(i => i.UIntValue * i.DoubleValue1);
 
     [Test]
-    public void UIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.UIntValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.UIntValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void UIntFieldExpressionTest14() => TestSum(i => i.UIntValue * i.DecimalValue);
 
     [Test]
-    public void LongFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest01() => TestSum(i => i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.LongValue * i.LongValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void LongFieldExpressionTest02() =>
+      TestSumWithAccuracy(i => (float) i.LongValue * i.LongValue, FloatValueAccuracy);
 
     [Test]
-    public void LongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.LongValue * (float) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.LongValue * (float) i.LongValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void LongFieldExpressionTest03() =>
+      TestSumWithAccuracy(i => (float) i.LongValue * (float) i.LongValue, FloatValueAccuracy);
 
     [Test]
-    public void LongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest04() =>
+      TestSum(i => (double) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.LongValue * (double) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.LongValue * (double) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest05() =>
+      TestSum(i => (double) i.LongValue * (double) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.LongValue * i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.LongValue * i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest06() =>
+      TestSum(i => (decimal) i.LongValue * i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.LongValue * (decimal) i.LongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.LongValue * (decimal) i.LongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest07() =>
+      TestSum(i => (decimal) i.LongValue * (decimal) i.LongValue);
 
     [Test]
-    public void LongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.LongValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.LongValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void LongFieldExpressionTest08() =>
+      TestSumWithAccuracy(i => i.LongValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void LongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.LongValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.LongValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest09() => TestSum(i => i.LongValue * i.DoubleValue1);
 
     [Test]
-    public void LongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.LongValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.LongValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void LongFieldExpressionTest10() => TestSum(i => i.LongValue * i.DecimalValue);
 
     [Test]
-    public void ULongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.ULongValue * i.ULongValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ULongFieldExpressionTest02() =>
+      TestSumWithAccuracy(i => (float) i.ULongValue * i.ULongValue, FloatValueAccuracy);
 
     [Test]
-    public void ULongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float) i.ULongValue * (float) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.ULongValue * (float) i.ULongValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ULongFieldExpressionTest03() =>
+      TestSumWithAccuracy(i => (float) i.ULongValue * (float) i.ULongValue, FloatValueAccuracy);
 
     [Test]
-    public void ULongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest04() =>
+      TestSum(i => (double) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.ULongValue * (double) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.ULongValue * (double) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest05() =>
+      TestSum(i => (double) i.ULongValue * (double) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.ULongValue * i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.ULongValue * i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest06() =>
+      TestSum(i => (decimal) i.ULongValue * i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest07() =>
+      TestSum(i => (decimal) i.ULongValue * (decimal) i.ULongValue);
 
     [Test]
-    public void ULongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ULongValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ULongValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void ULongFieldExpressionTest08() =>
+      TestSumWithAccuracy(i => i.ULongValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void ULongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ULongValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ULongValue * i.DoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest09() => TestSum(i => i.ULongValue * i.DoubleValue1);
 
     [Test]
-    public void ULongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.ULongValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.ULongValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void ULongFieldExpressionTest10() => TestSum(i => i.ULongValue * i.DecimalValue);
 
     [Test]
-    public void FloatFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.FloatValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.FloatValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest01() =>
+      TestSumWithAccuracy(i => i.FloatValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.FloatValue * i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.FloatValue * i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest02() =>
+      TestSumWithAccuracy(i => (double) i.FloatValue * i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.FloatValue * (double) i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.FloatValue * (double) i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest03() =>
+      TestSumWithAccuracy(i => (double) i.FloatValue * (double) i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.FloatValue * (decimal) i.FloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.FloatValue * (decimal) i.FloatValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest04() =>
+      TestSumWithAccuracy(i => (decimal) i.FloatValue * (decimal) i.FloatValue, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.FloatValue * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.FloatValue * i.DoubleValue1);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest05() =>
+      TestSumWithAccuracy(i => i.FloatValue * i.DoubleValue1, FloatValueAccuracy);
 
     [Test]
-    public void FloatFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.FloatValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.FloatValue * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void FloatFieldExpressionTest06() =>
+      TestSumWithAccuracy(i => (decimal) i.FloatValue * i.DecimalValue, FloatValueAccuracy);
 
     [Test]
-    public void DoubleFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.DoubleValue1 * i.DoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.DoubleValue1 * i.DoubleValue1);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(DoubleValueAccuracy));
-      }
-    }
+    public void DoubleFieldExpressionTest01() =>
+      TestSumWithAccuracy(i => i.DoubleValue1 * i.DoubleValue1, DoubleValueAccuracy);
 
     [Test]
-    public void DoubleFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal) i.DoubleValue1 * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal) i.DoubleValue1 * i.DecimalValue);
-        Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(DoubleValueAccuracy));
-      }
-    }
+    public void DoubleFieldExpressionTest02() =>
+      TestSumWithAccuracy(i => (decimal) i.DoubleValue1 * i.DecimalValue, DoubleValueAccuracy);
 
     [Test]
-    public void DecimalFieldExpressionTest()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.DecimalValue * i.DecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.DecimalValue * i.DecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void DecimalFieldExpressionTest() =>
+      TestSum(i => i.DecimalValue * i.DecimalValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest01() =>
+      TestSum(i => i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (short?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (short?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest02() =>
+      TestSum(i => (short?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest03() =>
+      TestSum(i => (short?) i.NullableByteValue + (short?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest04() =>
+      TestSum(i => (int?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest05() =>
+      TestSum(i => (int?) i.NullableByteValue + (int?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest06() =>
+      TestSum(i => (long?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest07() =>
+      TestSum(i => (long?) i.NullableByteValue + (long?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.ByteValue + i.NullableByteValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableByteFieldExpressionTest08() =>
+      TestSumWithAccuracy(i => (float?) i.NullableByteValue + i.NullableByteValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableByteFieldExpressionTest09() =>
+      TestSumWithAccuracy(i => (float?) i.NullableByteValue + (float?) i.NullableByteValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest10() =>
+      TestSum(i => (double?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double) i.ByteValue + (double) i.ByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double) i.ByteValue + (double) i.ByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest11() =>
+      TestSum(i => (double) i.ByteValue + (double) i.ByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest12() =>
+      TestSum(i => (decimal?) i.NullableByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest13() =>
+      TestSum(i => (decimal?) i.NullableByteValue + (decimal?) i.NullableByteValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableByteValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableByteValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest14() =>
+      TestSum(i => i.NullableByteValue + i.NullableIntValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableByteValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableByteValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest15() =>
+      TestSum(i => i.NullableByteValue + i.NullableLongValue);
 
     [Test]
-    public void NullableByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableByteValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableByteValue + i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableByteFieldExpressionTest16() =>
+      TestSumWithAccuracy(i => i.NullableByteValue + i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableByteValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableByteValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest17() =>
+      TestSum(i => i.NullableByteValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableByteValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableByteValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableByteFieldExpressionTest18() =>
+      TestSum(i => i.NullableByteValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest01() =>
+      TestSum(i => i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest02() =>
+      TestSum(i => (short?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest03() =>
+      TestSum(i => (short?) i.NullableSByteValue + (short?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest04() =>
+      TestSum(i => (int?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest05() =>
+      TestSum(i => (int?) i.NullableSByteValue + (int?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest06() =>
+      TestSum(i => (long?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest07() =>
+      TestSum(i => (long?) i.NullableSByteValue + (long?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableSByteFieldExpressionTest08() =>
+      TestSumWithAccuracy(i => (float?) i.NullableSByteValue + i.NullableSByteValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableSByteFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableSByteFieldExpressionTest09() =>
+      TestSumWithAccuracy(i => (float?) i.NullableSByteValue + (float?) i.NullableSByteValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableSByteFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest10() =>
+      TestSum(i => (double?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest11() =>
+      TestSum(i => (double?) i.NullableSByteValue + (double?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest12() =>
+      TestSum(i => (decimal?) i.NullableSByteValue + i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest13() =>
+      TestSum(i => (decimal?) i.NullableSByteValue + (decimal?) i.NullableSByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableSByteValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableSByteValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest14() =>
+      TestSum(i => i.NullableSByteValue + i.NullableByteValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableSByteValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableSByteValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest15() =>
+      TestSum(i => i.NullableSByteValue + i.NullableIntValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableSByteValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableSByteValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest16() =>
+      TestSum(i => i.NullableSByteValue + i.NullableLongValue);
 
     [Test]
-    public void NullableSByteFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableSByteValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableSByteValue + i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableSByteFieldExpressionTest17() =>
+      TestSumWithAccuracy(i => i.NullableSByteValue + i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableSByteFieldExpressionTest18()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableSByteValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableSByteValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest18() =>
+      TestSum(i => i.NullableSByteValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableSByteFieldExpressionTest19()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableSByteValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableSByteValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableSByteFieldExpressionTest19() =>
+      TestSum(i => i.NullableSByteValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest01() =>
+      TestSum(i => i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest02() =>
+      TestSum(i => (int?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest03() =>
+      TestSum(i => (int?) i.NullableShortValue + (int?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest04() =>
+      TestSum(i => (long?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest05() =>
+      TestSum(i => (long?) i.NullableShortValue + (long?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableShortFieldExpressionTest06() =>
+      TestSumWithAccuracy(i => (float?) i.NullableShortValue + i.NullableShortValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableShortValue + (float?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float) i.ShortValue + (float?) i.NullableShortValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableShortFieldExpressionTest07() =>
+      TestSumWithAccuracy(i => (float?) i.NullableShortValue + (float?) i.NullableShortValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest08() =>
+      TestSum(i => (double?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest09() =>
+      TestSum(i => (double?) i.NullableShortValue + (double?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest10() =>
+      TestSum(i => (decimal?) i.NullableShortValue + i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest11() =>
+      TestSum(i => (decimal?) i.NullableShortValue + (decimal?) i.NullableShortValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableShortValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableShortValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest12() =>
+      TestSum(i => i.NullableShortValue + i.NullableByteValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableShortValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableShortValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest13() =>
+      TestSum(i => i.NullableShortValue + i.NullableIntValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableShortValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableShortValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest14() =>
+      TestSum(i => i.NullableShortValue + i.NullableLongValue);
 
     [Test]
-    public void NullableShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableShortValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableShortValue + i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableShortFieldExpressionTest15() =>
+      TestSumWithAccuracy(i => i.NullableShortValue + i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableShortValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableShortValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest16() =>
+      TestSum(i => i.NullableShortValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableShortValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableShortValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableShortFieldExpressionTest17() =>
+      TestSum(i => i.NullableShortValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest01() =>
+      TestSum(i => i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest02() =>
+      TestSum(i => (int?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest03() =>
+      TestSum(i => (int?) i.NullableUShortValue + (int?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest04() =>
+      TestSum(i => (long?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest05() =>
+      TestSum(i => (long?) i.NullableUShortValue + (long?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableUShortFieldExpressionTest06() =>
+      TestSumWithAccuracy(i => (float?) i.NullableUShortValue + i.NullableUShortValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableUShortFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableUShortFieldExpressionTest07() =>
+      TestSumWithAccuracy(i => (float?) i.NullableUShortValue + (float?) i.NullableUShortValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableUShortFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest08() =>
+      TestSum(i => (double?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest09() =>
+      TestSum(i => (double?) i.NullableUShortValue + (double?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest10() =>
+      TestSum(i => (decimal?) i.NullableUShortValue + i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest11() =>
+      TestSum(i => (decimal?) i.NullableUShortValue + (decimal?) i.NullableUShortValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUShortValue + i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUShortValue + i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest12() =>
+      TestSum(i => i.NullableUShortValue + i.NullableByteValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUShortValue + i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUShortValue + i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest13() =>
+      TestSum(i => i.NullableUShortValue + i.NullableIntValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUShortValue + i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUShortValue + i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest14() =>
+      TestSum(i => i.NullableUShortValue + i.NullableLongValue);
 
     [Test]
-    public void NullableUShortFieldExpressionTest15()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUShortValue + i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUShortValue + i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableUShortFieldExpressionTest15() =>
+      TestSumWithAccuracy(i => i.NullableUShortValue + i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableUShortFieldExpressionTest16()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUShortValue + i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUShortValue + i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest16() =>
+      TestSum(i => i.NullableUShortValue + i.NullableDoubleValue1);
 
     [Test]
-    public void NullableUShortFieldExpressionTest17()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUShortValue + i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUShortValue + i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUShortFieldExpressionTest17() =>
+      TestSum(i => i.NullableUShortValue + i.NullableDecimalValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest01() =>
+      TestSum(i => i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest02() =>
+      TestSum(i => (long?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest03() =>
+      TestSum(i => (long?) i.NullableIntValue * (long?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableIntFieldExpressionTest04() =>
+      TestSumWithAccuracy(i => (float?) i.NullableIntValue * i.NullableIntValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableIntFieldExpressionTest05() =>
+      TestSumWithAccuracy(i => (float?) i.NullableIntValue * (float?) i.NullableIntValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest06() =>
+      TestSum(i => (double?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest07() =>
+      TestSum(i => (double?) i.NullableIntValue * (double?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest08() =>
+      TestSum(i => (decimal?) i.NullableIntValue * i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest09() =>
+      TestSum(i => (decimal?) i.NullableIntValue * (decimal?) i.NullableIntValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableIntValue * i.NullableByteValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableIntValue * i.NullableByteValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest10() =>
+      TestSum(i => i.NullableIntValue * i.NullableByteValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableIntValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableIntValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest11() =>
+      TestSum(i => i.NullableIntValue * i.NullableLongValue);
 
     [Test]
-    public void NullableIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableIntValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableIntValue * i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableIntFieldExpressionTest12() =>
+      TestSumWithAccuracy(i => i.NullableIntValue * i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableIntValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableIntValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest13() =>
+      TestSum(i => i.NullableIntValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableIntValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableIntValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableIntFieldExpressionTest14() =>
+      TestSum(i => i.NullableIntValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest01() =>
+      TestSum(i => i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest02() =>
+      TestSum(i => (long?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest03() =>
+      TestSum(i => (long?) i.NullableUIntValue * (long?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableUIntFieldExpressionTest04() =>
+      TestSumWithAccuracy(i => (float?) i.NullableUIntValue * i.NullableUIntValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableUIntFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableUIntFieldExpressionTest05() =>
+      TestSum(i => (float?) i.NullableUIntValue * (float?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest06() =>
+      TestSum(i => (double?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest07() =>
+      TestSum(i => (double?) i.NullableUIntValue * (double?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest08() =>
+      TestSum(i => (decimal?) i.NullableUIntValue * i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest09() =>
+      TestSum(i => (decimal?) i.NullableUIntValue * (decimal?) i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUIntValue + i.NullableUIntValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUIntValue + i.NullableUIntValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest10() =>
+      TestSum(i => i.NullableUIntValue + i.NullableUIntValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest11()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUIntValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUIntValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest11() =>
+      TestSum(i => i.NullableUIntValue * i.NullableLongValue);
 
     [Test]
-    public void NullableUIntFieldExpressionTest12()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUIntValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUIntValue * i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableUIntFieldExpressionTest12() =>
+      TestSumWithAccuracy(i => i.NullableUIntValue * i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableUIntFieldExpressionTest13()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUIntValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUIntValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest13() =>
+      TestSum(i => i.NullableUIntValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableUIntFieldExpressionTest14()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableUIntValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableUIntValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableUIntFieldExpressionTest14() =>
+      TestSum(i => i.NullableUIntValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest01()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest01() =>
+      TestSum(i => i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableLongFieldExpressionTest02() =>
+      TestSumWithAccuracy(i => (float?) i.NullableLongValue * i.NullableLongValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableLongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableLongFieldExpressionTest03() =>
+      TestSumWithAccuracy(i => (float?) i.NullableLongValue * (float?) i.NullableLongValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableLongFieldExpressionTest04()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest04() =>
+      TestSum(i => (double?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest05()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest05() =>
+      TestSum(i => (double?) i.NullableLongValue * (double?) i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest06()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest06() =>
+      TestSum(i => (decimal?) i.NullableLongValue * i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest07()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest07() =>
+      TestSum(i => (decimal?) i.NullableLongValue * (decimal?) i.NullableLongValue);
 
     [Test]
-    public void NullableLongFieldExpressionTest08()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableLongValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableLongValue * i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableLongFieldExpressionTest08() =>
+      TestSumWithAccuracy(i => i.NullableLongValue * i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableLongFieldExpressionTest09()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableLongValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableLongValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest09() =>
+      TestSum(i => i.NullableLongValue * i.NullableDoubleValue1);
 
     [Test]
-    public void NullableLongFieldExpressionTest10()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableLongValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableLongValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
-    }
+    public void NullableLongFieldExpressionTest10() =>
+      TestSum(i => i.NullableLongValue * i.NullableDecimalValue);
 
     [Test]
-    public void NullableULongFieldExpressionTest02()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableULongFieldExpressionTest02() =>
+      TestSumWithAccuracy(i => (float?) i.NullableULongValue * i.NullableULongValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableULongFieldExpressionTest03()
-    {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
-    }
+    public void NullableULongFieldExpressionTest03() =>
+      TestSumWithAccuracy(i => (float?) i.NullableULongValue * (float?) i.NullableULongValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableULongFieldExpressionTest04() =>
+      TestSum(i => (double?) i.NullableULongValue * i.NullableULongValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest05() =>
+      TestSum(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest06() =>
+      TestSum(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest07() =>
+      TestSum(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
+
+    [Test]
+    public void NullableULongFieldExpressionTest08() =>
+      TestSumWithAccuracy(i => i.NullableULongValue * i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableULongFieldExpressionTest09() =>
+      TestSum(i => i.NullableULongValue * i.NullableDoubleValue1);
+
+    [Test]
+    public void NullableULongFieldExpressionTest10() =>
+      TestSum(i => i.NullableULongValue * i.NullableDecimalValue);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest01() =>
+      TestSumWithAccuracy(i => i.NullableFloatValue * i.NullableFloatValue, FloatValueAccuracy);
 
     [Test]
-    public void NullableULongFieldExpressionTest04()
+    public void NullableFloatFieldExpressionTest02() =>
+      TestSumWithAccuracy(i => (double?) i.NullableFloatValue * i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest03() =>
+      TestSumWithAccuracy(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest04() =>
+      TestSumWithAccuracy(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest05() =>
+      TestSumWithAccuracy(i => i.NullableFloatValue * i.NullableDoubleValue1, FloatValueAccuracy);
+
+    [Test]
+    public void NullableFloatFieldExpressionTest06() =>
+      TestSumWithAccuracy(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue, FloatValueAccuracy);
+
+    [Test]
+    public void NullableDoubleFieldExpressionTest01() =>
+      TestSum(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
+
+    [Test]
+    public void NullableDoubleFieldExpressionTest02() =>
+      TestSum(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
+
+    [Test]
+    public void NullableDecimalFieldExpressionTest() =>
+      TestSum(i => i.NullableDecimalValue * i.NullableDecimalValue);
+
+
+    private void TestSum(Expression<Func<TestEntity, int>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest05()
+
+    private void TestSum(Expression<Func<TestEntity, int?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableULongValue * (double?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest06()
+    private void TestSum(Expression<Func<TestEntity, long>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableULongValue * i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest07()
+    private void TestSum(Expression<Func<TestEntity, long?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableULongValue * (decimal?) i.NullableULongValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest08()
+    private void TestSum(Expression<Func<TestEntity, float>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableULongValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableULongValue * i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest09()
+    private void TestSum(Expression<Func<TestEntity, float?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableULongValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableULongValue * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableULongFieldExpressionTest10()
+    private void TestSum(Expression<Func<TestEntity, double>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableULongValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableULongValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest01()
+    private void TestSum(Expression<Func<TestEntity, double?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableFloatValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableFloatValue * i.NullableFloatValue);
-        Assert.That(enumerableResult.HasValue, Is.True);
-        Assert.That(queryableResult.HasValue, Is.True);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest02()
+    private void TestSum(Expression<Func<TestEntity, decimal>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableFloatValue * i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableFloatValue * i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest03()
+    private void TestSum(Expression<Func<TestEntity, decimal?>> selector)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (double?) i.NullableFloatValue * (double?) i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(queryableResult, Is.EqualTo(enumerableResult), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest04()
+    private void TestSumWithAccuracy<TAccuracy>(Expression<Func<TestEntity, float>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableFloatValue * (decimal?) i.NullableFloatValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest05()
+    private void TestSumWithAccuracy<TAccuracy>(Expression<Func<TestEntity, float?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableFloatValue * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableFloatValue * i.NullableDoubleValue1);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableFloatFieldExpressionTest06()
+    private void TestSumWithAccuracy<TAccuracy>(Expression<Func<TestEntity, double>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableFloatValue * i.NullableDecimalValue);
-        Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(FloatValueAccuracy));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableDoubleFieldExpressionTest01()
+    private void TestSumWithAccuracy<TAccuracy>(Expression<Func<TestEntity, double?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableDoubleValue1 * i.NullableDoubleValue1);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableDoubleFieldExpressionTest02()
+    private void TestSumWithAccuracy<TAccuracy>(Expression<Func<TestEntity, decimal>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => (decimal?) i.NullableDoubleValue1 * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(Math.Abs(queryableResult - enumerableResult), Is.LessThan(accuracy), "Failed on Select(selector).Sum(t => t)");
     }
 
-    [Test]
-    public void NullableDecimalFieldExpressionTest()
+    private void TestSumWithAccuracy<TAccuracy>(Expression<Func<TestEntity, decimal?>> selector, TAccuracy accuracy)
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        var queryableResult = session.Query.All<TestEntity>().Sum(i => i.NullableDecimalValue * i.NullableDecimalValue);
-        var enumerableResult = session.Query.All<TestEntity>().AsEnumerable().Sum(i => i.NullableDecimalValue * i.NullableDecimalValue);
-        Assert.That(queryableResult, Is.EqualTo(enumerableResult));
-      }
+      var queryableResult = GlobalSession.Query.All<TestEntity>().Sum(selector);
+      var enumerableResult = GlobalSession.Query.All<TestEntity>().AsEnumerable().Sum(selector.Compile());
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Sum(selector)");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum();
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Sum()");
+
+      queryableResult = GlobalSession.Query.All<TestEntity>().Select(selector).Sum(t => t);
+      Assert.That(Math.Abs(queryableResult.Value - enumerableResult.Value), Is.LessThan(accuracy), "Failed on Select(selector).Sum(t => t)");
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/AggregateTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/AggregateTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2032 Xtensive LLC.
+// Copyright (C) 2009-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -18,6 +18,8 @@ namespace Xtensive.Orm.Tests.Storage
   public class AggregateTest : AutoBuildTest
   {
     private List<X> all;
+    private Session globalSession;
+    private TransactionScope globalTransaction;
 
     protected override DomainConfiguration BuildConfiguration()
     {
@@ -30,9 +32,10 @@ namespace Xtensive.Orm.Tests.Storage
     {
       base.TestFixtureSetUp();
 
-      _ = CreateSessionAndTransaction();
+      (globalSession, globalTransaction) = CreateSessionAndTransaction();
+      all = new List<X>();
 
-      for (int i = 0; i < 10; i++) {
+      for (var i = 0; i < 10; i++) {
         var x = new X();
         x.FByte = (byte) i;
         x.FSByte = (sbyte) i;
@@ -47,27 +50,56 @@ namespace Xtensive.Orm.Tests.Storage
         x.FDouble = i;
         x.FDateTime = new DateTime(2009, 1, i + 1);
         x.FTimeSpan = new TimeSpan(i, 0, 0, 0);
+
+        all.Add(x);
       }
 
-      all = Session.Demand().Query.All<X>().ToList();
+      globalSession.SaveChanges();
     }
     
     [Test]
     public void SumTest()
     {
-      Assert.AreEqual(all.Sum(x => x.FByte), Session.Demand().Query.All<X>().Sum(x => x.FByte));
-      Assert.AreEqual(all.Sum(x => x.FSByte), Session.Demand().Query.All<X>().Sum(x => x.FSByte));
+      Assert.AreEqual(all.Sum(x => x.FByte), globalSession.Query.All<X>().Sum(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Sum(x => x.FSByte), globalSession.Query.All<X>().Sum(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Sum(x => x.FShort), Session.Demand().Query.All<X>().Sum(x => x.FShort));
-      Assert.AreEqual(all.Sum(x => x.FUShort), Session.Demand().Query.All<X>().Sum(x => x.FUShort));
+      Assert.AreEqual(all.Sum(x => x.FShort), globalSession.Query.All<X>().Sum(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Sum(x => x.FUShort), globalSession.Query.All<X>().Sum(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Sum(x => x.FInt), Session.Demand().Query.All<X>().Sum(x => x.FInt));
-      Assert.AreEqual(all.Sum(x => x.FUInt), Session.Demand().Query.All<X>().Sum(x => x.FUInt));
+      Assert.AreEqual(all.Sum(x => x.FInt), globalSession.Query.All<X>().Sum(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Sum(x => x.FUInt), globalSession.Query.All<X>().Sum(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Sum(x => x.FLong), Session.Demand().Query.All<X>().Sum(x => x.FLong));
-      Assert.AreEqual(all.Sum(x => x.FFloat), Session.Demand().Query.All<X>().Sum(x => x.FFloat));
-      Assert.AreEqual(all.Sum(x => x.FDecimal), Session.Demand().Query.All<X>().Sum(x => x.FDecimal));
+      Assert.AreEqual(all.Sum(x => x.FLong), globalSession.Query.All<X>().Sum(x => x.FLong), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Sum(x => x.FFloat), globalSession.Query.All<X>().Sum(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Sum(x => x.FDecimal), globalSession.Query.All<X>().Sum(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
     }
+
+    [Test]
+    public void SumNoLambdaTest()
+    {
+      Assert.AreEqual(all.Sum(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Sum(), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Sum(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Sum(), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Sum(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Sum(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Sum(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Sum(), $"Failed for {nameof(X.FDecimal)}");
+    }
+
+    [Test]
+    public void SumByValueItselfTest()
+    {
+      Assert.AreEqual(all.Sum(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Sum(x => x), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Sum(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Sum(x => x), $"Failed for {nameof(X.FSByte)}");
+
+      Assert.AreEqual(all.Sum(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Sum(x => x), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Sum(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Sum(x => x), $"Failed for {nameof(X.FUShort)}");
+
+      Assert.AreEqual(all.Sum(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Sum(x => x), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Sum(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Sum(x => x), $"Failed for {nameof(X.FUInt)}");
+
+      Assert.AreEqual(all.Sum(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Sum(x => x), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Sum(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Sum(x => x), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Sum(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Sum(x => x), $"Failed for {nameof(X.FDecimal)}");
+    }
+
 
     [Test]
     public void AverageTest()
@@ -77,67 +109,198 @@ namespace Xtensive.Orm.Tests.Storage
       // © Firebird documentation
       // Funny, isn't it?
       if (Domain.Configuration.ConnectionInfo.Provider==WellKnown.Provider.Firebird) {
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FByte)), Session.Demand().Query.All<X>().Average(x => x.FByte));
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FSByte)), Session.Demand().Query.All<X>().Average(x => x.FSByte));
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FShort)), Session.Demand().Query.All<X>().Average(x => x.FShort));
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUShort)), Session.Demand().Query.All<X>().Average(x => x.FUShort));
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), Session.Demand().Query.All<X>().Average(x => x.FInt));
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), Session.Demand().Query.All<X>().Average(x => x.FUInt));
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), Session.Demand().Query.All<X>().Average(x => x.FLong));
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FByte)), globalSession.Query.All<X>().Average(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FSByte)), globalSession.Query.All<X>().Average(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FShort)), globalSession.Query.All<X>().Average(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUShort)), globalSession.Query.All<X>().Average(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), globalSession.Query.All<X>().Average(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), globalSession.Query.All<X>().Average(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), globalSession.Query.All<X>().Average(x => x.FLong), $"Failed for {nameof(X.FLong)}");
       }
       else {
-        Assert.AreEqual(all.Average(x => x.FByte), Session.Demand().Query.All<X>().Average(x => x.FByte));
-        Assert.AreEqual(all.Average(x => x.FSByte), Session.Demand().Query.All<X>().Average(x => x.FSByte));
-        Assert.AreEqual(all.Average(x => x.FShort), Session.Demand().Query.All<X>().Average(x => x.FShort));
-        Assert.AreEqual(all.Average(x => x.FUShort), Session.Demand().Query.All<X>().Average(x => x.FUShort));
-        Assert.AreEqual(all.Average(x => x.FInt), Session.Demand().Query.All<X>().Average(x => x.FInt));
-        Assert.AreEqual(all.Average(x => x.FUInt), Session.Demand().Query.All<X>().Average(x => x.FUInt));
-        Assert.AreEqual(all.Average(x => x.FLong), Session.Demand().Query.All<X>().Average(x => x.FLong));
+        Assert.AreEqual(all.Average(x => x.FByte), globalSession.Query.All<X>().Average(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+        Assert.AreEqual(all.Average(x => x.FSByte), globalSession.Query.All<X>().Average(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
+        Assert.AreEqual(all.Average(x => x.FShort), globalSession.Query.All<X>().Average(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+        Assert.AreEqual(all.Average(x => x.FUShort), globalSession.Query.All<X>().Average(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
+        Assert.AreEqual(all.Average(x => x.FInt), globalSession.Query.All<X>().Average(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(all.Average(x => x.FUInt), globalSession.Query.All<X>().Average(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(all.Average(x => x.FLong), globalSession.Query.All<X>().Average(x => x.FLong), $"Failed for {nameof(X.FLong)}");
       }
 
-      Assert.AreEqual(all.Average(x => x.FFloat), Session.Demand().Query.All<X>().Average(x => x.FFloat));
-      Assert.AreEqual(all.Average(x => x.FDecimal), Session.Demand().Query.All<X>().Average(x => x.FDecimal));
+      Assert.AreEqual(all.Average(x => x.FFloat), globalSession.Query.All<X>().Average(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Average(x => x.FDecimal), globalSession.Query.All<X>().Average(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
+    }
+
+    [Test]
+    public void AverageNoLambdaTest()
+    {
+      //"If Field is of an integer type, AVG is always rounded towards 0.
+      // For instance, 6 non-null INT records with a sum of -11 yield an average of -1, not -2."
+      // © Firebird documentation
+      // Funny, isn't it?
+      if (Domain.Configuration.ConnectionInfo.Provider == WellKnown.Provider.Firebird) {
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), globalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), globalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), globalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
+      }
+      else {
+        Assert.AreEqual(all.Average(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(all.Average(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(all.Average(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
+      }
+
+      Assert.AreEqual(all.Average(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Average(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Average(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Average(), $"Failed for {nameof(X.FDecimal)}");
+    }
+
+    [Test]
+    public void AverageByValueItselfTest()
+    {
+      //"If Field is of an integer type, AVG is always rounded towards 0.
+      // For instance, 6 non-null INT records with a sum of -11 yield an average of -1, not -2."
+      // © Firebird documentation
+      // Funny, isn't it?
+      if (Domain.Configuration.ConnectionInfo.Provider == WellKnown.Provider.Firebird) {
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FByte)), globalSession.Query.All<X>().Select(x => x.FByte).Average(x => x), $"Failed for {nameof(X.FByte)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FSByte)), globalSession.Query.All<X>().Select(x => x.FSByte).Average(x => x), $"Failed for {nameof(X.FSByte)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FShort)), globalSession.Query.All<X>().Select(x => x.FShort).Average(x => x), $"Failed for {nameof(X.FShort)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUShort)), globalSession.Query.All<X>().Select(x => x.FUShort).Average(x => x), $"Failed for {nameof(X.FUShort)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), globalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), globalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), globalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
+      }
+      else {
+        Assert.AreEqual(all.Average(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Average(x => x), $"Failed for {nameof(X.FByte)}");
+        Assert.AreEqual(all.Average(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Average(x => x), $"Failed for {nameof(X.FSByte)}");
+        Assert.AreEqual(all.Average(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Average(x => x), $"Failed for {nameof(X.FShort)}");
+        Assert.AreEqual(all.Average(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Average(x => x), $"Failed for {nameof(X.FUShort)}");
+        Assert.AreEqual(all.Average(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(all.Average(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(all.Average(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
+      }
+
+      Assert.AreEqual(all.Average(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Average(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Average(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Average(), $"Failed for {nameof(X.FDecimal)}");
     }
 
     [Test]
     public void MinTest()
     {
-      Assert.AreEqual(all.Min(x => x.FByte), Session.Demand().Query.All<X>().Min(x => x.FByte));
-      Assert.AreEqual(all.Min(x => x.FSByte), Session.Demand().Query.All<X>().Min(x => x.FSByte));
+      Assert.AreEqual(all.Min(x => x.FByte), globalSession.Query.All<X>().Min(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Min(x => x.FSByte), globalSession.Query.All<X>().Min(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Min(x => x.FShort), Session.Demand().Query.All<X>().Min(x => x.FShort));
-      Assert.AreEqual(all.Min(x => x.FUShort), Session.Demand().Query.All<X>().Min(x => x.FUShort));
+      Assert.AreEqual(all.Min(x => x.FShort), globalSession.Query.All<X>().Min(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Min(x => x.FUShort), globalSession.Query.All<X>().Min(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Min(x => x.FInt), Session.Demand().Query.All<X>().Min(x => x.FInt));
-      Assert.AreEqual(all.Min(x => x.FUInt), Session.Demand().Query.All<X>().Min(x => x.FUInt));
+      Assert.AreEqual(all.Min(x => x.FInt), globalSession.Query.All<X>().Min(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Min(x => x.FUInt), globalSession.Query.All<X>().Min(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Min(x => x.FLong), Session.Demand().Query.All<X>().Min(x => x.FLong));
-      Assert.AreEqual(all.Min(x => x.FFloat), Session.Demand().Query.All<X>().Min(x => x.FFloat));
-      Assert.AreEqual(all.Min(x => x.FDecimal), Session.Demand().Query.All<X>().Min(x => x.FDecimal));
+      Assert.AreEqual(all.Min(x => x.FLong), globalSession.Query.All<X>().Min(x => x.FLong), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Min(x => x.FFloat), globalSession.Query.All<X>().Min(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Min(x => x.FDecimal), globalSession.Query.All<X>().Min(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
 
-      Assert.AreEqual(all.Min(x => x.FDateTime), Session.Demand().Query.All<X>().Min(x => x.FDateTime));
-      Assert.AreEqual(all.Min(x => x.FTimeSpan), Session.Demand().Query.All<X>().Min(x => x.FTimeSpan));
+      Assert.AreEqual(all.Min(x => x.FDateTime), globalSession.Query.All<X>().Min(x => x.FDateTime), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Min(x => x.FTimeSpan), globalSession.Query.All<X>().Min(x => x.FTimeSpan), $"Failed for {nameof(X.FTimeSpan)}");
+    }
 
+    [Test]
+    public void MinNoLambdaTest()
+    {
+      Assert.AreEqual(all.Min(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Min(), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Min(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Min(), $"Failed for {nameof(X.FSByte)}");
+
+      Assert.AreEqual(all.Min(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Min(), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Min(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Min(), $"Failed for {nameof(X.FUShort)}");
+
+      Assert.AreEqual(all.Min(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Min(), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Min(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Min(), $"Failed for {nameof(X.FUInt)}");
+
+      Assert.AreEqual(all.Min(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Min(), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Min(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Min(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Min(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Min(), $"Failed for {nameof(X.FDecimal)}");
+
+      Assert.AreEqual(all.Min(x => x.FDateTime), globalSession.Query.All<X>().Select(x => x.FDateTime).Min(), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Min(x => x.FTimeSpan), globalSession.Query.All<X>().Select(x => x.FTimeSpan).Min(), $"Failed for {nameof(X.FTimeSpan)}");
+    }
+
+    [Test]
+    public void MinByValueItselfTest()
+    {
+      Assert.AreEqual(all.Min(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Min(x => x), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Min(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Min(x => x), $"Failed for {nameof(X.FSByte)}");
+
+      Assert.AreEqual(all.Min(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Min(x => x), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Min(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Min(x => x), $"Failed for {nameof(X.FUShort)}");
+
+      Assert.AreEqual(all.Min(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Min(x => x), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Min(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Min(x => x), $"Failed for {nameof(X.FUInt)}");
+
+      Assert.AreEqual(all.Min(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Min(x => x), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Min(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Min(x => x), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Min(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Min(x => x), $"Failed for {nameof(X.FDecimal)}");
+
+      Assert.AreEqual(all.Min(x => x.FDateTime), globalSession.Query.All<X>().Select(x => x.FDateTime).Min(x => x), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Min(x => x.FTimeSpan), globalSession.Query.All<X>().Select(x => x.FTimeSpan).Min(x => x), $"Failed for {nameof(X.FTimeSpan)}");
     }
 
     [Test]
     public void MaxTest()
     {
-      Assert.AreEqual(all.Max(x => x.FByte), Session.Demand().Query.All<X>().Max(x => x.FByte));
-      Assert.AreEqual(all.Max(x => x.FSByte), Session.Demand().Query.All<X>().Max(x => x.FSByte));
+      Assert.AreEqual(all.Max(x => x.FByte), globalSession.Query.All<X>().Max(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Max(x => x.FSByte), globalSession.Query.All<X>().Max(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Max(x => x.FShort), Session.Demand().Query.All<X>().Max(x => x.FShort));
-      Assert.AreEqual(all.Max(x => x.FUShort), Session.Demand().Query.All<X>().Max(x => x.FUShort));
+      Assert.AreEqual(all.Max(x => x.FShort), globalSession.Query.All<X>().Max(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Max(x => x.FUShort), globalSession.Query.All<X>().Max(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Max(x => x.FInt), Session.Demand().Query.All<X>().Max(x => x.FInt));
-      Assert.AreEqual(all.Max(x => x.FUInt), Session.Demand().Query.All<X>().Max(x => x.FUInt));
+      Assert.AreEqual(all.Max(x => x.FInt), globalSession.Query.All<X>().Max(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Max(x => x.FUInt), globalSession.Query.All<X>().Max(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Max(x => x.FLong), Session.Demand().Query.All<X>().Max(x => x.FLong));
-      Assert.AreEqual(all.Max(x => x.FFloat), Session.Demand().Query.All<X>().Max(x => x.FFloat));
-      Assert.AreEqual(all.Max(x => x.FDecimal), Session.Demand().Query.All<X>().Max(x => x.FDecimal));
+      Assert.AreEqual(all.Max(x => x.FLong), globalSession.Query.All<X>().Max(x => x.FLong), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Max(x => x.FFloat), globalSession.Query.All<X>().Max(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Max(x => x.FDecimal), globalSession.Query.All<X>().Max(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
 
-      Assert.AreEqual(all.Max(x => x.FDateTime), Session.Demand().Query.All<X>().Max(x => x.FDateTime));
-      Assert.AreEqual(all.Max(x => x.FTimeSpan), Session.Demand().Query.All<X>().Max(x => x.FTimeSpan));
+      Assert.AreEqual(all.Max(x => x.FDateTime), globalSession.Query.All<X>().Max(x => x.FDateTime), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Max(x => x.FTimeSpan), globalSession.Query.All<X>().Max(x => x.FTimeSpan), $"Failed for {nameof(X.FTimeSpan)}");
+    }
+
+    [Test]
+    public void MaxNoLambdaTest()
+    {
+      Assert.AreEqual(all.Max(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Max(), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Max(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Max(), $"Failed for {nameof(X.FSByte)}");
+
+      Assert.AreEqual(all.Max(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Max(), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Max(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Max(), $"Failed for {nameof(X.FUShort)}");
+
+      Assert.AreEqual(all.Max(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Max(), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Max(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Max(), $"Failed for {nameof(X.FUInt)}");
+
+      Assert.AreEqual(all.Max(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Max(), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Max(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Max(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Max(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Max(), $"Failed for {nameof(X.FDecimal)}");
+
+      Assert.AreEqual(all.Max(x => x.FDateTime), globalSession.Query.All<X>().Select(x => x.FDateTime).Max(), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Max(x => x.FTimeSpan), globalSession.Query.All<X>().Select(x => x.FTimeSpan).Max(), $"Failed for {nameof(X.FTimeSpan)}");
+    }
+
+    [Test]
+    public void MaxByValueItselfTest()
+    {
+      Assert.AreEqual(all.Max(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Max(x => x), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Max(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Max(x => x), $"Failed for {nameof(X.FSByte)}");
+
+      Assert.AreEqual(all.Max(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Max(x => x), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Max(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Max(x => x), $"Failed for {nameof(X.FUShort)}");
+
+      Assert.AreEqual(all.Max(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Max(x => x), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Max(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Max(x => x), $"Failed for {nameof(X.FUInt)}");
+
+      Assert.AreEqual(all.Max(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Max(x => x), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Max(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Max(x => x), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Max(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Max(x => x), $"Failed for {nameof(X.FDecimal)}");
+
+      Assert.AreEqual(all.Max(x => x.FDateTime), globalSession.Query.All<X>().Select(x => x.FDateTime).Max(x => x), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Max(x => x.FTimeSpan), globalSession.Query.All<X>().Select(x => x.FTimeSpan).Max(x => x), $"Failed for {nameof(X.FTimeSpan)}");
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -715,18 +715,8 @@ namespace Xtensive.Orm.Linq
       var originProjection = origin.First;
       var originColumnIndex = origin.Second;
 
-      // experiments
-
-      var headerColumns = originProjection.ItemProjector.DataSource.Header.Columns;
-      var aggregatedColumn = headerColumns[originColumnIndex];
-
-      // For decimal type we try to guess result precision and scale to avoid
-      // usage of general values which can create some issues result reading
-      (int precision, int scale)? aggregateTypeHints = TryGuessDecimalPrecisionAndSclale(aggregatedColumn, headerColumns, context.Model);
-
-      var aggregateDescriptor = aggregateTypeHints.HasValue
-        ? new AggregateColumnDescriptor(context.GetNextColumnAlias(), originColumnIndex, aggregateType, aggregateTypeHints.Value)
-        : new AggregateColumnDescriptor(context.GetNextColumnAlias(), originColumnIndex, aggregateType);
+      var aggregateDescriptor = new AggregateColumnDescriptor(
+        context.GetNextColumnAlias(), originColumnIndex, aggregateType);
       var originDataSource = originProjection.ItemProjector.DataSource;
       var resultDataSource = originDataSource.Aggregate(null, aggregateDescriptor);
 
@@ -808,55 +798,6 @@ namespace Xtensive.Orm.Linq
         return Expression.Convert(result, resultType);
       }
       return result;
-
-
-      static (int, int)? TryGuessDecimalPrecisionAndSclale(Column aggregatedColumn, Rse.ColumnCollection headerColumns, Orm.Model.DomainModel domainModel)
-      {
-        if (aggregatedColumn.Type != WellKnownTypes.Decimal)
-          return null;
-
-        if (aggregatedColumn is MappedColumn mColumn) {
-          var resolvedColumn = mColumn.ColumnInfoRef.Resolve(domainModel);
-          if (resolvedColumn.Precision.HasValue && resolvedColumn.Scale.HasValue)
-            return (resolvedColumn.Precision.Value, resolvedColumn.Scale.Value);
-        }
-        else if (aggregatedColumn is CalculatedColumn cColumn) {
-          var expression = cColumn.Expression;
-          var usedColumns = new Rse.Transformation.TupleAccessGatherer().Gather(expression);
-
-          var maxFloorDigits = -1;
-          var maxScaleDigits = -1;
-          foreach (var cIndex in usedColumns.Distinct()) {
-            var usedColumn = headerColumns[cIndex];
-            if (usedColumn is MappedColumn mmColumn) {
-              var resolvedColumn = mmColumn.ColumnInfoRef.Resolve(domainModel);
-
-              (int? p, int? s) @params = Type.GetTypeCode(resolvedColumn.ValueType) switch {
-                TypeCode.Decimal => (resolvedColumn.Precision, resolvedColumn.Scale),
-                TypeCode.Int32 or TypeCode.UInt32 => (19, 8),
-                TypeCode.Int64 or TypeCode.UInt64 => (28, 8),
-                TypeCode.Byte  or TypeCode.SByte => (8, 5),
-                TypeCode.Int16 or TypeCode.UInt16 => (10, 5),
-                _ => (null, null),
-              };
-
-              if (@params.p.HasValue && @params.s.HasValue) {
-                if (maxScaleDigits < @params.s.Value)
-                  maxScaleDigits = @params.s.Value;
-                var floorDigits = @params.p.Value - @params.s.Value;
-                if (maxFloorDigits < floorDigits)
-                  maxFloorDigits = floorDigits;
-              }
-            }
-          }
-          if (maxFloorDigits == -1 || maxScaleDigits == -1)
-            return null;
-          if (maxFloorDigits + maxScaleDigits <= 28)
-            return (maxFloorDigits + maxScaleDigits, maxScaleDigits);
-        }
-
-        return null;
-      }
     }
 
     private CompilableProvider ChooseSourceForAggregate(CompilableProvider left, CompilableProvider right,

--- a/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
@@ -168,31 +168,29 @@ namespace Xtensive.Orm.Providers
     {
       var unordered = Domain.Services.GetAll<IQueryPreprocessor>();
       var ordered = unordered.SortTopologically((first, second) => second.IsDependentOn(first));
-      if (ordered==null)
-        throw new InvalidOperationException(Strings.ExCyclicDependencyInQueryPreprocessorGraphIsDetected);
-      QueryPreprocessors = ordered;
+      QueryPreprocessors = ordered ?? throw new InvalidOperationException(Strings.ExCyclicDependencyInQueryPreprocessorGraphIsDetected);
     }
 
     private static ProviderOrderingDescriptor ResolveOrderingDescriptor(CompilableProvider provider)
     {
-      bool isOrderSensitive = provider.Type==ProviderType.Skip 
-        || provider.Type == ProviderType.Take
-        || provider.Type == ProviderType.Seek
-        || provider.Type == ProviderType.Paging
-        || provider.Type == ProviderType.RowNumber;
-      bool preservesOrder = provider.Type==ProviderType.Take
-        || provider.Type == ProviderType.Skip
-        || provider.Type == ProviderType.Seek
-        || provider.Type == ProviderType.RowNumber
-        || provider.Type == ProviderType.Paging
-        || provider.Type == ProviderType.Distinct
-        || provider.Type == ProviderType.Alias;
-      bool isOrderBreaker = provider.Type == ProviderType.Except
-        || provider.Type == ProviderType.Intersect
-        || provider.Type == ProviderType.Union
-        || provider.Type == ProviderType.Concat
-        || provider.Type == ProviderType.Existence;
-      bool isSorter = provider.Type==ProviderType.Sort || provider.Type == ProviderType.Index;
+      var isOrderSensitive = provider.Type is ProviderType.Skip
+        or ProviderType.Take
+        or ProviderType.Seek
+        or ProviderType.Paging
+        or ProviderType.RowNumber;
+      var preservesOrder = provider.Type is ProviderType.Skip
+        or ProviderType.Take
+        or ProviderType.Seek
+        or ProviderType.Paging
+        or ProviderType.RowNumber
+        or ProviderType.Distinct
+        or ProviderType.Alias;
+      var isOrderBreaker = provider.Type is ProviderType.Except
+        or ProviderType.Intersect
+        or ProviderType.Union
+        or ProviderType.Concat
+        or ProviderType.Existence;
+      var isSorter = provider.Type is ProviderType.Sort or ProviderType.Index;
       return new ProviderOrderingDescriptor(isOrderSensitive, preservesOrder, isOrderBreaker, isSorter);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
@@ -23,16 +23,26 @@ namespace Xtensive.Orm.Rse
   /// </summary>
   public static class CompilableProviderExtensions
   {
-    public static CompilableProvider Calculate(this CompilableProvider source,
+    public static CalculateProvider Calculate(this CompilableProvider source,
       params CalculatedColumnDescriptor[] columns)
     {
-      return new CalculateProvider(source, (IReadOnlyList<CalculatedColumnDescriptor>) columns);
+      return new CalculateProvider(source, columns, false);
     }
 
-    public static CompilableProvider Calculate(this CompilableProvider source, bool isInlined,
+    public static CalculateProvider Calculate(this CompilableProvider source, bool isInlined,
       params CalculatedColumnDescriptor[] columns)
     {
-      return new CalculateProvider(source, (IReadOnlyList<CalculatedColumnDescriptor>) columns, isInlined);
+      return new CalculateProvider(source, columns, isInlined);
+    }
+
+    public static CalculateProvider Calculate(this CompilableProvider source, IReadOnlyList<CalculatedColumnDescriptor> columns)
+    {
+      return new CalculateProvider(source, columns);
+    }
+
+    public static CalculateProvider Calculate(this CompilableProvider source, bool isInlined, IReadOnlyList<CalculatedColumnDescriptor> columns)
+    {
+      return new CalculateProvider(source, columns, isInlined);
     }
 
     public static CompilableProvider RowNumber(this CompilableProvider source, string columnName)

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -168,7 +168,7 @@ namespace Xtensive.Orm.Rse.Providers
       }
       if (!translated && source == provider.Source)
         return provider;
-      return new CalculateProvider(source, descriptors);
+      return source.Calculate(descriptors);
     }
 
     protected override Provider VisitRowNumber(RowNumberProvider provider)

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/AggregateOverDecimalColumnCorrector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/AggregateOverDecimalColumnCorrector.cs
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using Xtensive.Orm.Model;
+using Xtensive.Orm.Rse.Compilation;
+using Xtensive.Orm.Rse.Providers;
+
+namespace Xtensive.Orm.Rse.Transformation
+{
+  /// <summary>
+  /// Corrects <see cref="AggregateProvider"/>'s columns of <see cref="decimal"/> type
+  /// by adding information about desirable precision and scale (if such info successfully gathered).
+  /// </summary>
+  public sealed class AggregateOverDecimalColumnCorrector : IPreCompiler
+  {
+    private readonly DomainModel domainModel;
+
+    CompilableProvider IPreCompiler.Process(CompilableProvider rootProvider)
+    {
+      return new DecimalAggregateColumnRewriter(domainModel, rootProvider).Rewrite();
+    }
+
+    public AggregateOverDecimalColumnCorrector(DomainModel domainModel)
+    {
+      this.domainModel = domainModel;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -317,7 +317,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
       return !translated && newSourceProvider == provider.Source && descriptors.Count == provider.CalculatedColumns.Length
         ? provider
-        : new CalculateProvider(newSourceProvider, descriptors);
+        : newSourceProvider.Calculate(descriptors);
     }
 
     protected override Provider VisitRowNumber(RowNumberProvider provider)

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
@@ -396,7 +396,7 @@ namespace Xtensive.Orm.Rse.Transformation
       var ccds = provider.CalculatedColumns
         .SelectToArray(
           column => new CalculatedColumnDescriptor(column.Name, column.Type, column.Expression));
-      return new CalculateProvider(source, (IReadOnlyList<CalculatedColumnDescriptor>) ccds);
+      return source.Calculate(ccds);
     }
 
     private CalculateProvider RewriteCalculateColumnExpressions(
@@ -412,7 +412,7 @@ namespace Xtensive.Orm.Rse.Transformation
           var currentName = columnCollection.Single(c => c.Index==column.Index).Name;
           return new CalculatedColumnDescriptor(currentName, column.Type, newColumnExpression);
         });
-      return new CalculateProvider(source, (IReadOnlyList<CalculatedColumnDescriptor>) ccd);
+      return source.Calculate(ccd);
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/DecimalAggregateColumnRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/DecimalAggregateColumnRewriter.cs
@@ -1,0 +1,131 @@
+// Copyright (C) 2025 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xtensive.Orm.Model;
+using Xtensive.Orm.Rse.Providers;
+using Xtensive.Reflection;
+
+
+namespace Xtensive.Orm.Rse.Transformation
+{
+  internal sealed class DecimalAggregateColumnRewriter : CompilableProviderVisitor
+  {
+    private readonly List<CalculateProvider> calculateProviders = new();
+    private readonly DomainModel domainModel;
+    private readonly CompilableProvider rootProvider;
+
+    public CompilableProvider Rewrite()
+    {
+      return VisitCompilable(rootProvider);
+    }
+
+    protected override Provider VisitAggregate(AggregateProvider provider)
+    {
+      OnRecursionEntrance(provider);
+      var source = VisitCompilable(provider.Source);
+      var resultParameters = OnRecursionExit(provider);
+      var shouldUseNewProvider = source != provider.Source && resultParameters == null;
+
+      var aggregateColumns = provider.AggregateColumns;
+      var headerColumns = source.Header.Columns;
+      var newDescriptors = new AggregateColumnDescriptor[aggregateColumns.Length];
+
+      for (int i = 0, count = aggregateColumns.Length; i < count; i++) {
+        var column = aggregateColumns[i];
+        if (column.Type == WellKnownTypes.Decimal) {
+          var originDescriptor = column.Descriptor;
+          var aggregatedColumn = headerColumns[originDescriptor.SourceIndex];
+
+          var hints = TryGuessDecimalPrecisionAndSclale(aggregatedColumn, source);
+          if (hints.HasValue) {
+            newDescriptors[i] = new AggregateColumnDescriptor(originDescriptor.Name, originDescriptor.SourceIndex, originDescriptor.AggregateType, hints.Value);
+            shouldUseNewProvider = true;
+            continue;
+          }
+        }
+        newDescriptors[i] = column.Descriptor;
+      }
+
+      if (!shouldUseNewProvider) {
+        return provider;
+      }
+
+      return source.Aggregate(provider.GroupColumnIndexes, newDescriptors);
+    }
+
+    protected override Provider VisitCalculate(CalculateProvider provider)
+    {
+      var visitedProvider = base.VisitCalculate(provider);
+      calculateProviders.Add((CalculateProvider) visitedProvider);
+      return visitedProvider;
+    }
+
+
+    private (int, int)? TryGuessDecimalPrecisionAndSclale(
+      Column aggregatedColumn, CompilableProvider originDataSource)
+    {
+      var headerColumns = originDataSource.Header.Columns;
+
+      if (aggregatedColumn is MappedColumn mColumn) {
+        var resolvedColumn = mColumn.ColumnInfoRef.Resolve(domainModel);
+        if (resolvedColumn.Precision.HasValue && resolvedColumn.Scale.HasValue)
+          return (resolvedColumn.Precision.Value, resolvedColumn.Scale.Value);
+      }
+      else if (aggregatedColumn is CalculatedColumn cColumn) {
+        if (headerColumns.Count == 1) {
+          // If current source contains only calculated column which is aggregate,
+          // that means it uses indexes of its source in the calculated column
+          var ownerProvider = calculateProviders.FirstOrDefault(cp => cp.CalculatedColumns.Contains(cColumn));
+          if (ownerProvider == null)
+            return null;
+          headerColumns = ownerProvider.Header.Columns;
+        }
+        var expression = cColumn.Expression;
+        var usedColumns = new TupleAccessGatherer().Gather(expression);
+
+        var maxFloorDigits = -1;
+        var maxScaleDigits = -1;
+        foreach (var cIndex in usedColumns.Distinct()) {
+          var usedColumn = headerColumns[cIndex];
+          if (usedColumn is MappedColumn mmColumn) {
+            var resolvedColumn = mmColumn.ColumnInfoRef.Resolve(domainModel);
+
+            (int? p, int? s) @params = Type.GetTypeCode(resolvedColumn.ValueType) switch {
+              TypeCode.Decimal => (resolvedColumn.Precision, resolvedColumn.Scale),
+              TypeCode.Int32 or TypeCode.UInt32 => (19, 8),
+              TypeCode.Int64 or TypeCode.UInt64 => (28, 8),
+              TypeCode.Byte or TypeCode.SByte => (8, 5),
+              TypeCode.Int16 or TypeCode.UInt16 => (10, 5),
+              _ => (null, null),
+            };
+
+            if (@params.p.HasValue && @params.s.HasValue) {
+              if (maxScaleDigits < @params.s.Value)
+                maxScaleDigits = @params.s.Value;
+              var floorDigits = @params.p.Value - @params.s.Value;
+              if (maxFloorDigits < floorDigits)
+                maxFloorDigits = floorDigits;
+            }
+          }
+        }
+
+        if (maxFloorDigits == -1 || maxScaleDigits == -1)
+          return null;
+        if (maxFloorDigits + maxScaleDigits <= 28)
+          return (maxFloorDigits + maxScaleDigits, maxScaleDigits);
+      }
+
+      return null;
+    }
+
+    public DecimalAggregateColumnRewriter(DomainModel model, CompilableProvider rootProvider)
+    {
+      domainModel = model;
+      this.rootProvider = rootProvider;
+    }
+  }
+}


### PR DESCRIPTION
- Reverts ```Translator.Queryable``` changes connected with guessing of precision and scale for actual decimal expression for aggregates;
- Adds ```IPreCompiler``` that does the guessing and extends data of ```AggregateColumnDescriptor``` if needed
- Applies the pre-compiler for postgre only
- Extends aggregate tests 

Includes case declared in #414
Addresses #415
