### PR TITLE
Fix IndexOutOfRangeException when an Enum's MetadataToken collides with Nullable<T>

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/NullableTokenCollisionTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/NullableTokenCollisionTest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using NUnit.Framework;
+
+namespace Xtensive.Tuples;
+
+[TestFixture]
+public class NullableTokenCollisionTest
+{
+  [Test]
+  public void EnumWithNullableMetadataTokenIsNotTreatedAsNullable()
+  {
+    var nullableToken = typeof(Nullable<>).MetadataToken;
+    var enumType = EmitEnumWithMetadataToken(nullableToken);
+    
+    Assert.That(enumType.IsEnum, Is.True);
+    Assert.That(enumType.MetadataToken, Is.EqualTo(nullableToken));
+    Assert.That(enumType.Module, Is.Not.EqualTo(typeof(Nullable<>).Module));
+    Assert.DoesNotThrow(() =>TupleDescriptor.Create(new[] { enumType}));
+  }
+
+  [Test]
+  public void GenuineNullableEnumStillResolves()
+  {
+    var nullableToken = typeof(Nullable<>).MetadataToken;
+    var enumType = EmitEnumWithMetadataToken(nullableToken);
+    var nullableEnum = typeof(Nullable<>).MakeGenericType(enumType);
+    
+    Assert.DoesNotThrow(() => TupleDescriptor.Create(new[] { nullableEnum }));
+  }
+
+  private static Type EmitEnumWithMetadataToken(int targetToken)
+  {
+    var rowId = targetToken & 0X00FFFFFF;
+    var assembly = AssemblyBuilder.DefineDynamicAssembly(
+      new AssemblyName("NullableTokenCollisionAsm"), AssemblyBuilderAccess.Run);
+    var module = assembly.DefineDynamicModule("NullableTokenCollisionModule");
+
+    //Starting at 2 because module is at 1 and then we add fake test until we reach the desired value
+    for (var i = 2; i < rowId; i++) {
+      module.DefineType("Filler" + i, TypeAttributes.Public).CreateType();
+    }
+
+    var enumBuilder = module.DefineEnum("CollidingStatus", TypeAttributes.Public, typeof(int));
+    enumBuilder.DefineLiteral("FirstOption", 0);
+    enumBuilder.DefineLiteral("SecondOption", 1);
+    return enumBuilder.CreateType();
+  }
+}

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -5,6 +5,7 @@
 // Created:    2012.12.29
 
 using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xtensive.Reflection;
 
@@ -54,10 +55,11 @@ namespace Xtensive.Tuples.Packed
       private static readonly ValueFieldAccessor DateTimeOffsetAccessor = new DateTimeOffsetFieldAccessor();
 
       private static readonly int NullableTypeMetadataToken = WellKnownTypes.NullableOfT.MetadataToken;
+      private static readonly Module NullableTypeModule = WellKnownTypes.NullableOfT.Module;
 
       public static ValueFieldAccessor GetValue(Type probeType)
       {
-        return (probeType.MetadataToken ^ NullableTypeMetadataToken) == 0
+        return probeType.MetadataToken == NullableTypeMetadataToken && probeType.Module == NullableTypeModule
           ? (ResolveByNullableType(probeType) ?? TryResolveNullableEnum(probeType))
           : (ResolveByType(probeType) ?? TryResolveEnum(probeType));
       }


### PR DESCRIPTION
---**Context**

This PR comes from an issue we encountered. We started getting an IndexOutOfRangeException on a simple query that filters an entity based on its enum values:
`result.Where(r => statuses.Contains(r.ProcessingInformation.ProcessingStatus));`

---**Root Cause**

TupleLayout.ValueFieldAccessorResolver.GetValue decides whether a type is Nullable<T> by comparing the MetadataToken alone. The problem is that a MetadataToken is unique only within a single module, not globally. Our enum lives in an application assembly and happened to be assigned the same token as Nullable<> from CoreLib, so it was sent down the nullable branch. Once it reached TryResolveNullableEnum, which assumes the type is generic and calls GetGenericArguments()[0], the exception was thrown.

---**Fix**

Use of the module in addition to the MetadataToken in the condition, so the combination is unique.

---**Performance**

I understand the original comparison was an optimisation to save a few CPU operations. Je However, GetValue runs when the tuple layout is built and the descriptors should be cached, so this doesn't seem to be a hot path Nevertheless, here is a screenshot of a benchmark showing the differences:

<img width="974" height="597" alt="image" src="https://github.com/user-attachments/assets/e21d7caa-8968-4810-b84f-294bd66f9f54" />

**Code used for the benchmark:**

```
private enum SampleEnum { A, B }

private static readonly int NullableTypeMetadataToken = typeof(Nullable<>).MetadataToken;
private static readonly Module NullableTypeModule = typeof(Nullable<>).Module;

private static readonly Type[] Types = {
  typeof(int), typeof(int?), typeof(long), typeof(Guid),
  typeof(bool), typeof(DateTime?), typeof(SampleEnum), typeof(SampleEnum?),
  typeof(string), typeof(decimal?)
};

[Benchmark(Baseline = true)]
public int Xor()
{
  var hits = 0;
  foreach (var t in Types) {
    if ((t.MetadataToken ^ NullableTypeMetadataToken) == 0) {
      hits++;
    }
  }
  return hits;
}

[Benchmark]
public int TokenAndModule()
{
  var hits = 0;
  foreach (var t in Types) {
    if (t.MetadataToken == NullableTypeMetadataToken && ReferenceEquals(t.Module, NullableTypeModule)) {
      hits++;
    }
  }
  return hits;
}
```
