### PR TITLE
Cached instances of correctors

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
@@ -22,8 +22,6 @@ namespace Xtensive.Orm.Providers
   /// </summary>
   public abstract class DomainHandler : DomainBoundHandler
   {
-    private static readonly OrderingCorrector OrderingCorrector = new OrderingCorrector(ResolveOrderingDescriptor);
-
     private Dictionary<Type, IMemberCompilerProvider> memberCompilerProviders;
 
     /// <summary>
@@ -93,16 +91,20 @@ namespace Xtensive.Orm.Providers
     {
       var providerInfo = Handlers.ProviderInfo;
 
-      var applyCorrector = new ApplyProviderCorrector(
-        !providerInfo.Supports(ProviderFeatures.Apply));
-      var skipTakeCorrector = new SkipTakeCorrector(
-        providerInfo.Supports(ProviderFeatures.NativeTake),
-        providerInfo.Supports(ProviderFeatures.NativeSkip));
+      var applyCorrector = providerInfo.Supports(ProviderFeatures.Apply)
+        ? ApplyProviderCorrector.SilentCorrector
+        : ApplyProviderCorrector.ExceptionThrowingCorrector;
+
+      var skipTakeCorrector = (providerInfo.Supports(ProviderFeatures.NativeTake | ProviderFeatures.NativeSkip))
+        ? SkipTakeCorrector.FullPaginationSupportCorrector
+        : new SkipTakeCorrector(providerInfo.Supports(ProviderFeatures.NativeTake),
+            providerInfo.Supports(ProviderFeatures.NativeSkip));
+
       return new CompositePreCompiler(
         applyCorrector,
         skipTakeCorrector,
         RedundantColumnOptimizer.Instance,
-        OrderingCorrector);
+        OrderingCorrector.DefaultInstance);
     }
 
     /// <summary>
@@ -192,29 +194,6 @@ namespace Xtensive.Orm.Providers
       var unordered = Domain.Services.GetAll<IQueryPreprocessor>();
       var ordered = unordered.SortTopologically((first, second) => second.IsDependentOn(first));
       QueryPreprocessors = ordered ?? throw new InvalidOperationException(Strings.ExCyclicDependencyInQueryPreprocessorGraphIsDetected);
-    }
-
-    private static ProviderOrderingDescriptor ResolveOrderingDescriptor(CompilableProvider provider)
-    {
-      var isOrderSensitive = provider.Type is ProviderType.Skip
-        or ProviderType.Take
-        or ProviderType.Seek
-        or ProviderType.Paging
-        or ProviderType.RowNumber;
-      var preservesOrder = provider.Type is ProviderType.Skip
-        or ProviderType.Take
-        or ProviderType.Seek
-        or ProviderType.Paging
-        or ProviderType.RowNumber
-        or ProviderType.Distinct
-        or ProviderType.Alias;
-      var isOrderBreaker = provider.Type is ProviderType.Except
-        or ProviderType.Intersect
-        or ProviderType.Union
-        or ProviderType.Concat
-        or ProviderType.Existence;
-      var isSorter = provider.Type is ProviderType.Sort or ProviderType.Index;
-      return new ProviderOrderingDescriptor(isOrderSensitive, preservesOrder, isOrderBreaker, isSorter);
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ApplyProviderCorrector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ApplyProviderCorrector.cs
@@ -15,6 +15,10 @@ namespace Xtensive.Orm.Rse.Transformation
   /// </summary>
   public sealed class ApplyProviderCorrector : IPreCompiler
   {
+    public static ApplyProviderCorrector ExceptionThrowingCorrector { get; } = new ApplyProviderCorrector(true);
+    public static ApplyProviderCorrector SilentCorrector { get; } = new ApplyProviderCorrector(false);
+
+
     private readonly bool throwOnCorrectionFault;
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/OrderingCorrector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/OrderingCorrector.cs
@@ -18,12 +18,38 @@ namespace Xtensive.Orm.Rse.Transformation
   [Serializable]
   public sealed class OrderingCorrector : IPreCompiler
   {
+    public static OrderingCorrector DefaultInstance { get; } = new OrderingCorrector();
+
+
     private readonly Func<CompilableProvider, ProviderOrderingDescriptor> orderingDescriptorResolver;
 
     /// <inheritdoc/>
     CompilableProvider IPreCompiler.Process(CompilableProvider rootProvider)
     {
       return OrderingRewriter.Rewrite(rootProvider, orderingDescriptorResolver);
+    }
+
+    private static ProviderOrderingDescriptor ResolveOrderingDescriptor(CompilableProvider provider)
+    {
+      var isOrderSensitive = provider.Type is ProviderType.Skip
+        or ProviderType.Take
+        or ProviderType.Seek
+        or ProviderType.Paging
+        or ProviderType.RowNumber;
+      var preservesOrder = provider.Type is ProviderType.Skip
+        or ProviderType.Take
+        or ProviderType.Seek
+        or ProviderType.Paging
+        or ProviderType.RowNumber
+        or ProviderType.Distinct
+        or ProviderType.Alias;
+      var isOrderBreaker = provider.Type is ProviderType.Except
+        or ProviderType.Intersect
+        or ProviderType.Union
+        or ProviderType.Concat
+        or ProviderType.Existence;
+      var isSorter = provider.Type is ProviderType.Sort or ProviderType.Index;
+      return new ProviderOrderingDescriptor(isOrderSensitive, preservesOrder, isOrderBreaker, isSorter);
     }
 
 
@@ -37,6 +63,11 @@ namespace Xtensive.Orm.Rse.Transformation
     public OrderingCorrector(Func<CompilableProvider, ProviderOrderingDescriptor> orderingDescriptorResolver)
     {
       this.orderingDescriptorResolver = orderingDescriptorResolver ?? throw new ArgumentNullException(nameof(orderingDescriptorResolver));
+    }
+
+    private OrderingCorrector()
+    {
+      this.orderingDescriptorResolver = ResolveOrderingDescriptor;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/SkipTakeCorrector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/SkipTakeCorrector.cs
@@ -16,6 +16,8 @@ namespace Xtensive.Orm.Rse.Transformation
   [Serializable]
   public sealed class SkipTakeCorrector : IPreCompiler
   {
+    public static SkipTakeCorrector FullPaginationSupportCorrector { get; } = new(true, true);
+
     private readonly bool takeSupported;
     private readonly bool skipSupported;
 


### PR DESCRIPTION
Some implementors of ```IPreCompiler``` have dot static instances to default usage within standard precompiler chain to reduce number of created instances which are just wrappers