### PR TITLE
AutoBuildTest: Global session for read-only tests

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Framework/AutoBuildTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/AutoBuildTest.cs
@@ -18,6 +18,8 @@ namespace Xtensive.Orm.Tests
   public abstract class AutoBuildTest : HasConfigurationAccessTest
   {
     private const string ErrorInTestFixtureSetup = "Error in TestFixtureSetUp:\r\n{0}";
+    private const string ErrorNotInitializedGlobalSession = "Set InitGlobalSession to true";
+
     private DisposableSet disposables;
     private (Session session, TransactionScope transaction) globalSessionAndTransaction;
 
@@ -33,8 +35,8 @@ namespace Xtensive.Orm.Tests
     // Use these two for read-only tests only, don't change them, they are controlled by AutoBuildTest.
     // If there is need to change Session/Transactionscope or add/modify/remove entities
     // then open dedicated Session/TransactionScope within test
-    protected Session GlobalSession => InitGlobalSession ? globalSessionAndTransaction.session : throw new Exception("Set UseGlobalSession to true");
-    protected TransactionScope GlobalTransaction => InitGlobalSession ? globalSessionAndTransaction.transaction : throw new Exception("Set UseGlobalSession to true");
+    protected Session GlobalSession => InitGlobalSession ? globalSessionAndTransaction.session : throw new Exception(ErrorNotInitializedGlobalSession);
+    protected TransactionScope GlobalTransaction => InitGlobalSession ? globalSessionAndTransaction.transaction : throw new Exception(ErrorNotInitializedGlobalSession);
 
     [OneTimeSetUp]
     public virtual void TestFixtureSetUp()

--- a/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/AggregatesProblemTestBase.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/AggregatesRelatedIssues/IssueJira0786/AggregatesProblemTestBase.cs
@@ -15,14 +15,11 @@ namespace Xtensive.Orm.Tests.Issues.IssueJira0786_AggregatesProblem
 {
   public abstract class AggregatesProblemTestBase : AutoBuildTest
   {
-    private bool refillDatabase = false;
-
     protected decimal FloatValueAccuracy { get; private set; } = 0.000001m;
     protected decimal DoubleValueAccuracy { get; private set; } = 0.00000000000001m;
     protected decimal DecimalValueAccuracy { get; private set; } = 0.00000000000000001m;
 
-    protected Session GlobalSession { get; private set; }
-    protected TransactionScope GlobalTransaction { get; private set; }
+    protected override bool InitGlobalSession => true;
 
     protected override DomainConfiguration BuildConfiguration()
     {
@@ -45,8 +42,6 @@ namespace Xtensive.Orm.Tests.Issues.IssueJira0786_AggregatesProblem
         DoubleValueAccuracy = 0.00001m;
         DecimalValueAccuracy = 0.00001m;
       }
-
-      (GlobalSession, GlobalTransaction) = CreateSessionAndTransaction();
 
       _ = new TestEntity(GlobalSession) {
         ByteValue = 2,

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue0435_BatchingFail.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue0435_BatchingFail.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-20223 Xtensive LLC.
+// Copyright (C) 2009-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -28,17 +28,13 @@ namespace Xtensive.Orm.Tests.Issues
 {
   public class Issue0435_BatchingFail : AutoBuildTest
   {
+    protected override bool InitGlobalSession => true;
+
     protected override DomainConfiguration BuildConfiguration()
     {
       var configuration = base.BuildConfiguration();
       configuration.Types.Register(typeof (MyEntity));
       return configuration;
-    }
-
-    public override void TestFixtureSetUp()
-    {
-      base.TestFixtureSetUp();
-      _ = CreateSessionAndTransaction();
     }
 
     [Test]
@@ -52,7 +48,7 @@ namespace Xtensive.Orm.Tests.Issues
         Text = "Entity 2"
       }; // Nothing is sent to server yet
 
-      foreach (var e in Session.Demand().Query.All<MyEntity>()) // Batch is sent
+      foreach (var e in GlobalSession.Query.All<MyEntity>()) // Batch is sent
         Console.WriteLine("Entity.Text: {0}", e.Text); 
     }
 
@@ -67,9 +63,9 @@ namespace Xtensive.Orm.Tests.Issues
           Text = "Entity 2"
       }; // Nothing is sent to server yet
 
-      var futureCount = Session.Demand().Query.CreateDelayedQuery(qe => qe.All<MyEntity>().Count());
+      var futureCount = GlobalSession.Query.CreateDelayedQuery(qe => qe.All<MyEntity>().Count());
 
-      foreach (var e in Session.Demand().Query.All<MyEntity>()) // Batch is sent
+      foreach (var e in GlobalSession.Query.All<MyEntity>()) // Batch is sent
         Console.WriteLine("Entity.Text: {0}", e.Text); 
       Console.WriteLine("Count: {0}", futureCount.Value);
     }

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0187_TypeCastInContain.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0187_TypeCastInContain.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2023 Xtensive LLC.
+// Copyright (C) 2011-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -43,6 +43,8 @@ namespace Xtensive.Orm.Tests.Issues
 {
   public class Issue_TypeCastInContain : AutoBuildTest
   {
+    protected override bool InitGlobalSession => true;
+
     protected override DomainConfiguration BuildConfiguration()
     {
       var config = base.BuildConfiguration();
@@ -50,52 +52,46 @@ namespace Xtensive.Orm.Tests.Issues
       return config;
     }
 
-    public override void TestFixtureSetUp()
-    {
-      base.TestFixtureSetUp();
-      _ = CreateSessionAndTransaction();
-    }
-
     [Test]
     public void ParentsContainsChildWithImplicitCastTest()
     {
-      var parents = Query.All<Parent>().ToArray();
-      var result = Query.All<Child>().Where(child => parents.Contains(child)).ToArray();
+      var parents = GlobalSession.Query.All<Parent>().ToArray();
+      var result = GlobalSession.Query.All<Child>().Where(child => parents.Contains(child)).ToArray();
     }
 
     [Test]
     public void ParentsContainsChildWithExplicitCastTest()
     {
-      var parents = Query.All<Parent>().ToArray();
-      var result = Query.All<Child>().Where(child => parents.Contains(child as Parent)).ToArray();
+      var parents = GlobalSession.Query.All<Parent>().ToArray();
+      var result = GlobalSession.Query.All<Child>().Where(child => parents.Contains(child as Parent)).ToArray();
     }
 
     [Test]
     public void ChildInParentsTest()
     {
-      var parents = Query.All<Parent>().ToArray();
-      var result = Query.All<Child>().Where(child => child.In(parents)).ToArray();
+      var parents = GlobalSession.Query.All<Parent>().ToArray();
+      var result = GlobalSession.Query.All<Child>().Where(child => child.In(parents)).ToArray();
     }
 
     [Test]
     public void ChildContainsParentWithImplicitCast()
     {
-      var children = Query.All<Child>().ToArray();
-      var result = Query.All<Child>().Where(a => children.Contains(a.Parent)).ToArray();
+      var children = GlobalSession.Query.All<Child>().ToArray();
+      var result = GlobalSession.Query.All<Child>().Where(a => children.Contains(a.Parent)).ToArray();
     }
 
     [Test]
     public void ChildContainsParentWithExplicitCast()
     {
-      var children = Query.All<Child>().ToArray();
-      var result = Query.All<Child>().Where(a => (children as IEnumerable<Parent>).Contains(a.Parent)).ToArray();
+      var children = GlobalSession.Query.All<Child>().ToArray();
+      var result = GlobalSession.Query.All<Child>().Where(a => (children as IEnumerable<Parent>).Contains(a.Parent)).ToArray();
     }
 
     [Test]
     public void ParentInChildrenTest()
     {
-      var children = Query.All<Child>().ToArray();
-      var result = Query.All<Child>().Where(a => a.Parent.In(children)).ToArray();
+      var children = GlobalSession.Query.All<Child>().ToArray();
+      var result = GlobalSession.Query.All<Child>().Where(a => a.Parent.In(children)).ToArray();
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Linq/ConvariantQueriesTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/ConvariantQueriesTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2023 Xtensive LLC.
+// Copyright (C) 2011-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -32,6 +32,8 @@ namespace Xtensive.Orm.Tests.Linq
 {
   public class ConvariantQueriesTest : AutoBuildTest
   {
+    protected override bool InitGlobalSession => true;
+
     protected override DomainConfiguration BuildConfiguration()
     {
       var config = base.BuildConfiguration();
@@ -39,24 +41,18 @@ namespace Xtensive.Orm.Tests.Linq
       return config;
     }
 
-    public override void TestFixtureSetUp()
-    {
-      base.TestFixtureSetUp();
-      _ = CreateSessionAndTransaction();
-    }
-
     [Test]
     public void ConcatTest()
     {
-      var q1 = Query.All<MyBaseEntity>().Concat(Query.All<MyChildEntity>()).ToList();
-      var q2 = Query.All<MyChildEntity>().Concat(Query.All<MyBaseEntity>()).ToList();
+      var q1 = GlobalSession.Query.All<MyBaseEntity>().Concat(GlobalSession.Query.All<MyChildEntity>()).ToList();
+      var q2 = GlobalSession.Query.All<MyChildEntity>().Concat(GlobalSession.Query.All<MyBaseEntity>()).ToList();
     }
 
     [Test]
     public void UnionTest()
     {
-      var q1 = Query.All<MyBaseEntity>().Union(Query.All<MyChildEntity>()).ToList();
-      var q2 = Query.All<MyChildEntity>().Union(Query.All<MyBaseEntity>()).ToList();
+      var q1 = GlobalSession.Query.All<MyBaseEntity>().Union(GlobalSession.Query.All<MyChildEntity>()).ToList();
+      var q2 = GlobalSession.Query.All<MyChildEntity>().Union(GlobalSession.Query.All<MyBaseEntity>()).ToList();
     }
 
     [Test]
@@ -64,8 +60,8 @@ namespace Xtensive.Orm.Tests.Linq
     {
       //some storages does not support Intersect operation
       Require.ProviderIsNot(StorageProvider.Firebird | StorageProvider.MySql);
-      var q1 = Query.All<MyBaseEntity>().Intersect(Query.All<MyChildEntity>()).ToList();
-      var q2 = Query.All<MyChildEntity>().Intersect(Query.All<MyBaseEntity>()).ToList();
+      var q1 = GlobalSession.Query.All<MyBaseEntity>().Intersect(GlobalSession.Query.All<MyChildEntity>()).ToList();
+      var q2 = GlobalSession.Query.All<MyChildEntity>().Intersect(GlobalSession.Query.All<MyBaseEntity>()).ToList();
     }
 
     [Test]
@@ -73,29 +69,29 @@ namespace Xtensive.Orm.Tests.Linq
     {
       //Some storages does not support Except operation 
       Require.ProviderIsNot(StorageProvider.Firebird | StorageProvider.MySql);
-      var q1 = Query.All<MyBaseEntity>().Except(Query.All<MyChildEntity>()).ToList();
-      var q2 = Query.All<MyChildEntity>().Except(Query.All<MyBaseEntity>()).ToList();
+      var q1 = GlobalSession.Query.All<MyBaseEntity>().Except(GlobalSession.Query.All<MyChildEntity>()).ToList();
+      var q2 = GlobalSession.Query.All<MyChildEntity>().Except(GlobalSession.Query.All<MyBaseEntity>()).ToList();
     }
 
     [Test]
     public void ContainsTest()
     {
-      var q1 = Query.All<MyBaseEntity>()
-        .Where(baseEntity => Query.All<MyChildEntity>().Contains(baseEntity))
+      var q1 = GlobalSession.Query.All<MyBaseEntity>()
+        .Where(baseEntity => GlobalSession.Query.All<MyChildEntity>().Contains(baseEntity))
         .ToList();
-      var q2 = Query.All<MyChildEntity>()
-        .Where(childEntity => Query.All<MyBaseEntity>().Contains(childEntity))
+      var q2 = GlobalSession.Query.All<MyChildEntity>()
+        .Where(childEntity => GlobalSession.Query.All<MyBaseEntity>().Contains(childEntity))
         .ToList();
     }
 
     [Test]
     public void InTest()
     {
-      var q1 = Query.All<MyBaseEntity>()
-        .Where(baseEntity => baseEntity.In(Query.All<MyChildEntity>()))
+      var q1 = GlobalSession.Query.All<MyBaseEntity>()
+        .Where(baseEntity => baseEntity.In(GlobalSession.Query.All<MyChildEntity>()))
         .ToList();
-      var q2 = Query.All<MyChildEntity>()
-        .Where(childEntity => childEntity.In(Query.All<MyBaseEntity>()))
+      var q2 = GlobalSession.Query.All<MyChildEntity>()
+        .Where(childEntity => childEntity.In(GlobalSession.Query.All<MyBaseEntity>()))
         .ToList();
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
@@ -171,8 +171,7 @@ namespace Xtensive.Orm.Tests.Linq
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      CreateSessionAndTransaction();
-      sharedSession = Session.Current;
+      sharedSession = CreateSessionAndTransaction().Item1;
       castSign = StorageProviderInfo.Instance.CheckProviderIs(StorageProvider.PostgreSql)
         ? "::"
         : "CAST";

--- a/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/WhereByEnumTest.cs
@@ -165,21 +165,23 @@ namespace Xtensive.Orm.Tests.Linq
 {
   public class WhereByEnumTest : AutoBuildTest
   {
-    private Session sharedSession;
     private string castSign;
+    private QueryFormatter queryFormatter;
+
+    protected override bool InitGlobalSession => true;
 
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      sharedSession = CreateSessionAndTransaction().Item1;
       castSign = StorageProviderInfo.Instance.CheckProviderIs(StorageProvider.PostgreSql)
         ? "::"
         : "CAST";
+      queryFormatter = GlobalSession.Services.Demand<QueryFormatter>();
     }
 
     public override void TestFixtureTearDown()
     {
-      sharedSession = null;
+      queryFormatter = null;
       base.TestFixtureTearDown();
     }
 
@@ -193,78 +195,72 @@ namespace Xtensive.Orm.Tests.Linq
 
     protected override void PopulateData()
     {
-      using (var session = Domain.OpenSession())
-      using (var tx = session.OpenTransaction()) {
-        _ = new EnumContainer(session, EnumContainer.Zero);
-        _ = new EnumContainer(session, EnumContainer.One);
-        _ = new EnumContainer(session, EnumContainer.Two);
-        _ = new EnumContainer(session, EnumContainer.Max);
-        tx.Complete();
-      }
+      _ = new EnumContainer(GlobalSession, EnumContainer.Zero);
+      _ = new EnumContainer(GlobalSession, EnumContainer.One);
+      _ = new EnumContainer(GlobalSession, EnumContainer.Two);
+      _ = new EnumContainer(GlobalSession, EnumContainer.Max);
     }
 
     [Test]
     public void ByteTest()
     {
-      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
-      
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField != ByteEnum.Zero);
+      var query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField != ByteEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField > ByteEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField > ByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField >= ByteEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField >= ByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField < ByteEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField < ByteEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField <= ByteEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField <= ByteEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ByteEnumField == ByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField != ByteEnum.Zero);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField != ByteEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField > ByteEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField > ByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField >= ByteEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField >= ByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField < ByteEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField < ByteEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField <= ByteEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField <= ByteEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NByteEnumField == ByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -273,65 +269,63 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void SByteTest()
     {
-      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
-
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField != SByteEnum.Zero);
+      var query = GlobalSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField != SByteEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField > SByteEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField > SByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField >= SByteEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField >= SByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField < SByteEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField < SByteEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField <= SByteEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField <= SByteEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.SByteEnumField == SByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField != SByteEnum.Zero);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField != SByteEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField > SByteEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField > SByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField >= SByteEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField >= SByteEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField < SByteEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField < SByteEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField <= SByteEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField <= SByteEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NSByteEnumField == SByteEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -340,55 +334,53 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void ShortTest()
     {
-      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
-
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Zero);
+      var query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField != ShortEnum.Zero);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField != ShortEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField > ShortEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField > ShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField >= ShortEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NShortEnumField >= ShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField < ShortEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField < ShortEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField <= ShortEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField <= ShortEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ShortEnumField == ShortEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -397,65 +389,63 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void UShortTest()
     {
-      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
-
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField != UShortEnum.Zero);
+      var query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField != UShortEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField > UShortEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField > UShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField >= UShortEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField >= UShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField < UShortEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField < UShortEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField <= UShortEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField <= UShortEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField != UShortEnum.Zero);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField != UShortEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField > UShortEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField > UShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField >= UShortEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField >= UShortEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField < UShortEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField < UShortEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField <= UShortEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUShortEnumField <= UShortEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UShortEnumField == UShortEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -464,65 +454,63 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void IntTest()
     {
-      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
-
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField != IntEnum.Zero);
+      var query = GlobalSession.Query.All<EnumContainer>().Where(e => e.IntEnumField != IntEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField > IntEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.IntEnumField > IntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField >= IntEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.IntEnumField >= IntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField < IntEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.IntEnumField < IntEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField <= IntEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.IntEnumField <= IntEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.IntEnumField == IntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField != IntEnum.Zero);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField != IntEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField > IntEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField > IntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField >= IntEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField >= IntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField < IntEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField < IntEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField <= IntEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField <= IntEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NIntEnumField == IntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -531,65 +519,63 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void UIntTest()
     {
-      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
-
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField != UIntEnum.Zero);
+      var query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField != UIntEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField > UIntEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField > UIntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField >= UIntEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField >= UIntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField < UIntEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField < UIntEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField <= UIntEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField <= UIntEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.UIntEnumField == UIntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField != UIntEnum.Zero);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField != UIntEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField > UIntEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField > UIntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField >= UIntEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField >= UIntEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField < UIntEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField < UIntEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField <= UIntEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField <= UIntEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NUIntEnumField == UIntEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -598,69 +584,67 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void LongTest()
     {
-      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
-
       var substractValue = StorageProviderInfo.Instance.CheckProviderIs(StorageProvider.SqlServer)
         ? castSign.Length
         : 0;
 
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField != LongEnum.Zero);
+      var query = GlobalSession.Query.All<EnumContainer>().Where(e => e.LongEnumField != LongEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField > LongEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.LongEnumField > LongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField >= LongEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.LongEnumField >= LongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField < LongEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.LongEnumField < LongEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField <= LongEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.LongEnumField <= LongEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.LongEnumField == LongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField != LongEnum.Zero);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField != LongEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField > LongEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField > LongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField >= LongEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField >= LongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField < LongEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField < LongEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField <= LongEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField <= LongEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NLongEnumField == LongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length - substractValue));
       Assert.That(query.Count(), Is.EqualTo(1));
@@ -669,65 +653,63 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void ULongTest()
     {
-      var queryFormatter = sharedSession.Services.Demand<QueryFormatter>();
-
-      var query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField != ULongEnum.Zero);
+      var query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField != ULongEnum.Zero);
       var queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField > ULongEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField > ULongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField >= ULongEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField >= ULongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField < ULongEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField < ULongEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField <= ULongEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField <= ULongEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.ULongEnumField == ULongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));
 
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField != ULongEnum.Zero);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField != ULongEnum.Zero);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField > ULongEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField > ULongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField >= ULongEnum.One);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField >= ULongEnum.One);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField < ULongEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField < ULongEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(2));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField <= ULongEnum.Two);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField <= ULongEnum.Two);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(3));
 
-      query = sharedSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Max);
+      query = GlobalSession.Query.All<EnumContainer>().Where(e => e.NULongEnumField == ULongEnum.Max);
       queryString = queryFormatter.ToSqlString(query);
       Assert.That(queryString.Replace(castSign, "").Length, Is.EqualTo(queryString.Length));
       Assert.That(query.Count(), Is.EqualTo(1));

--- a/Orm/Xtensive.Orm.Tests/Storage/AggregateTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/AggregateTest.cs
@@ -18,8 +18,8 @@ namespace Xtensive.Orm.Tests.Storage
   public class AggregateTest : AutoBuildTest
   {
     private List<X> all;
-    private Session globalSession;
-    private TransactionScope globalTransaction;
+
+    protected override bool InitGlobalSession => true;
 
     protected override DomainConfiguration BuildConfiguration()
     {
@@ -32,7 +32,6 @@ namespace Xtensive.Orm.Tests.Storage
     {
       base.TestFixtureSetUp();
 
-      (globalSession, globalTransaction) = CreateSessionAndTransaction();
       all = new List<X>();
 
       for (var i = 0; i < 10; i++) {
@@ -54,50 +53,50 @@ namespace Xtensive.Orm.Tests.Storage
         all.Add(x);
       }
 
-      globalSession.SaveChanges();
+      GlobalSession.SaveChanges();
     }
     
     [Test]
     public void SumTest()
     {
-      Assert.AreEqual(all.Sum(x => x.FByte), globalSession.Query.All<X>().Sum(x => x.FByte), $"Failed for {nameof(X.FByte)}");
-      Assert.AreEqual(all.Sum(x => x.FSByte), globalSession.Query.All<X>().Sum(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
+      Assert.AreEqual(all.Sum(x => x.FByte), GlobalSession.Query.All<X>().Sum(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Sum(x => x.FSByte), GlobalSession.Query.All<X>().Sum(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Sum(x => x.FShort), globalSession.Query.All<X>().Sum(x => x.FShort), $"Failed for {nameof(X.FShort)}");
-      Assert.AreEqual(all.Sum(x => x.FUShort), globalSession.Query.All<X>().Sum(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
+      Assert.AreEqual(all.Sum(x => x.FShort), GlobalSession.Query.All<X>().Sum(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Sum(x => x.FUShort), GlobalSession.Query.All<X>().Sum(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Sum(x => x.FInt), globalSession.Query.All<X>().Sum(x => x.FInt), $"Failed for {nameof(X.FInt)}");
-      Assert.AreEqual(all.Sum(x => x.FUInt), globalSession.Query.All<X>().Sum(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
+      Assert.AreEqual(all.Sum(x => x.FInt), GlobalSession.Query.All<X>().Sum(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Sum(x => x.FUInt), GlobalSession.Query.All<X>().Sum(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Sum(x => x.FLong), globalSession.Query.All<X>().Sum(x => x.FLong), $"Failed for {nameof(X.FLong)}");
-      Assert.AreEqual(all.Sum(x => x.FFloat), globalSession.Query.All<X>().Sum(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Sum(x => x.FDecimal), globalSession.Query.All<X>().Sum(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Sum(x => x.FLong), GlobalSession.Query.All<X>().Sum(x => x.FLong), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Sum(x => x.FFloat), GlobalSession.Query.All<X>().Sum(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Sum(x => x.FDecimal), GlobalSession.Query.All<X>().Sum(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
     }
 
     [Test]
     public void SumNoLambdaTest()
     {
-      Assert.AreEqual(all.Sum(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Sum(), $"Failed for {nameof(X.FInt)}");
-      Assert.AreEqual(all.Sum(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Sum(), $"Failed for {nameof(X.FLong)}");
-      Assert.AreEqual(all.Sum(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Sum(), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Sum(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Sum(), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Sum(x => x.FInt), GlobalSession.Query.All<X>().Select(x => x.FInt).Sum(), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Sum(x => x.FLong), GlobalSession.Query.All<X>().Select(x => x.FLong).Sum(), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Sum(x => x.FFloat), GlobalSession.Query.All<X>().Select(x => x.FFloat).Sum(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Sum(x => x.FDecimal), GlobalSession.Query.All<X>().Select(x => x.FDecimal).Sum(), $"Failed for {nameof(X.FDecimal)}");
     }
 
     [Test]
     public void SumByValueItselfTest()
     {
-      Assert.AreEqual(all.Sum(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Sum(x => x), $"Failed for {nameof(X.FByte)}");
-      Assert.AreEqual(all.Sum(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Sum(x => x), $"Failed for {nameof(X.FSByte)}");
+      Assert.AreEqual(all.Sum(x => x.FByte), GlobalSession.Query.All<X>().Select(x => x.FByte).Sum(x => x), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Sum(x => x.FSByte), GlobalSession.Query.All<X>().Select(x => x.FSByte).Sum(x => x), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Sum(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Sum(x => x), $"Failed for {nameof(X.FShort)}");
-      Assert.AreEqual(all.Sum(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Sum(x => x), $"Failed for {nameof(X.FUShort)}");
+      Assert.AreEqual(all.Sum(x => x.FShort), GlobalSession.Query.All<X>().Select(x => x.FShort).Sum(x => x), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Sum(x => x.FUShort), GlobalSession.Query.All<X>().Select(x => x.FUShort).Sum(x => x), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Sum(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Sum(x => x), $"Failed for {nameof(X.FInt)}");
-      Assert.AreEqual(all.Sum(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Sum(x => x), $"Failed for {nameof(X.FUInt)}");
+      Assert.AreEqual(all.Sum(x => x.FInt), GlobalSession.Query.All<X>().Select(x => x.FInt).Sum(x => x), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Sum(x => x.FUInt), GlobalSession.Query.All<X>().Select(x => x.FUInt).Sum(x => x), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Sum(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Sum(x => x), $"Failed for {nameof(X.FLong)}");
-      Assert.AreEqual(all.Sum(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Sum(x => x), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Sum(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Sum(x => x), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Sum(x => x.FLong), GlobalSession.Query.All<X>().Select(x => x.FLong).Sum(x => x), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Sum(x => x.FFloat), GlobalSession.Query.All<X>().Select(x => x.FFloat).Sum(x => x), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Sum(x => x.FDecimal), GlobalSession.Query.All<X>().Select(x => x.FDecimal).Sum(x => x), $"Failed for {nameof(X.FDecimal)}");
     }
 
 
@@ -109,26 +108,26 @@ namespace Xtensive.Orm.Tests.Storage
       // © Firebird documentation
       // Funny, isn't it?
       if (Domain.Configuration.ConnectionInfo.Provider==WellKnown.Provider.Firebird) {
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FByte)), globalSession.Query.All<X>().Average(x => x.FByte), $"Failed for {nameof(X.FByte)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FSByte)), globalSession.Query.All<X>().Average(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FShort)), globalSession.Query.All<X>().Average(x => x.FShort), $"Failed for {nameof(X.FShort)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUShort)), globalSession.Query.All<X>().Average(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), globalSession.Query.All<X>().Average(x => x.FInt), $"Failed for {nameof(X.FInt)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), globalSession.Query.All<X>().Average(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), globalSession.Query.All<X>().Average(x => x.FLong), $"Failed for {nameof(X.FLong)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FByte)), GlobalSession.Query.All<X>().Average(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FSByte)), GlobalSession.Query.All<X>().Average(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FShort)), GlobalSession.Query.All<X>().Average(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUShort)), GlobalSession.Query.All<X>().Average(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), GlobalSession.Query.All<X>().Average(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), GlobalSession.Query.All<X>().Average(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), GlobalSession.Query.All<X>().Average(x => x.FLong), $"Failed for {nameof(X.FLong)}");
       }
       else {
-        Assert.AreEqual(all.Average(x => x.FByte), globalSession.Query.All<X>().Average(x => x.FByte), $"Failed for {nameof(X.FByte)}");
-        Assert.AreEqual(all.Average(x => x.FSByte), globalSession.Query.All<X>().Average(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
-        Assert.AreEqual(all.Average(x => x.FShort), globalSession.Query.All<X>().Average(x => x.FShort), $"Failed for {nameof(X.FShort)}");
-        Assert.AreEqual(all.Average(x => x.FUShort), globalSession.Query.All<X>().Average(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
-        Assert.AreEqual(all.Average(x => x.FInt), globalSession.Query.All<X>().Average(x => x.FInt), $"Failed for {nameof(X.FInt)}");
-        Assert.AreEqual(all.Average(x => x.FUInt), globalSession.Query.All<X>().Average(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
-        Assert.AreEqual(all.Average(x => x.FLong), globalSession.Query.All<X>().Average(x => x.FLong), $"Failed for {nameof(X.FLong)}");
+        Assert.AreEqual(all.Average(x => x.FByte), GlobalSession.Query.All<X>().Average(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+        Assert.AreEqual(all.Average(x => x.FSByte), GlobalSession.Query.All<X>().Average(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
+        Assert.AreEqual(all.Average(x => x.FShort), GlobalSession.Query.All<X>().Average(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+        Assert.AreEqual(all.Average(x => x.FUShort), GlobalSession.Query.All<X>().Average(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
+        Assert.AreEqual(all.Average(x => x.FInt), GlobalSession.Query.All<X>().Average(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(all.Average(x => x.FUInt), GlobalSession.Query.All<X>().Average(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(all.Average(x => x.FLong), GlobalSession.Query.All<X>().Average(x => x.FLong), $"Failed for {nameof(X.FLong)}");
       }
 
-      Assert.AreEqual(all.Average(x => x.FFloat), globalSession.Query.All<X>().Average(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Average(x => x.FDecimal), globalSession.Query.All<X>().Average(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Average(x => x.FFloat), GlobalSession.Query.All<X>().Average(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Average(x => x.FDecimal), GlobalSession.Query.All<X>().Average(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
     }
 
     [Test]
@@ -139,18 +138,18 @@ namespace Xtensive.Orm.Tests.Storage
       // © Firebird documentation
       // Funny, isn't it?
       if (Domain.Configuration.ConnectionInfo.Provider == WellKnown.Provider.Firebird) {
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), globalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), globalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), globalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), GlobalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), GlobalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), GlobalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
       }
       else {
-        Assert.AreEqual(all.Average(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
-        Assert.AreEqual(all.Average(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
-        Assert.AreEqual(all.Average(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
+        Assert.AreEqual(all.Average(x => x.FInt), GlobalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(all.Average(x => x.FUInt), GlobalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(all.Average(x => x.FLong), GlobalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
       }
 
-      Assert.AreEqual(all.Average(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Average(), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Average(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Average(), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Average(x => x.FFloat), GlobalSession.Query.All<X>().Select(x => x.FFloat).Average(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Average(x => x.FDecimal), GlobalSession.Query.All<X>().Select(x => x.FDecimal).Average(), $"Failed for {nameof(X.FDecimal)}");
     }
 
     [Test]
@@ -161,146 +160,146 @@ namespace Xtensive.Orm.Tests.Storage
       // © Firebird documentation
       // Funny, isn't it?
       if (Domain.Configuration.ConnectionInfo.Provider == WellKnown.Provider.Firebird) {
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FByte)), globalSession.Query.All<X>().Select(x => x.FByte).Average(x => x), $"Failed for {nameof(X.FByte)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FSByte)), globalSession.Query.All<X>().Select(x => x.FSByte).Average(x => x), $"Failed for {nameof(X.FSByte)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FShort)), globalSession.Query.All<X>().Select(x => x.FShort).Average(x => x), $"Failed for {nameof(X.FShort)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUShort)), globalSession.Query.All<X>().Select(x => x.FUShort).Average(x => x), $"Failed for {nameof(X.FUShort)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), globalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), globalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
-        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), globalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FByte)), GlobalSession.Query.All<X>().Select(x => x.FByte).Average(x => x), $"Failed for {nameof(X.FByte)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FSByte)), GlobalSession.Query.All<X>().Select(x => x.FSByte).Average(x => x), $"Failed for {nameof(X.FSByte)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FShort)), GlobalSession.Query.All<X>().Select(x => x.FShort).Average(x => x), $"Failed for {nameof(X.FShort)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUShort)), GlobalSession.Query.All<X>().Select(x => x.FUShort).Average(x => x), $"Failed for {nameof(X.FUShort)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FInt)), GlobalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FUInt)), GlobalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(Math.Truncate(all.Average(x => x.FLong)), GlobalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
       }
       else {
-        Assert.AreEqual(all.Average(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Average(x => x), $"Failed for {nameof(X.FByte)}");
-        Assert.AreEqual(all.Average(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Average(x => x), $"Failed for {nameof(X.FSByte)}");
-        Assert.AreEqual(all.Average(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Average(x => x), $"Failed for {nameof(X.FShort)}");
-        Assert.AreEqual(all.Average(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Average(x => x), $"Failed for {nameof(X.FUShort)}");
-        Assert.AreEqual(all.Average(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
-        Assert.AreEqual(all.Average(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
-        Assert.AreEqual(all.Average(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
+        Assert.AreEqual(all.Average(x => x.FByte), GlobalSession.Query.All<X>().Select(x => x.FByte).Average(x => x), $"Failed for {nameof(X.FByte)}");
+        Assert.AreEqual(all.Average(x => x.FSByte), GlobalSession.Query.All<X>().Select(x => x.FSByte).Average(x => x), $"Failed for {nameof(X.FSByte)}");
+        Assert.AreEqual(all.Average(x => x.FShort), GlobalSession.Query.All<X>().Select(x => x.FShort).Average(x => x), $"Failed for {nameof(X.FShort)}");
+        Assert.AreEqual(all.Average(x => x.FUShort), GlobalSession.Query.All<X>().Select(x => x.FUShort).Average(x => x), $"Failed for {nameof(X.FUShort)}");
+        Assert.AreEqual(all.Average(x => x.FInt), GlobalSession.Query.All<X>().Select(x => x.FInt).Average(), $"Failed for {nameof(X.FInt)}");
+        Assert.AreEqual(all.Average(x => x.FUInt), GlobalSession.Query.All<X>().Select(x => x.FUInt).Average(x => x), $"Failed for {nameof(X.FUInt)}");
+        Assert.AreEqual(all.Average(x => x.FLong), GlobalSession.Query.All<X>().Select(x => x.FLong).Average(), $"Failed for {nameof(X.FLong)}");
       }
 
-      Assert.AreEqual(all.Average(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Average(), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Average(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Average(), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Average(x => x.FFloat), GlobalSession.Query.All<X>().Select(x => x.FFloat).Average(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Average(x => x.FDecimal), GlobalSession.Query.All<X>().Select(x => x.FDecimal).Average(), $"Failed for {nameof(X.FDecimal)}");
     }
 
     [Test]
     public void MinTest()
     {
-      Assert.AreEqual(all.Min(x => x.FByte), globalSession.Query.All<X>().Min(x => x.FByte), $"Failed for {nameof(X.FByte)}");
-      Assert.AreEqual(all.Min(x => x.FSByte), globalSession.Query.All<X>().Min(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
+      Assert.AreEqual(all.Min(x => x.FByte), GlobalSession.Query.All<X>().Min(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Min(x => x.FSByte), GlobalSession.Query.All<X>().Min(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Min(x => x.FShort), globalSession.Query.All<X>().Min(x => x.FShort), $"Failed for {nameof(X.FShort)}");
-      Assert.AreEqual(all.Min(x => x.FUShort), globalSession.Query.All<X>().Min(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
+      Assert.AreEqual(all.Min(x => x.FShort), GlobalSession.Query.All<X>().Min(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Min(x => x.FUShort), GlobalSession.Query.All<X>().Min(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Min(x => x.FInt), globalSession.Query.All<X>().Min(x => x.FInt), $"Failed for {nameof(X.FInt)}");
-      Assert.AreEqual(all.Min(x => x.FUInt), globalSession.Query.All<X>().Min(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
+      Assert.AreEqual(all.Min(x => x.FInt), GlobalSession.Query.All<X>().Min(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Min(x => x.FUInt), GlobalSession.Query.All<X>().Min(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Min(x => x.FLong), globalSession.Query.All<X>().Min(x => x.FLong), $"Failed for {nameof(X.FLong)}");
-      Assert.AreEqual(all.Min(x => x.FFloat), globalSession.Query.All<X>().Min(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Min(x => x.FDecimal), globalSession.Query.All<X>().Min(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Min(x => x.FLong), GlobalSession.Query.All<X>().Min(x => x.FLong), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Min(x => x.FFloat), GlobalSession.Query.All<X>().Min(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Min(x => x.FDecimal), GlobalSession.Query.All<X>().Min(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
 
-      Assert.AreEqual(all.Min(x => x.FDateTime), globalSession.Query.All<X>().Min(x => x.FDateTime), $"Failed for {nameof(X.FDateTime)}");
-      Assert.AreEqual(all.Min(x => x.FTimeSpan), globalSession.Query.All<X>().Min(x => x.FTimeSpan), $"Failed for {nameof(X.FTimeSpan)}");
+      Assert.AreEqual(all.Min(x => x.FDateTime), GlobalSession.Query.All<X>().Min(x => x.FDateTime), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Min(x => x.FTimeSpan), GlobalSession.Query.All<X>().Min(x => x.FTimeSpan), $"Failed for {nameof(X.FTimeSpan)}");
     }
 
     [Test]
     public void MinNoLambdaTest()
     {
-      Assert.AreEqual(all.Min(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Min(), $"Failed for {nameof(X.FByte)}");
-      Assert.AreEqual(all.Min(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Min(), $"Failed for {nameof(X.FSByte)}");
+      Assert.AreEqual(all.Min(x => x.FByte), GlobalSession.Query.All<X>().Select(x => x.FByte).Min(), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Min(x => x.FSByte), GlobalSession.Query.All<X>().Select(x => x.FSByte).Min(), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Min(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Min(), $"Failed for {nameof(X.FShort)}");
-      Assert.AreEqual(all.Min(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Min(), $"Failed for {nameof(X.FUShort)}");
+      Assert.AreEqual(all.Min(x => x.FShort), GlobalSession.Query.All<X>().Select(x => x.FShort).Min(), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Min(x => x.FUShort), GlobalSession.Query.All<X>().Select(x => x.FUShort).Min(), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Min(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Min(), $"Failed for {nameof(X.FInt)}");
-      Assert.AreEqual(all.Min(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Min(), $"Failed for {nameof(X.FUInt)}");
+      Assert.AreEqual(all.Min(x => x.FInt), GlobalSession.Query.All<X>().Select(x => x.FInt).Min(), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Min(x => x.FUInt), GlobalSession.Query.All<X>().Select(x => x.FUInt).Min(), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Min(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Min(), $"Failed for {nameof(X.FLong)}");
-      Assert.AreEqual(all.Min(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Min(), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Min(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Min(), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Min(x => x.FLong), GlobalSession.Query.All<X>().Select(x => x.FLong).Min(), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Min(x => x.FFloat), GlobalSession.Query.All<X>().Select(x => x.FFloat).Min(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Min(x => x.FDecimal), GlobalSession.Query.All<X>().Select(x => x.FDecimal).Min(), $"Failed for {nameof(X.FDecimal)}");
 
-      Assert.AreEqual(all.Min(x => x.FDateTime), globalSession.Query.All<X>().Select(x => x.FDateTime).Min(), $"Failed for {nameof(X.FDateTime)}");
-      Assert.AreEqual(all.Min(x => x.FTimeSpan), globalSession.Query.All<X>().Select(x => x.FTimeSpan).Min(), $"Failed for {nameof(X.FTimeSpan)}");
+      Assert.AreEqual(all.Min(x => x.FDateTime), GlobalSession.Query.All<X>().Select(x => x.FDateTime).Min(), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Min(x => x.FTimeSpan), GlobalSession.Query.All<X>().Select(x => x.FTimeSpan).Min(), $"Failed for {nameof(X.FTimeSpan)}");
     }
 
     [Test]
     public void MinByValueItselfTest()
     {
-      Assert.AreEqual(all.Min(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Min(x => x), $"Failed for {nameof(X.FByte)}");
-      Assert.AreEqual(all.Min(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Min(x => x), $"Failed for {nameof(X.FSByte)}");
+      Assert.AreEqual(all.Min(x => x.FByte), GlobalSession.Query.All<X>().Select(x => x.FByte).Min(x => x), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Min(x => x.FSByte), GlobalSession.Query.All<X>().Select(x => x.FSByte).Min(x => x), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Min(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Min(x => x), $"Failed for {nameof(X.FShort)}");
-      Assert.AreEqual(all.Min(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Min(x => x), $"Failed for {nameof(X.FUShort)}");
+      Assert.AreEqual(all.Min(x => x.FShort), GlobalSession.Query.All<X>().Select(x => x.FShort).Min(x => x), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Min(x => x.FUShort), GlobalSession.Query.All<X>().Select(x => x.FUShort).Min(x => x), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Min(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Min(x => x), $"Failed for {nameof(X.FInt)}");
-      Assert.AreEqual(all.Min(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Min(x => x), $"Failed for {nameof(X.FUInt)}");
+      Assert.AreEqual(all.Min(x => x.FInt), GlobalSession.Query.All<X>().Select(x => x.FInt).Min(x => x), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Min(x => x.FUInt), GlobalSession.Query.All<X>().Select(x => x.FUInt).Min(x => x), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Min(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Min(x => x), $"Failed for {nameof(X.FLong)}");
-      Assert.AreEqual(all.Min(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Min(x => x), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Min(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Min(x => x), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Min(x => x.FLong), GlobalSession.Query.All<X>().Select(x => x.FLong).Min(x => x), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Min(x => x.FFloat), GlobalSession.Query.All<X>().Select(x => x.FFloat).Min(x => x), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Min(x => x.FDecimal), GlobalSession.Query.All<X>().Select(x => x.FDecimal).Min(x => x), $"Failed for {nameof(X.FDecimal)}");
 
-      Assert.AreEqual(all.Min(x => x.FDateTime), globalSession.Query.All<X>().Select(x => x.FDateTime).Min(x => x), $"Failed for {nameof(X.FDateTime)}");
-      Assert.AreEqual(all.Min(x => x.FTimeSpan), globalSession.Query.All<X>().Select(x => x.FTimeSpan).Min(x => x), $"Failed for {nameof(X.FTimeSpan)}");
+      Assert.AreEqual(all.Min(x => x.FDateTime), GlobalSession.Query.All<X>().Select(x => x.FDateTime).Min(x => x), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Min(x => x.FTimeSpan), GlobalSession.Query.All<X>().Select(x => x.FTimeSpan).Min(x => x), $"Failed for {nameof(X.FTimeSpan)}");
     }
 
     [Test]
     public void MaxTest()
     {
-      Assert.AreEqual(all.Max(x => x.FByte), globalSession.Query.All<X>().Max(x => x.FByte), $"Failed for {nameof(X.FByte)}");
-      Assert.AreEqual(all.Max(x => x.FSByte), globalSession.Query.All<X>().Max(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
+      Assert.AreEqual(all.Max(x => x.FByte), GlobalSession.Query.All<X>().Max(x => x.FByte), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Max(x => x.FSByte), GlobalSession.Query.All<X>().Max(x => x.FSByte), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Max(x => x.FShort), globalSession.Query.All<X>().Max(x => x.FShort), $"Failed for {nameof(X.FShort)}");
-      Assert.AreEqual(all.Max(x => x.FUShort), globalSession.Query.All<X>().Max(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
+      Assert.AreEqual(all.Max(x => x.FShort), GlobalSession.Query.All<X>().Max(x => x.FShort), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Max(x => x.FUShort), GlobalSession.Query.All<X>().Max(x => x.FUShort), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Max(x => x.FInt), globalSession.Query.All<X>().Max(x => x.FInt), $"Failed for {nameof(X.FInt)}");
-      Assert.AreEqual(all.Max(x => x.FUInt), globalSession.Query.All<X>().Max(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
+      Assert.AreEqual(all.Max(x => x.FInt), GlobalSession.Query.All<X>().Max(x => x.FInt), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Max(x => x.FUInt), GlobalSession.Query.All<X>().Max(x => x.FUInt), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Max(x => x.FLong), globalSession.Query.All<X>().Max(x => x.FLong), $"Failed for {nameof(X.FLong)}");
-      Assert.AreEqual(all.Max(x => x.FFloat), globalSession.Query.All<X>().Max(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Max(x => x.FDecimal), globalSession.Query.All<X>().Max(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Max(x => x.FLong), GlobalSession.Query.All<X>().Max(x => x.FLong), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Max(x => x.FFloat), GlobalSession.Query.All<X>().Max(x => x.FFloat), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Max(x => x.FDecimal), GlobalSession.Query.All<X>().Max(x => x.FDecimal), $"Failed for {nameof(X.FDecimal)}");
 
-      Assert.AreEqual(all.Max(x => x.FDateTime), globalSession.Query.All<X>().Max(x => x.FDateTime), $"Failed for {nameof(X.FDateTime)}");
-      Assert.AreEqual(all.Max(x => x.FTimeSpan), globalSession.Query.All<X>().Max(x => x.FTimeSpan), $"Failed for {nameof(X.FTimeSpan)}");
+      Assert.AreEqual(all.Max(x => x.FDateTime), GlobalSession.Query.All<X>().Max(x => x.FDateTime), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Max(x => x.FTimeSpan), GlobalSession.Query.All<X>().Max(x => x.FTimeSpan), $"Failed for {nameof(X.FTimeSpan)}");
     }
 
     [Test]
     public void MaxNoLambdaTest()
     {
-      Assert.AreEqual(all.Max(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Max(), $"Failed for {nameof(X.FByte)}");
-      Assert.AreEqual(all.Max(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Max(), $"Failed for {nameof(X.FSByte)}");
+      Assert.AreEqual(all.Max(x => x.FByte), GlobalSession.Query.All<X>().Select(x => x.FByte).Max(), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Max(x => x.FSByte), GlobalSession.Query.All<X>().Select(x => x.FSByte).Max(), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Max(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Max(), $"Failed for {nameof(X.FShort)}");
-      Assert.AreEqual(all.Max(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Max(), $"Failed for {nameof(X.FUShort)}");
+      Assert.AreEqual(all.Max(x => x.FShort), GlobalSession.Query.All<X>().Select(x => x.FShort).Max(), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Max(x => x.FUShort), GlobalSession.Query.All<X>().Select(x => x.FUShort).Max(), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Max(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Max(), $"Failed for {nameof(X.FInt)}");
-      Assert.AreEqual(all.Max(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Max(), $"Failed for {nameof(X.FUInt)}");
+      Assert.AreEqual(all.Max(x => x.FInt), GlobalSession.Query.All<X>().Select(x => x.FInt).Max(), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Max(x => x.FUInt), GlobalSession.Query.All<X>().Select(x => x.FUInt).Max(), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Max(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Max(), $"Failed for {nameof(X.FLong)}");
-      Assert.AreEqual(all.Max(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Max(), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Max(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Max(), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Max(x => x.FLong), GlobalSession.Query.All<X>().Select(x => x.FLong).Max(), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Max(x => x.FFloat), GlobalSession.Query.All<X>().Select(x => x.FFloat).Max(), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Max(x => x.FDecimal), GlobalSession.Query.All<X>().Select(x => x.FDecimal).Max(), $"Failed for {nameof(X.FDecimal)}");
 
-      Assert.AreEqual(all.Max(x => x.FDateTime), globalSession.Query.All<X>().Select(x => x.FDateTime).Max(), $"Failed for {nameof(X.FDateTime)}");
-      Assert.AreEqual(all.Max(x => x.FTimeSpan), globalSession.Query.All<X>().Select(x => x.FTimeSpan).Max(), $"Failed for {nameof(X.FTimeSpan)}");
+      Assert.AreEqual(all.Max(x => x.FDateTime), GlobalSession.Query.All<X>().Select(x => x.FDateTime).Max(), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Max(x => x.FTimeSpan), GlobalSession.Query.All<X>().Select(x => x.FTimeSpan).Max(), $"Failed for {nameof(X.FTimeSpan)}");
     }
 
     [Test]
     public void MaxByValueItselfTest()
     {
-      Assert.AreEqual(all.Max(x => x.FByte), globalSession.Query.All<X>().Select(x => x.FByte).Max(x => x), $"Failed for {nameof(X.FByte)}");
-      Assert.AreEqual(all.Max(x => x.FSByte), globalSession.Query.All<X>().Select(x => x.FSByte).Max(x => x), $"Failed for {nameof(X.FSByte)}");
+      Assert.AreEqual(all.Max(x => x.FByte), GlobalSession.Query.All<X>().Select(x => x.FByte).Max(x => x), $"Failed for {nameof(X.FByte)}");
+      Assert.AreEqual(all.Max(x => x.FSByte), GlobalSession.Query.All<X>().Select(x => x.FSByte).Max(x => x), $"Failed for {nameof(X.FSByte)}");
 
-      Assert.AreEqual(all.Max(x => x.FShort), globalSession.Query.All<X>().Select(x => x.FShort).Max(x => x), $"Failed for {nameof(X.FShort)}");
-      Assert.AreEqual(all.Max(x => x.FUShort), globalSession.Query.All<X>().Select(x => x.FUShort).Max(x => x), $"Failed for {nameof(X.FUShort)}");
+      Assert.AreEqual(all.Max(x => x.FShort), GlobalSession.Query.All<X>().Select(x => x.FShort).Max(x => x), $"Failed for {nameof(X.FShort)}");
+      Assert.AreEqual(all.Max(x => x.FUShort), GlobalSession.Query.All<X>().Select(x => x.FUShort).Max(x => x), $"Failed for {nameof(X.FUShort)}");
 
-      Assert.AreEqual(all.Max(x => x.FInt), globalSession.Query.All<X>().Select(x => x.FInt).Max(x => x), $"Failed for {nameof(X.FInt)}");
-      Assert.AreEqual(all.Max(x => x.FUInt), globalSession.Query.All<X>().Select(x => x.FUInt).Max(x => x), $"Failed for {nameof(X.FUInt)}");
+      Assert.AreEqual(all.Max(x => x.FInt), GlobalSession.Query.All<X>().Select(x => x.FInt).Max(x => x), $"Failed for {nameof(X.FInt)}");
+      Assert.AreEqual(all.Max(x => x.FUInt), GlobalSession.Query.All<X>().Select(x => x.FUInt).Max(x => x), $"Failed for {nameof(X.FUInt)}");
 
-      Assert.AreEqual(all.Max(x => x.FLong), globalSession.Query.All<X>().Select(x => x.FLong).Max(x => x), $"Failed for {nameof(X.FLong)}");
-      Assert.AreEqual(all.Max(x => x.FFloat), globalSession.Query.All<X>().Select(x => x.FFloat).Max(x => x), $"Failed for {nameof(X.FFloat)}");
-      Assert.AreEqual(all.Max(x => x.FDecimal), globalSession.Query.All<X>().Select(x => x.FDecimal).Max(x => x), $"Failed for {nameof(X.FDecimal)}");
+      Assert.AreEqual(all.Max(x => x.FLong), GlobalSession.Query.All<X>().Select(x => x.FLong).Max(x => x), $"Failed for {nameof(X.FLong)}");
+      Assert.AreEqual(all.Max(x => x.FFloat), GlobalSession.Query.All<X>().Select(x => x.FFloat).Max(x => x), $"Failed for {nameof(X.FFloat)}");
+      Assert.AreEqual(all.Max(x => x.FDecimal), GlobalSession.Query.All<X>().Select(x => x.FDecimal).Max(x => x), $"Failed for {nameof(X.FDecimal)}");
 
-      Assert.AreEqual(all.Max(x => x.FDateTime), globalSession.Query.All<X>().Select(x => x.FDateTime).Max(x => x), $"Failed for {nameof(X.FDateTime)}");
-      Assert.AreEqual(all.Max(x => x.FTimeSpan), globalSession.Query.All<X>().Select(x => x.FTimeSpan).Max(x => x), $"Failed for {nameof(X.FTimeSpan)}");
+      Assert.AreEqual(all.Max(x => x.FDateTime), GlobalSession.Query.All<X>().Select(x => x.FDateTime).Max(x => x), $"Failed for {nameof(X.FDateTime)}");
+      Assert.AreEqual(all.Max(x => x.FTimeSpan), GlobalSession.Query.All<X>().Select(x => x.FTimeSpan).Max(x => x), $"Failed for {nameof(X.FTimeSpan)}");
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessorContextProviderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessorContextProviderTest.cs
@@ -10,15 +10,12 @@ namespace Xtensive.Orm.Tests.Storage
 {
   public class CommandProcessorContextProviderTest : AutoBuildTest
   {
-    protected override void PopulateData()
-    {
-      _ = CreateSessionAndTransaction();
-    }
+    protected override bool InitGlobalSession => true;
 
     [Test]
     public void GetContextTest()
     {
-      var session = Session.Demand();
+      var session = GlobalSession;
       var provider = session.CommandProcessorContextProvider;
       var context = provider.ProvideContext();
 
@@ -36,7 +33,7 @@ namespace Xtensive.Orm.Tests.Storage
     [Test]
     public void GetContextForPartialExecutionTest()
     {
-      var session = Session.Demand();
+      var session = GlobalSession;
       var provider = session.CommandProcessorContextProvider;
       var context = provider.ProvideContext(true);
 

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessorContextProviderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessorContextProviderTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Xtensive LLC.
+// Copyright (C) 2019-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kulakov

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/NullValuesTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/NullValuesTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2023 Xtensive LLC.
+// Copyright (C) 2009-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -18,22 +18,23 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
   {
     private bool emptyStringIsNull;
 
+    protected override bool InitGlobalSession => true;
+
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      _ = CreateSessionAndTransaction();
       emptyStringIsNull = ProviderInfo.Supports(ProviderFeatures.TreatEmptyStringAsNull);
       
-      new X {FString = "Xtensive"};
-      new X {FString = null};
-      new X {FString = string.Empty};
+      _ = new X(GlobalSession) {FString = "Xtensive"};
+      _ = new X(GlobalSession) {FString = null};
+      _ = new X(GlobalSession) {FString = string.Empty};
     }
 
     [Test]
     public void CompareWithEmptyStringParameterTest()
     {
       var value = string.Empty;
-      var result = Session.Demand().Query.All<X>().Where(x => x.FString==value).ToList();
+      var result = GlobalSession.Query.All<X>().Where(x => x.FString==value).ToList();
       if (emptyStringIsNull)
         CheckIsNull(result, 2);
       else
@@ -44,7 +45,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public void CompareWithNullStringParameterTest()
     {
       string value = null;
-      var result = Session.Demand().Query.All<X>().Where(x => x.FString==value).ToList();
+      var result = GlobalSession.Query.All<X>().Where(x => x.FString==value).ToList();
       CheckIsNull(result, emptyStringIsNull ? 2 : 1);
     }
 
@@ -52,7 +53,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public void CompareWithEmptyStringConstantTest()
     {
       // NOTE: string.Empty should not be used here, because it is translated via string parameter
-      var result = Session.Demand().Query.All<X>().Where(x => x.FString=="").ToList();
+      var result = GlobalSession.Query.All<X>().Where(x => x.FString=="").ToList();
       if (emptyStringIsNull)
         CheckIsNull(result, 2);
       else
@@ -62,7 +63,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void CompareWithNullStringConstantTest()
     {
-      var result = Session.Demand().Query.All<X>().Where(x => x.FString==null).ToList();
+      var result = GlobalSession.Query.All<X>().Where(x => x.FString==null).ToList();
       CheckIsNull(result, emptyStringIsNull ? 2 : 1);
     }
 
@@ -70,7 +71,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public void SelectNullStringParameter()
     {
       string value = null;
-      var result = Session.Demand().Query.All<X>().Select(x => new {x.Id, Value = value}).ToList();
+      var result = GlobalSession.Query.All<X>().Select(x => new {x.Id, Value = value}).ToList();
       foreach (var item in result)
         Assert.IsNull(item.Value);
     }

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/RoundingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/RoundingTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2023 Xtensive LLC.
+// Copyright (C) 2009-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -19,14 +19,16 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     private const double DoubleDelta = 0.00000001d;
     private const decimal DecimalDelta = 0.000000000001m;
 
+    protected override bool InitGlobalSession => true;
+
     [Test]
     public void TruncateTest()
     {
-      Query.All<DecimalContainer>().Select(x => new { Decimal = x.d18_9, DecimalTruncate = Math.Truncate(x.d18_9) })
+      GlobalSession.Query.All<DecimalContainer>().Select(x => new { Decimal = x.d18_9, DecimalTruncate = Math.Truncate(x.d18_9) })
         .GroupBy(x => x.DecimalTruncate)
         .ForEach(i => i.ForEach(x => AreEqual(Math.Truncate(x.Decimal), x.DecimalTruncate)));
 
-      Query.All<DoubleContainer>().Select(x => new { Double = x.FDouble, DoubleTruncate = Math.Truncate(x.FDouble) })
+      GlobalSession.Query.All<DoubleContainer>().Select(x => new { Double = x.FDouble, DoubleTruncate = Math.Truncate(x.FDouble) })
         .GroupBy(x => x.DoubleTruncate)
         .ForEach(i => i.ForEach(x => AreEqual(Math.Truncate(x.Double), x.DoubleTruncate)));
     }
@@ -34,12 +36,12 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void CeilTest()
     {
-      Query.All<DecimalContainer>()
+      GlobalSession.Query.All<DecimalContainer>()
         .Select(x => new { Decimal = x.d18_9, DecimalCeiling = Math.Ceiling(x.d18_9) })
         .GroupBy(x => x.DecimalCeiling)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Ceiling(i.Decimal), x.Key)));
 
-      Query.All<DoubleContainer>()
+      GlobalSession.Query.All<DoubleContainer>()
         .Select(x => new { Double = x.FDouble, DoubleCeiling = Math.Ceiling(x.FDouble) })
         .GroupBy(x => x.DoubleCeiling)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Ceiling(i.Double), x.Key)));
@@ -48,12 +50,12 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void FloorTest()
     {
-      Query.All<DecimalContainer>()
+      GlobalSession.Query.All<DecimalContainer>()
         .Select(x => new { Decimal = x.d18_9, DecimalFloor = Math.Floor(x.d18_9) })
         .GroupBy(x => x.DecimalFloor)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Floor(i.Decimal), x.Key)));
 
-      Query.All<DoubleContainer>()
+      GlobalSession.Query.All<DoubleContainer>()
         .Select(x => new { Double = x.FDouble, DoubleFloor = Math.Floor(x.FDouble) })
         .GroupBy(x => x.DoubleFloor)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Floor(i.Double), x.Key)));
@@ -62,12 +64,12 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void RoundDefaultToZeroDigitsTest()
     {
-      Query.All<DecimalContainer>()
+      GlobalSession.Query.All<DecimalContainer>()
         .Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9) })
         .GroupBy(x => x.DecimalRound)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Decimal), x.Key)));
 
-      Query.All<DoubleContainer>()
+      GlobalSession.Query.All<DoubleContainer>()
         .Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble) })
         .GroupBy(x => x.DoubleRound)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Double), x.Key)));
@@ -78,24 +80,24 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     {
       if (ExpectNotSupported()) {
         var ex = Assert.Throws<QueryTranslationException>(() =>
-          Query.All<DecimalContainer>().Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, 1) })
+          GlobalSession.Query.All<DecimalContainer>().Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, 1) })
             .GroupBy(x => x.DecimalRound).Run());
         Assert.That(ex.InnerException, Is.InstanceOf<NotSupportedException>());
         Assert.That(ex.InnerException.Message.Contains("Power", StringComparison.Ordinal));
 
         ex = Assert.Throws<QueryTranslationException>(() =>
-          Query.All<DoubleContainer>().Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, 1) })
+          GlobalSession.Query.All<DoubleContainer>().Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, 1) })
             .GroupBy(x => x.DoubleRound).Run());
         Assert.That(ex.InnerException, Is.InstanceOf<NotSupportedException>());
         Assert.That(ex.InnerException.Message.Contains("Power", StringComparison.Ordinal));
       }
       else {
-        Query.All<DecimalContainer>()
+        GlobalSession.Query.All<DecimalContainer>()
           .Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, 1) })
           .GroupBy(x => x.DecimalRound)
           .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Decimal, 1), x.Key)));
 
-        Query.All<DoubleContainer>()
+        GlobalSession.Query.All<DoubleContainer>()
           .Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, 1) })
           .GroupBy(x => x.DoubleRound)
           .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Double, 1), x.Key)));
@@ -107,12 +109,12 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void RoundToEvenToZeroDigitsTest()
     {
-      Query.All<DecimalContainer>()
+      GlobalSession.Query.All<DecimalContainer>()
         .Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, MidpointRounding.ToEven) })
         .GroupBy(x => x.DecimalRound)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Decimal, MidpointRounding.ToEven), x.Key)));
 
-      Query.All<DoubleContainer>()
+      GlobalSession.Query.All<DoubleContainer>()
         .Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, MidpointRounding.ToEven) })
         .GroupBy(x => x.DoubleRound)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Double, MidpointRounding.ToEven), x.Key)));
@@ -123,24 +125,24 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     {
       if (ExpectNotSupported()) {// sqlite has no support for Power operation
         var ex = Assert.Throws<QueryTranslationException>(() =>
-          Query.All<DecimalContainer>().Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, 1, MidpointRounding.ToEven) })
+          GlobalSession.Query.All<DecimalContainer>().Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, 1, MidpointRounding.ToEven) })
             .GroupBy(x => x.DecimalRound).Run());
         Assert.That(ex.InnerException, Is.InstanceOf<NotSupportedException>());
         Assert.That(ex.InnerException.Message.Contains("Power", StringComparison.Ordinal));
 
         ex = Assert.Throws<QueryTranslationException>(() =>
-          Query.All<DoubleContainer>().Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, 1, MidpointRounding.ToEven) })
+          GlobalSession.Query.All<DoubleContainer>().Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, 1, MidpointRounding.ToEven) })
             .GroupBy(x => x.DoubleRound).Run());
         Assert.That(ex.InnerException, Is.InstanceOf<NotSupportedException>());
         Assert.That(ex.InnerException.Message.Contains("Power", StringComparison.Ordinal));
       }
       else {
-        Query.All<DecimalContainer>()
+        GlobalSession.Query.All<DecimalContainer>()
           .Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, 1, MidpointRounding.ToEven) })
           .GroupBy(x => x.DecimalRound)
           .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Decimal, 1, MidpointRounding.ToEven), x.Key)));
 
-        Query.All<DoubleContainer>()
+        GlobalSession.Query.All<DoubleContainer>()
           .Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, 1, MidpointRounding.ToEven) })
           .GroupBy(x => x.DoubleRound)
           .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Double, 1, MidpointRounding.ToEven), x.Key)));
@@ -150,12 +152,12 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void RoundAwayFromZeroToZeroDigitsTest()
     {
-      Query.All<DecimalContainer>()
+      GlobalSession.Query.All<DecimalContainer>()
         .Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, MidpointRounding.AwayFromZero) })
         .GroupBy(x => x.DecimalRound)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Decimal, MidpointRounding.AwayFromZero), x.Key)));
 
-      Query.All<DoubleContainer>()
+      GlobalSession.Query.All<DoubleContainer>()
         .Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, MidpointRounding.AwayFromZero) })
         .GroupBy(x => x.DoubleRound)
         .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Double, MidpointRounding.AwayFromZero), x.Key)));
@@ -166,24 +168,24 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     {
       if (ExpectNotSupported()) {
         var ex = Assert.Throws<QueryTranslationException>(() =>
-          Query.All<DecimalContainer>().Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, 1, MidpointRounding.AwayFromZero) })
+          GlobalSession.Query.All<DecimalContainer>().Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, 1, MidpointRounding.AwayFromZero) })
             .GroupBy(x => x.DecimalRound).Run());
         Assert.That(ex.InnerException, Is.InstanceOf<NotSupportedException>());
         Assert.That(ex.InnerException.Message.Contains("Power", StringComparison.Ordinal));
 
         ex = Assert.Throws<QueryTranslationException>(() =>
-          Query.All<DoubleContainer>().Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, 1, MidpointRounding.AwayFromZero) })
+          GlobalSession.Query.All<DoubleContainer>().Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, 1, MidpointRounding.AwayFromZero) })
             .GroupBy(x => x.DoubleRound).Run());
         Assert.That(ex.InnerException, Is.InstanceOf<NotSupportedException>());
         Assert.That(ex.InnerException.Message.Contains("Power", StringComparison.Ordinal));
       }
       else {
-        Query.All<DecimalContainer>()
+        GlobalSession.Query.All<DecimalContainer>()
           .Select(x => new { Decimal = x.d18_9, DecimalRound = Math.Round(x.d18_9, 1, MidpointRounding.AwayFromZero) })
           .GroupBy(x => x.DecimalRound)
           .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Decimal, 1, MidpointRounding.AwayFromZero), x.Key)));
 
-        Query.All<DoubleContainer>()
+        GlobalSession.Query.All<DoubleContainer>()
           .Select(x => new { Double = x.FDouble, DoubleRound = Math.Round(x.FDouble, 1, MidpointRounding.AwayFromZero) })
           .GroupBy(x => x.DoubleRound)
           .ForEach(x => x.ForEach(i => AreEqual(Math.Round(i.Double, 1, MidpointRounding.AwayFromZero), x.Key)));
@@ -193,7 +195,6 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      _ = CreateSessionAndTransaction();
 
       var testValues = new[] {
         1.3m, 1.5m, 1.6m,
@@ -230,8 +231,8 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
       };
 
       foreach (var value in testValues) {
-        _ = new DoubleContainer { FDouble = (double) value };
-        _ = new DecimalContainer { d18_9 = value };
+        _ = new DoubleContainer (GlobalSession) { FDouble = (double) value };
+        _ = new DecimalContainer (GlobalSession) { d18_9 = value };
         //_ = new X { FDouble = (double) value, FDecimal = value };
       }
     }

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/StringOperationsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/StringOperationsTest.cs
@@ -19,6 +19,8 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
 
     private bool emptyStringIsNull;
 
+    protected override bool InitGlobalSession => true;
+
     protected override DomainConfiguration BuildConfiguration()
     {
       var configuration = base.BuildConfiguration();
@@ -29,7 +31,6 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public override void TestFixtureSetUp()
     {
       base.TestFixtureSetUp();
-      _ = CreateSessionAndTransaction();
       emptyStringIsNull = ProviderInfo.Supports(ProviderFeatures.TreatEmptyStringAsNull);
       var testValues = new[] {
         // test values for TrimStart, TrimEnd, Trim
@@ -76,7 +77,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void LengthTest()
     {
-      var results = Session.Demand().Query.All<X>().Select(x => new {
+      var results = GlobalSession.Query.All<X>().Select(x => new {
         String = x.FString,
         Length = x.FString.Length
       }).ToList();
@@ -89,7 +90,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void TrimSpaceTest()
     {
-      var results = Session.Demand().Query.All<X>()
+      var results = GlobalSession.Query.All<X>()
         .Select(x => new {
           String = x.FString,
           StringTrim = x.FString.Trim(),
@@ -119,7 +120,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public void TrimOtherCharTest()
     {
       Require.ProviderIsNot(StorageProvider.SqlServer | StorageProvider.SqlServerCe);
-      var results = Session.Demand().Query.All<X>()
+      var results = GlobalSession.Query.All<X>()
         .Select(x => new {
           String = x.FString,
           StringTrimLeadingLargePLetter = x.FString.TrimStart('P'),
@@ -137,7 +138,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     public void TrimMultipleCharsTest()
     {
       Require.ProviderIsNot(StorageProvider.SqlServer | StorageProvider.Oracle | StorageProvider.SqlServerCe);
-      var results = Session.Demand().Query.All<X>()
+      var results = GlobalSession.Query.All<X>()
         .Select(x => new {
           String = x.FString,
           StringTrimLeadingZeroAndOne = x.FString.TrimStart('0', '1'),
@@ -154,7 +155,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void StartsWithTest()
     {
-      var result = Session.Demand().Query.All<X>().Select(x => new {
+      var result = GlobalSession.Query.All<X>().Select(x => new {
         x.Id,
         String = x.FString,
         StartsWithA = x.FString.StartsWith("A"),
@@ -181,7 +182,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void EndsWithTest()
     {
-      var result = Session.Demand().Query.All<X>().Select(x => new {
+      var result = GlobalSession.Query.All<X>().Select(x => new {
         x.Id,
         String = x.FString,
         EndsWithA = x.FString.EndsWith("A"),
@@ -208,7 +209,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void ContainsTest()
     {
-      var result = Session.Demand().Query.All<X>().Select(x => new {
+      var result = GlobalSession.Query.All<X>().Select(x => new {
         x.Id,
         String = x.FString,
         ContainsA = x.FString.Contains("A"),
@@ -239,7 +240,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     [Test]
     public void PaddingTest()
     {
-      var result = Session.Demand().Query.All<X>().Select(x => new {
+      var result = GlobalSession.Query.All<X>().Select(x => new {
         x.Id,
         String = x.FString,
         PadLeft = x.FString.PadLeft(10),

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/StringOperationsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/StringOperationsTest.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2023 Xtensive LLC.
+// Copyright (C) 2009-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm.Tests/Storage/TypeCompatibilityTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/TypeCompatibilityTest.cs
@@ -241,6 +241,15 @@ namespace Xtensive.Orm.Tests.Storage.DbTypeSupportModel
     [Field]
     public EULong? FNEULong { get; set; }
 
+    public X(Session session)
+      : base(session)
+    {
+    }
+
+    public X()
+      : base()
+    {
+    }
   }
 
   [HierarchyRoot]
@@ -254,6 +263,11 @@ namespace Xtensive.Orm.Tests.Storage.DbTypeSupportModel
 
     [Field(Precision = 18, Scale = 0)]
     public decimal d18_0 { get; set; }
+
+    public DecimalContainer(Session session)
+      : base(session)
+    {
+    }
   }
 
   [HierarchyRoot]
@@ -264,6 +278,11 @@ namespace Xtensive.Orm.Tests.Storage.DbTypeSupportModel
 
     [Field]
     public double FDouble { get; set; }
+
+    public DoubleContainer(Session session)
+      : base(session)
+    {
+    }
   }
 }
 
@@ -388,7 +407,7 @@ namespace Xtensive.Orm.Tests.Storage
       using (var session = Domain.OpenSession()) {
         Key key;
         using (var transactionScope = session.OpenTransaction()) {
-          var container = new DecimalContainer() {
+          var container = new DecimalContainer(session) {
             d18_9 = d18_9,
             d18_0 = d18_0
           };


### PR DESCRIPTION
It makes sense to have one session for tests that only read data and do not perform upgrades or create/modify/remove entities.
Session and transaction opening were able to be opened by AutoBuildTest abstract class, this PR gives access to single session for its descendants, if they declare they need such session