### PR TITLE
RecordSetReader overlaps SQL exception when DbCommand execution failed

### DIFF
--- a/ChangeLog/7.1.5_dev.txt
+++ b/ChangeLog/7.1.5_dev.txt
@@ -1,0 +1,1 @@
+[main] Addressed certain cases of overlaping server-side error by new one when temporary tables are used in query

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetReader.cs
@@ -176,7 +176,7 @@ namespace Xtensive.Orm.Rse
     {
       if (isErrorOnServerSide) {
         // Possible connection closing because of server-side error, like operation timeout,
-        // which makes finish of some providers imposible, like ones that work with tempoerary tables and require clean-up.
+        // which makes finish of some providers imposible, like ones that work with temporary tables and require clean-up.
         // Exception may happen but we must prevent overlaping original exception with new one.
         if (!enumerated) {
           try {


### PR DESCRIPTION
On certain conditions original exception, e.g. TimeoutException from client library, might be overwritten by newer exception because of temporary table cleanup when DO don't use batches.

For instance, PostgreSQL closes connection when certain errors appeared during command execution, which cause inability to run cleanup code for temporary table content, which we perform. Such stale connection triggers exception which substitutes the original one.