### PR TITLE
Small tests' improvements

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/FreeTextTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/FreeTextTest.cs
@@ -5,13 +5,10 @@
 // Created:    2009.12.14
 
 using System;
-using System.Data.Common;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using NUnit.Framework;
 using Xtensive.Orm.Providers;
-using Xtensive.Orm.Services;
 using Xtensive.Orm.Tests.ObjectModel;
 using Xtensive.Orm.Tests.ObjectModel.ChinookDO;
 
@@ -27,36 +24,14 @@ namespace Xtensive.Orm.Tests.Linq
     protected override Domain BuildDomain(Xtensive.Orm.Configuration.DomainConfiguration configuration)
     {
       var domain = base.BuildDomain(configuration);
-      if (StorageProviderInfo.Instance.Provider == StorageProvider.SqlServer) {
-        using (var session = domain.OpenSession())
-        using (var tx = session.OpenTransaction()) {
-          var sqlAccessor = session.Services.Get<DirectSqlAccessor>();
-          var timeout = DateTime.UtcNow.AddSeconds(20);
-          while (!CheckFtIndexesPopulated(sqlAccessor.CreateCommand()) && DateTime.UtcNow < timeout) {
-            Thread.Sleep(TimeSpan.FromSeconds(2));
-          }
-          return domain;
-        }
-      }
-      else {
-        Thread.Sleep(TimeSpan.FromSeconds(6));
-      }
+      StorageTestHelper.WaitFullTextIndexesPopulated(domain, TimeSpan.FromSeconds(20));
       return domain;
-
-
-      static bool CheckFtIndexesPopulated(DbCommand sqlCommand)
-      {
-        using (sqlCommand) {
-          sqlCommand.CommandText = $"SELECT COUNT(*) FROM [{WellKnownDatabases.MultiDatabase.MainDb}].sys.fulltext_indexes WHERE has_crawl_completed=0";
-          return ((int) sqlCommand.ExecuteScalar()) == 0;
-        }
-      }
     }
 
     [Test]
     public void ReuseFreeText1Test()
     {
-      Assert.Throws<QueryTranslationException>(
+      _ = Assert.Throws<QueryTranslationException>(
         () => {
           var result1 = TakeMatchesIncorrect("black babbath back").Count();
           Assert.AreEqual(3, result1);
@@ -148,13 +123,13 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void NegativeTopNTest()
     {
-      Assert.Throws<ArgumentOutOfRangeException>(() => Session.Query.FreeText<Album>("sfdgfdhghgf", -1));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => Session.Query.FreeText<Album>("sfdgfdhghgf", -1));
     }
 
     [Test]
     public void ZeroTopNTest()
     {
-      Assert.Throws<ArgumentOutOfRangeException>(() => Session.Query.FreeText<Album>("sfdgfhgfhhj", 0));
+      _ = Assert.Throws<ArgumentOutOfRangeException>(() => Session.Query.FreeText<Album>("sfdgfhgfhhj", 0));
     }
 
     [Test]

--- a/Orm/Xtensive.Orm.Tests/Storage/NestedTransactionsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/NestedTransactionsTest.cs
@@ -126,8 +126,9 @@ namespace Xtensive.Orm.Tests.Storage
         outerScope.Complete();
         AssertEx.ThrowsInvalidOperationException(outerScope.Dispose);
       }
-      Assert.IsNull(Session.Current.Transaction);
-      Assert.IsNull(StorageTestHelper.GetNativeTransaction());
+      var currentSession = Session.Current;
+      Assert.IsNull(currentSession.Transaction);
+      Assert.IsNull(StorageTestHelper.GetNativeTransaction(currentSession));
     }
 
     [Test]

--- a/Orm/Xtensive.Orm.Tests/Storage/TransactionModesTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/TransactionModesTest.cs
@@ -41,15 +41,10 @@ namespace Xtensive.Orm.Tests.Storage
         track.Milliseconds++;
         session.SaveChanges();
         Assert.IsTrue(session.Handler.TransactionIsStarted);
-        object dbTransaction;
-        using (session.Activate()) {
-          dbTransaction = StorageTestHelper.GetNativeTransaction();
-        }
+        var dbTransaction = StorageTestHelper.GetNativeTransaction(session);
         track.Milliseconds++;
         session.SaveChanges();
-        using (session.Activate()) {
-          Assert.AreSame(dbTransaction, StorageTestHelper.GetNativeTransaction());
-        }
+        Assert.AreSame(dbTransaction, StorageTestHelper.GetNativeTransaction(session));
         track.Milliseconds++;
         milliseconds = track.Milliseconds;
         trackKey = track.Key;


### PR DESCRIPTION
Full-text population wait moved to StorageTestHelper
StorageTestHelper.GetNativeTransaction explicitly requires session to be provided