### PR TITLE
Postgresql: Declare the same setting for nulls in indexes as in order by statement

### DIFF
--- a/ChangeLog/7.1.4_dev.txt
+++ b/ChangeLog/7.1.4_dev.txt
@@ -1,2 +1,3 @@
 [main] Addressed IndexOutOfRangeException on translation of certain queries with aggregates
 [main] Notification to BuildLog when a hierarchy changes KeyGeneratorKind value to None
+[postgresql] Added explicit nulls setting for both column order directions to improve OrderBy/OrderByDescending performance

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v9_0/Translator.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v9_0/Translator.cs
@@ -30,6 +30,9 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v9_0
       }
     }
 
+    public override void TranslateSortOrder(IOutput output, bool ascending) =>
+      output.Append(ascending ? "ASC NULLS FIRST" : "DESC NULLS LAST");
+
     // Constructors
 
     public Translator(SqlDriver driver)


### PR DESCRIPTION
otherwise, index order conflicts with order by which cause longer query execution. According to documentation default settings for nulls are exact opposite.