### PR TITLE
Apply 'trim_scale' function to results of aggregation to improve compatibility with .NET decimal

### DIFF
--- a/ChangeLog/7.1.6-dev.txt
+++ b/ChangeLog/7.1.6-dev.txt
@@ -1,0 +1,1 @@
+[postgresql] For PostgreSQL 13+ apply 'trim_scale' function to results of aggregation to improve compatibility with .NET decimal

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/DomainHandler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/DomainHandler.cs
@@ -18,6 +18,12 @@ namespace Xtensive.Orm.Providers.PostgreSql
   /// </summary>
   public class DomainHandler : Providers.DomainHandler
   {
+    /// <summary>
+    /// <see langword="true"/> if storage can trim insignificant zeros in numeric values
+    /// </summary>
+    protected bool HasNativeTrimOfInsignificantDecimalPoints =>
+      Handlers.ProviderInfo.StorageVersion.Major < 13;
+
     /// <inheritdoc/>
     protected override ICompiler CreateCompiler(CompilerConfiguration configuration) =>
       new SqlCompiler(Handlers, configuration);
@@ -25,8 +31,11 @@ namespace Xtensive.Orm.Providers.PostgreSql
     /// <inheritdoc/>
     protected override IPreCompiler CreatePreCompiler(CompilerConfiguration configuration)
     {
-      var decimalAggregateCorrector = new AggregateOverDecimalColumnCorrector(Handlers.Domain.Model);
-      return new CompositePreCompiler(decimalAggregateCorrector, base.CreatePreCompiler(configuration));
+      if (HasNativeTrimOfInsignificantDecimalPoints) {
+        var decimalAggregateCorrector = new AggregateOverDecimalColumnCorrector(Handlers.Domain.Model);
+        return new CompositePreCompiler(decimalAggregateCorrector, base.CreatePreCompiler(configuration));
+      }
+      return base.CreatePreCompiler(configuration);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/DomainHandler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/DomainHandler.cs
@@ -21,8 +21,8 @@ namespace Xtensive.Orm.Providers.PostgreSql
     /// <summary>
     /// <see langword="true"/> if storage can trim insignificant zeros in numeric values
     /// </summary>
-    protected bool HasNativeTrimOfInsignificantDecimalPoints =>
-      Handlers.ProviderInfo.StorageVersion.Major < 13;
+    protected bool HasNativeTrimOfInsignificantZerosInDecimals =>
+      Handlers.ProviderInfo.StorageVersion.Major >= 13;
 
     /// <inheritdoc/>
     protected override ICompiler CreateCompiler(CompilerConfiguration configuration) =>
@@ -31,7 +31,7 @@ namespace Xtensive.Orm.Providers.PostgreSql
     /// <inheritdoc/>
     protected override IPreCompiler CreatePreCompiler(CompilerConfiguration configuration)
     {
-      if (HasNativeTrimOfInsignificantDecimalPoints) {
+      if (!HasNativeTrimOfInsignificantZerosInDecimals) {
         var decimalAggregateCorrector = new AggregateOverDecimalColumnCorrector(Handlers.Domain.Model);
         return new CompositePreCompiler(decimalAggregateCorrector, base.CreatePreCompiler(configuration));
       }

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/DomainHandler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/DomainHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/PostgresqlSqlDml.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/PostgresqlSqlDml.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Providers.PostgreSql
   public class PostgresqlSqlDml
   {
     /// <summary>
-    /// Creates expression for native "trim_scale" function call. The function is supported starting from PostgreSQL 13
+    /// Creates an expression for native "trim_scale" function call. The function is supported starting from PostgreSQL 13
     /// </summary>
     public static SqlExpression DecimalTrimScale(SqlExpression operand)
     {

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/PostgresqlSqlDml.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/PostgresqlSqlDml.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2020 Xtensive LLC.
+// Copyright (C) 2014-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alena Mikshina

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/PostgresqlSqlDml.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/PostgresqlSqlDml.cs
@@ -5,6 +5,7 @@
 // Created:    2014.05.06;
 
 using Xtensive.Core;
+using Xtensive.Sql;
 using Xtensive.Sql.Dml;
 
 namespace Xtensive.Orm.Providers.PostgreSql
@@ -16,6 +17,15 @@ namespace Xtensive.Orm.Providers.PostgreSql
   /// </summary>
   public class PostgresqlSqlDml
   {
+    /// <summary>
+    /// Creates expression for native "trim_scale" function call. The function is supported starting from PostgreSQL 13
+    /// </summary>
+    public static SqlExpression DecimalTrimScale(SqlExpression operand)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(operand, nameof(operand));
+      return SqlDml.FunctionCall("TRIM_SCALE", operand);
+    }
+
     #region Spatial types
 
     /// <summary>

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/SqlCompiler.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2021 Xtensive LLC.
+// Copyright (C) 2009-2025 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/SqlCompiler.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Orm.Providers.PostgreSql
   {
     private const int MaxDotnetDecimalPrecision = 28;
 
-    private readonly bool canRemoveInsignificantZerosInDecimal;
+    private readonly bool canRemoveInsignificantZerosInDecimals;
 
     protected override SqlProvider VisitFreeText(FreeTextProvider provider)
     {
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Providers.PostgreSql
       var aggregateType = aggregateColumn.AggregateType;
       var originCalculateColumn = source.Origin.Header.Columns[aggregateColumn.SourceIndex];
       if (AggregateRequiresDecimalAdjustments(aggregateColumn)) {
-        if (canRemoveInsignificantZerosInDecimal) {
+        if (canRemoveInsignificantZerosInDecimals) {
           return (IsCalculatedColumn(originCalculateColumn))
             ? PostgresqlSqlDml.DecimalTrimScale(SqlDml.Cast(result, Driver.MapValueType(aggregateColumn.Type)))
             : PostgresqlSqlDml.DecimalTrimScale(result);
@@ -145,7 +145,7 @@ namespace Xtensive.Orm.Providers.PostgreSql
     public SqlCompiler(HandlerAccessor handlers, CompilerConfiguration configuration)
       : base(handlers, configuration)
     {
-      canRemoveInsignificantZerosInDecimal = handlers.ProviderInfo.StorageVersion.Major >= 13;
+      canRemoveInsignificantZerosInDecimals = handlers.ProviderInfo.StorageVersion.Major >= 13;
     }
   }
 }


### PR DESCRIPTION
Backport of #435.

PostgreSQL 13+ has built-in function that trims unnecessary zeros in fractional part of numeric/decimals, we apply it because insignificant zeros can overflow inner array of longs in .NET decimal. It also allows to not guess precision and scale which may cause precision loss.