### PR TITLE
Resolves #340 - Succeed removing backing field when backing field does not exist

### DIFF
--- a/Weaver/Xtensive.Orm.Weaver/Tasks/RemoveBackingFieldTask.cs
+++ b/Weaver/Xtensive.Orm.Weaver/Tasks/RemoveBackingFieldTask.cs
@@ -18,7 +18,10 @@ namespace Xtensive.Orm.Weaver.Tasks
     public override ActionResult Execute(ProcessorContext context)
     {
       var fieldName = GetBackingFieldName();
-      if (fieldName!=null && type.Fields.Remove(fieldName))
+      if (string.IsNullOrEmpty(fieldName)) {
+        return ActionResult.Success;
+      }
+      if (type.Fields.Remove(fieldName))
         return ActionResult.Success;
       context.Logger.Write(MessageCode.ErrorUnableToRemoveBackingField,
         $"type: {type.FullName}, property: {property.Name}, field: {fieldName}");


### PR DESCRIPTION
I am in the same team as the person who created this issue. We thought the problem would disappear after migrating to .NET8 but we're still having it. 

The ORM seems to try weaving already weaved dlls. The problem occurs randomly in our solution. The solution everytime is to remove the obj folder, restore dependencies, and rebuild.

I'm wondering if telling the weaver that removing backing field is done successfully (which's made in this PR) when the field does not exist anyway would be a good solution ?