### PR TITLE
Apply 'trim_scale' function to results of aggregation to improve compatibility with .NET decimal

### DIFF
--- a/ChangeLog/7.2.0-Beta-2-dev.txt
+++ b/ChangeLog/7.2.0-Beta-2-dev.txt
@@ -21,6 +21,7 @@
 [postgresql] DateTimeOffset values '0001.01.01 00:00:00.00000+00:00' and '9999.12.31 23:59:59.99999+00:00' will be read as MinValue and MaxValue accordingly
 [postgresql] When legacy timestamp behavior is disabled, connection time zone is applied to DateTimeOffset values if possible, otherwise, to local one
 [postgresql] TimeSpans based on values lower than -9223372036854775800L and higher 92233720368547758xxL will be read as MinValue and MaxValue accordingly
+[postgresql] For PostgreSQL 13+ apply 'trim_scale' function to results of aggregation to improve compatibility with .NET decimal
 [oracle] Updated client library to version 23.7.0
 [sqlite] Fixed string.Lenght translation
 [sqlite] Added support for string.PadLeft/PadRight operations

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/PostgresqlSqlDml.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/PostgresqlSqlDml.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2014-2020 Xtensive LLC.
+// Copyright (C) 2014-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alena Mikshina
 // Created:    2014.05.06;
 
 using Xtensive.Core;
+using Xtensive.Sql;
 using Xtensive.Sql.Dml;
 
 namespace Xtensive.Orm.Providers.PostgreSql
@@ -16,6 +17,15 @@ namespace Xtensive.Orm.Providers.PostgreSql
   /// </summary>
   public class PostgresqlSqlDml
   {
+    /// <summary>
+    /// Creates an expression for native "trim_scale" function call. The function is supported starting from PostgreSQL 13
+    /// </summary>
+    public static SqlExpression DecimalTrimScale(SqlExpression operand)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(operand, nameof(operand));
+      return SqlDml.FunctionCall("TRIM_SCALE", operand);
+    }
+
     #region Spatial types
 
     /// <summary>


### PR DESCRIPTION
PostgreSQL 13+ has built-in function that trims unnecessary zeros in fractional part of numeric/decimals, we apply it because insignificant zeros can overflow inner array of longs in .NET decimal. I also allows to not guess precision and scale which may cause precision loss.